### PR TITLE
feat(ui/ux): 统一窗口、交互体验以及 macOS 原生化

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "2", features = [] }
 
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset", "tray-icon"] }
+tauri = { version = "2", features = ["protocol-asset", "tray-icon", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2.0.0"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,7 +3,9 @@ use crate::services::global;
 use font_kit::source::SystemSource;
 use serde::Deserialize;
 use std::collections::HashSet;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
+#[cfg(target_os = "macos")]
+use tauri::Manager;
 #[cfg(target_os = "macos")]
 use window_vibrancy::{
     apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
@@ -142,7 +144,7 @@ pub fn apply_acrylic(enabled: bool, app: AppHandle) -> Result<(), String> {
 
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = enabled;
+        let _ = (enabled, app);
     }
 
     Ok(())

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,6 +3,11 @@ use crate::services::global;
 use font_kit::source::SystemSource;
 use serde::Deserialize;
 use std::collections::HashSet;
+use tauri::{AppHandle, Manager};
+#[cfg(target_os = "macos")]
+use window_vibrancy::{
+    apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
+};
 
 #[derive(serde::Serialize)]
 pub struct UpdateSettingsResult {
@@ -113,4 +118,32 @@ pub fn update_plugin_commands(commands: PluginCommands) -> Result<UpdateSettings
             .map(|g| format!("{:?}", g))
             .collect(),
     })
+}
+
+#[tauri::command]
+pub fn apply_acrylic(enabled: bool, app: AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(window) = app.get_webview_window("main") {
+            if enabled {
+                apply_vibrancy(
+                    &window,
+                    NSVisualEffectMaterial::UnderWindowBackground,
+                    Some(NSVisualEffectState::Active),
+                    None,
+                )
+                .map_err(|e| format!("Failed to apply native macOS vibrancy effect: {}", e))?;
+            } else {
+                clear_vibrancy(&window)
+                    .map_err(|e| format!("Failed to clear native macOS vibrancy effect: {}", e))?;
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = enabled;
+    }
+
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,8 +27,10 @@ use std::sync::{Arc, Mutex};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Emitter, Listener, Manager, TitleBarStyle,
+    Emitter, Listener, Manager,
 };
+#[cfg(target_os = "macos")]
+use tauri::TitleBarStyle;
 #[cfg(target_os = "macos")]
 use window_vibrancy::{
     apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,13 +24,13 @@ use crate::services::download_manager::DownloadManager;
 use plugins::manager::PluginManager;
 
 use std::sync::{Arc, Mutex};
+#[cfg(target_os = "macos")]
+use tauri::TitleBarStyle;
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Listener, Manager,
 };
-#[cfg(target_os = "macos")]
-use tauri::TitleBarStyle;
 #[cfg(target_os = "macos")]
 use window_vibrancy::{
     apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,7 @@ use std::sync::{Arc, Mutex};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Emitter, Listener, Manager,
+    Emitter, Listener, Manager, TitleBarStyle,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -279,6 +279,17 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(e) = window.set_decorations(true) {
+                    eprintln!("Failed to enable native macOS window decorations: {}", e);
+                }
+
+                if let Err(e) = window.set_title_bar_style(TitleBarStyle::Overlay) {
+                    eprintln!("Failed to set macOS title bar style to overlay: {}", e);
+                }
+            }
+
             // 初始化插件管理
             // 插件目录与其他模块共用同一套数据目录选择规则
             let app_data_dir = crate::utils::path::get_app_data_dir();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,10 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Listener, Manager, TitleBarStyle,
 };
+#[cfg(target_os = "macos")]
+use window_vibrancy::{
+    apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
+};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -180,6 +184,7 @@ pub fn run() {
             settings_commands::get_system_fonts,
             settings_commands::get_plugin_commands,
             settings_commands::update_plugin_commands,
+            settings_commands::apply_acrylic,
             update_commands::check_update,
             update_commands::open_download_url,
             update_commands::download_update,
@@ -279,6 +284,13 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            #[cfg(not(target_os = "macos"))]
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(e) = window.set_decorations(false) {
+                    eprintln!("Failed to disable native window decorations: {}", e);
+                }
+            }
+
             #[cfg(target_os = "macos")]
             if let Some(window) = app.get_webview_window("main") {
                 if let Err(e) = window.set_decorations(true) {
@@ -287,6 +299,26 @@ pub fn run() {
 
                 if let Err(e) = window.set_title_bar_style(TitleBarStyle::Overlay) {
                     eprintln!("Failed to set macOS title bar style to overlay: {}", e);
+                }
+
+                let acrylic_enabled = crate::services::global::settings_manager()
+                    .get()
+                    .acrylic_enabled;
+
+                let native_effect_result = if acrylic_enabled {
+                    apply_vibrancy(
+                        &window,
+                        NSVisualEffectMaterial::UnderWindowBackground,
+                        Some(NSVisualEffectState::Active),
+                        None,
+                    )
+                    .map(|_| ())
+                } else {
+                    clear_vibrancy(&window).map(|_| ())
+                };
+
+                if let Err(e) = native_effect_result {
+                    eprintln!("Failed to sync native macOS vibrancy effect: {}", e);
                 }
             }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,12 +19,19 @@
         "minWidth": 1000,
         "minHeight": 625,
         "center": true,
-        "decorations": false,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": {
+          "x": 14,
+          "y": 18
+        },
         "resizable": true,
         "transparent": true,
         "visible": true
       }
     ],
+    "macOSPrivateApi": true,
     "security": {
       "csp": null,
       "assetProtocol": {

--- a/src/api/downloader.ts
+++ b/src/api/downloader.ts
@@ -89,44 +89,62 @@ export const downloadApi = {
     const isSuccess = computed(() => taskInfo.status === "Completed");
 
     let timer: number | null = null;
-    let isPolling = false;
+    let activeSession = 0;
 
     const start = async (options: DownloadOptions) => {
+      stop();
+
+      const session = ++activeSession;
       taskInfo.isFinished = false;
       taskInfo.progress = 0;
       taskInfo.status = "Pending";
-      isPolling = false;
 
       try {
         const id = await this.downloadFile(options);
-        taskInfo.id = id;
+        if (session !== activeSession) return;
 
-        timer = window.setInterval(async () => {
-          if (isPolling || taskInfo.id !== id || taskInfo.isFinished) {
+        taskInfo.id = id;
+        let pollingInFlight = false;
+
+        const intervalId = window.setInterval(async () => {
+          if (session !== activeSession) {
+            clearInterval(intervalId);
+            if (timer === intervalId) timer = null;
             return;
           }
 
-          isPolling = true;
+          if (pollingInFlight || taskInfo.id !== id || taskInfo.isFinished) {
+            if (taskInfo.id !== id || taskInfo.isFinished) {
+              clearInterval(intervalId);
+              if (timer === intervalId) timer = null;
+            }
+            return;
+          }
+
+          pollingInFlight = true;
           try {
             const data = await this.pollTask(id);
-            if (taskInfo.id !== id) {
+            if (session !== activeSession || taskInfo.id !== id) {
               return;
             }
 
             Object.assign(taskInfo, data);
             if (data.isFinished) {
               taskInfo.progress = 100;
-              stop();
+              clearInterval(intervalId);
+              if (timer === intervalId) timer = null;
             }
           } catch (err) {
-            if (taskInfo.id === id && !taskInfo.isFinished) {
+            if (session === activeSession && taskInfo.id === id && !taskInfo.isFinished) {
               taskInfo.status = { Error: i18n.t("downloader.connection_lost") };
             }
-            stop();
+            clearInterval(intervalId);
+            if (timer === intervalId) timer = null;
           } finally {
-            isPolling = false;
+            pollingInFlight = false;
           }
         }, 800);
+        timer = intervalId;
       } catch (err: any) {
         taskInfo.status = { Error: err.toString() };
         taskInfo.isFinished = true;
@@ -134,11 +152,11 @@ export const downloadApi = {
     };
 
     const stop = () => {
+      activeSession += 1;
       if (timer) {
         clearInterval(timer);
         timer = null;
       }
-      isPolling = false;
     };
 
     const reset = () => {

--- a/src/api/downloader.ts
+++ b/src/api/downloader.ts
@@ -89,28 +89,42 @@ export const downloadApi = {
     const isSuccess = computed(() => taskInfo.status === "Completed");
 
     let timer: number | null = null;
+    let isPolling = false;
 
     const start = async (options: DownloadOptions) => {
       taskInfo.isFinished = false;
       taskInfo.progress = 0;
+      taskInfo.status = "Pending";
+      isPolling = false;
 
       try {
         const id = await this.downloadFile(options);
         taskInfo.id = id;
 
         timer = window.setInterval(async () => {
+          if (isPolling || taskInfo.id !== id || taskInfo.isFinished) {
+            return;
+          }
+
+          isPolling = true;
           try {
             const data = await this.pollTask(id);
+            if (taskInfo.id !== id) {
+              return;
+            }
+
             Object.assign(taskInfo, data);
             if (data.isFinished) {
-              data.progress = 100;
+              taskInfo.progress = 100;
               stop();
             }
           } catch (err) {
-            if (!taskInfo.isFinished) {
+            if (taskInfo.id === id && !taskInfo.isFinished) {
               taskInfo.status = { Error: i18n.t("downloader.connection_lost") };
             }
             stop();
+          } finally {
+            isPolling = false;
           }
         }, 800);
       } catch (err: any) {
@@ -124,6 +138,7 @@ export const downloadApi = {
         clearInterval(timer);
         timer = null;
       }
+      isPolling = false;
     };
 
     const reset = () => {

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,4 +1,4 @@
-import { tauriInvoke } from "@api/tauri";
+import { isBrowserEnv, tauriInvoke } from "@api/tauri";
 import type { JavaInfo } from "@api/java";
 
 export type SettingsGroup =
@@ -110,6 +110,10 @@ export const settingsApi = {
   },
   async importJson(json: string): Promise<AppSettings> {
     return tauriInvoke("import_settings", { json });
+  },
+  async applyAcrylic(enabled: boolean): Promise<void> {
+    if (isBrowserEnv()) return;
+    await tauriInvoke("apply_acrylic", { enabled }, { silent: true });
   },
 };
 

--- a/src/components/common/SLServerSelector.vue
+++ b/src/components/common/SLServerSelector.vue
@@ -299,14 +299,14 @@ watch(
 
 .sl-server-selector.collapsed .server-selector-trigger {
   width: 40px;
-  height: 67px;
+  height: 40px;
   justify-content: center;
-  padding: 5px;
-  border: none;
-  background: transparent;
-  margin-top: 0px;
-  margin-left: left;
-  margin-right: left;
+  padding: 0;
+  border: 1px solid var(--sl-border);
+  background: var(--sl-surface);
+  margin-top: 5px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .sl-server-selector.collapsed .server-selector-trigger:hover {

--- a/src/components/console/ConsoleOutput.vue
+++ b/src/components/console/ConsoleOutput.vue
@@ -226,12 +226,19 @@ onMounted(() => {
     letterSpacing: props.consoleLetterSpacing,
     lineHeight: 1,
     scrollback: Math.max(100, props.maxLogLines),
+    overviewRuler: {
+      width: 4,
+    },
     theme: {
       background: cssVar("--sl-bg-secondary", "#111827"),
       foreground: cssVar("--sl-text-primary", "#e5e7eb"),
       cursor: "transparent",
       cursorAccent: "transparent",
       selectionBackground: cssVar("--sl-primary-bg", "#1e3a8a"),
+      scrollbarSliderBackground: "rgba(94, 122, 145, 0.18)",
+      scrollbarSliderHoverBackground: "rgba(94, 122, 145, 0.34)",
+      scrollbarSliderActiveBackground: "rgba(94, 122, 145, 0.48)",
+      overviewRulerBorder: "rgba(0, 0, 0, 0)",
     },
   });
 
@@ -358,6 +365,22 @@ defineExpose({ doScroll, appendLines, clear, getAllPlainText });
 .terminal-host :deep(.xterm-viewport) {
   overflow-y: auto !important;
   background: var(--sl-bg-secondary);
+}
+
+.terminal-host :deep(.xterm .xterm-scrollable-element > .scrollbar) {
+  background: transparent !important;
+}
+
+.terminal-host :deep(.xterm .xterm-scrollable-element > .scrollbar.vertical) {
+  width: 4px !important;
+}
+
+.terminal-host :deep(.xterm .xterm-scrollable-element > .scrollbar > .slider) {
+  border-radius: 999px;
+  border: none;
+  transition:
+    background-color 0.16s ease,
+    opacity 0.16s ease;
 }
 
 .scroll-btn {

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -25,6 +25,7 @@ const settings = ref<AppSettings | null>(null);
 const closeAction = ref<string>("ask"); // ask, minimize, close
 const rememberChoice = ref(false);
 const isMaximized = ref(false);
+const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
 
 const pageTitle = computed(() => {
   const titleKey = route.meta?.titleKey as string;
@@ -266,7 +267,11 @@ function computeOverallProgress() {
 </script>
 
 <template>
-  <header class="app-header glass-strong">
+  <header
+    class="app-header"
+    :class="{ 'macos-overlay': isMacOS, 'glass-strong': !isMacOS }"
+    data-tauri-drag-region
+  >
     <div class="header-center" data-tauri-drag-region></div>
 
     <div class="header-right">
@@ -312,7 +317,7 @@ function computeOverallProgress() {
         <span class="status-text">{{ i18n.t("common.app_name") }}</span>
       </div>
 
-      <div class="window-controls">
+      <div v-if="!isMacOS" class="window-controls">
         <button class="win-btn" @click="minimizeWindow" :title="i18n.t('common.minimize')">
           <Minus :size="12" />
         </button>

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -9,6 +9,7 @@ import SLButton from "@components/common/SLButton.vue";
 import SLCheckbox from "@components/common/SLCheckbox.vue";
 import { settingsApi, type AppSettings } from "@api/settings";
 import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/vue";
+import { isMacOSPlatform } from "@utils/platform";
 import {
   dispatchSettingsUpdate,
   SETTINGS_UPDATE_EVENT,
@@ -22,7 +23,7 @@ const settings = ref<AppSettings | null>(null);
 const closeAction = ref<string>("ask"); // ask, minimize, close
 const rememberChoice = ref(false);
 const isMaximized = ref(false);
-const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
+const isMacOS = isMacOSPlatform();
 
 const primaryLanguages = computed(() => {
   const primaryCodes = ["zh-CN", "zh-TW", "en-US", "ja-JP"];

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted, reactive } from "vue";
-import { useRoute } from "vue-router";
+import { computed, ref, onMounted, onUnmounted } from "vue";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Minus, Square, X, ChevronDown, ChevronUp, Copy } from "lucide-vue-next";
 import { useI18nStore } from "@stores/i18nStore";
@@ -8,7 +7,7 @@ import { i18n } from "@language";
 import SLModal from "@components/common/SLModal.vue";
 import SLButton from "@components/common/SLButton.vue";
 import SLCheckbox from "@components/common/SLCheckbox.vue";
-import { settingsApi, type AppSettings, type SettingsGroup } from "@api/settings";
+import { settingsApi, type AppSettings } from "@api/settings";
 import { Menu, MenuButton, MenuItems, MenuItem } from "@headlessui/vue";
 import {
   dispatchSettingsUpdate,
@@ -16,28 +15,16 @@ import {
   type SettingsUpdateEvent,
 } from "@stores/settingsStore";
 
-const route = useRoute();
 const appWindow = getCurrentWindow();
 const i18nStore = useI18nStore();
 const showCloseModal = ref(false);
-const perLocaleProgress = reactive<Record<string, { loaded: number; total: number | null }>>({});
 const settings = ref<AppSettings | null>(null);
 const closeAction = ref<string>("ask"); // ask, minimize, close
 const rememberChoice = ref(false);
 const isMaximized = ref(false);
 const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
 
-const pageTitle = computed(() => {
-  const titleKey = route.meta?.titleKey as string;
-  if (titleKey) {
-    return i18n.t(titleKey);
-  }
-  return i18n.t("common.app_name");
-});
-
 const primaryLanguages = computed(() => {
-  // 为了确保语言切换时重新计算，我们使用 i18nStore.currentLocale 作为依赖
-  const currentLocale = i18nStore.currentLocale;
   const primaryCodes = ["zh-CN", "zh-TW", "en-US", "ja-JP"];
 
   return primaryCodes.map((code) => {
@@ -67,8 +54,6 @@ const primaryLanguages = computed(() => {
 });
 
 const otherLanguages = computed(() => {
-  // 为了确保语言切换时重新计算，我们使用 i18nStore.currentLocale 作为依赖
-  const currentLocale = i18nStore.currentLocale;
   const primaryCodes = new Set(["zh-CN", "zh-TW", "en-US", "ja-JP"]);
   const allLocales = i18n.getAvailableLocales();
 
@@ -252,17 +237,6 @@ async function handleLanguageClick(locale: string, close?: () => void) {
   } finally {
     isChangingLanguage.value = false;
   }
-}
-
-function computeOverallProgress() {
-  const locales = Object.keys(perLocaleProgress);
-  if (locales.length === 0) return 0;
-  const completed = locales.filter(
-    (k) =>
-      perLocaleProgress[k].total &&
-      perLocaleProgress[k].loaded >= (perLocaleProgress[k].total ?? 0),
-  ).length;
-  return Math.round((completed / locales.length) * 100);
 }
 </script>
 

--- a/src/components/layout/AppLayout.vue
+++ b/src/components/layout/AppLayout.vue
@@ -17,6 +17,7 @@ import {
   applyDeveloperMode,
   isThemeProviderActive,
 } from "@utils/theme";
+import { isMacOSPlatform } from "@utils/platform";
 
 const ui = useUiStore();
 const settingsStore = useSettingsStore();
@@ -26,7 +27,7 @@ const backgroundOpacity = computed(() => settingsStore.backgroundOpacity);
 const backgroundBlur = computed(() => settingsStore.backgroundBlur);
 const backgroundBrightness = computed(() => settingsStore.backgroundBrightness);
 const backgroundSize = computed(() => settingsStore.backgroundSize);
-const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
+const isMacOS = isMacOSPlatform();
 
 let systemThemeQuery: MediaQueryList | null = null;
 let lastNativeAcrylic: boolean | null = null;

--- a/src/components/layout/AppLayout.vue
+++ b/src/components/layout/AppLayout.vue
@@ -2,6 +2,7 @@
 import { onMounted, onUnmounted, computed, watch } from "vue";
 import AppSidebar from "@components/layout/AppSidebar.vue";
 import AppHeader from "@components/layout/AppHeader.vue";
+import { settingsApi } from "@api/settings";
 import { useUiStore } from "@stores/uiStore";
 import {
   useSettingsStore,
@@ -25,8 +26,10 @@ const backgroundOpacity = computed(() => settingsStore.backgroundOpacity);
 const backgroundBlur = computed(() => settingsStore.backgroundBlur);
 const backgroundBrightness = computed(() => settingsStore.backgroundBrightness);
 const backgroundSize = computed(() => settingsStore.backgroundSize);
+const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
 
 let systemThemeQuery: MediaQueryList | null = null;
+let lastNativeAcrylic: boolean | null = null;
 
 function applyAcrylicEffect(enabled: boolean): void {
   document.documentElement.setAttribute("data-acrylic", enabled ? "true" : "false");
@@ -50,6 +53,10 @@ async function applyAppearanceSettings(): Promise<void> {
   applyFontFamily(settings.font_family || "");
 
   applyAcrylicEffect(settings.acrylic_enabled);
+  if (lastNativeAcrylic !== settings.acrylic_enabled) {
+    lastNativeAcrylic = settings.acrylic_enabled;
+    await settingsApi.applyAcrylic(settings.acrylic_enabled);
+  }
 
   if (!isThemeProviderActive()) {
     applyColors(settings);
@@ -107,10 +114,13 @@ const backgroundStyle = computed(() => {
 </script>
 
 <template>
-  <div class="app-layout">
+  <div class="app-layout" :class="{ 'macos-native-vibrancy': isMacOS }">
     <div class="app-background" :style="backgroundStyle"></div>
     <AppSidebar />
-    <div class="app-main" :class="{ 'sidebar-collapsed': ui.sidebarCollapsed }">
+    <div
+      class="app-main"
+      :class="{ 'sidebar-collapsed': ui.sidebarCollapsed, 'macos-native-vibrancy': isMacOS }"
+    >
       <AppHeader />
       <main class="app-content">
         <router-view v-slot="{ Component }">

--- a/src/components/layout/AppLayout.vue
+++ b/src/components/layout/AppLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, computed, watch } from "vue";
+import { onMounted, onUnmounted, computed } from "vue";
 import AppSidebar from "@components/layout/AppSidebar.vue";
 import AppHeader from "@components/layout/AppHeader.vue";
 import { settingsApi } from "@api/settings";
@@ -31,6 +31,7 @@ const isMacOS = isMacOSPlatform();
 
 let systemThemeQuery: MediaQueryList | null = null;
 let lastNativeAcrylic: boolean | null = null;
+let appearanceApplyQueue: Promise<void> = Promise.resolve();
 
 function applyAcrylicEffect(enabled: boolean): void {
   document.documentElement.setAttribute("data-acrylic", enabled ? "true" : "false");
@@ -64,12 +65,20 @@ async function applyAppearanceSettings(): Promise<void> {
   }
 }
 
+function enqueueAppearanceApply(): Promise<void> {
+  appearanceApplyQueue = appearanceApplyQueue.then(
+    () => applyAppearanceSettings(),
+    () => applyAppearanceSettings(),
+  );
+  return appearanceApplyQueue;
+}
+
 function applyDeveloperSettings(): void {
   applyDeveloperMode(settingsStore.settings.developer_mode || false);
 }
 
 async function applyAllSettings(): Promise<void> {
-  await applyAppearanceSettings();
+  await enqueueAppearanceApply();
   applyDeveloperSettings();
 }
 
@@ -78,7 +87,7 @@ function handleSettingsUpdateEvent(e: CustomEvent<SettingsUpdateEvent>): void {
   settingsStore.settings = settings;
 
   if (changedGroups.includes("Appearance")) {
-    applyAppearanceSettings();
+    void enqueueAppearanceApply();
   }
   if (changedGroups.includes("Developer")) {
     applyDeveloperSettings();

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -55,7 +55,10 @@ const ui = useUiStore();
 const serverStore = useServerStore();
 const pluginStore = usePluginStore();
 const navIndicator = ref<HTMLElement | null>(null);
+const sidebarTransitioning = ref(false);
 const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
+let indicatorSyncInterval: ReturnType<typeof setInterval> | null = null;
+let indicatorSyncTimeout: ReturnType<typeof setTimeout> | null = null;
 
 interface NavItem {
   name: string;
@@ -267,13 +270,37 @@ function updateNavIndicator() {
   });
 }
 
+function startIndicatorSyncDuringSidebarTransition() {
+  if (indicatorSyncInterval) {
+    clearInterval(indicatorSyncInterval);
+    indicatorSyncInterval = null;
+  }
+  if (indicatorSyncTimeout) {
+    clearTimeout(indicatorSyncTimeout);
+    indicatorSyncTimeout = null;
+  }
+
+  sidebarTransitioning.value = true;
+  indicatorSyncInterval = setInterval(() => {
+    updateNavIndicator();
+  }, 16);
+
+  indicatorSyncTimeout = setTimeout(() => {
+    if (indicatorSyncInterval) {
+      clearInterval(indicatorSyncInterval);
+      indicatorSyncInterval = null;
+    }
+    sidebarTransitioning.value = false;
+    updateNavIndicator();
+  }, 360);
+}
+
 // 监听侧边栏折叠状态变化，更新指示器位置
 watch(
   () => ui.sidebarCollapsed,
   () => {
-    setTimeout(() => {
-      updateNavIndicator();
-    }, 350);
+    updateNavIndicator();
+    startIndicatorSyncDuringSidebarTransition();
   },
 );
 
@@ -339,6 +366,15 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  if (indicatorSyncInterval) {
+    clearInterval(indicatorSyncInterval);
+    indicatorSyncInterval = null;
+  }
+  if (indicatorSyncTimeout) {
+    clearTimeout(indicatorSyncTimeout);
+    indicatorSyncTimeout = null;
+  }
+
   window.removeEventListener("resize", updateNavIndicator);
 
   // 移除侧边栏滚动监听
@@ -393,7 +429,11 @@ function getAppName() {
 <template>
   <aside
     class="sidebar glass-strong"
-    :class="{ collapsed: ui.sidebarCollapsed, 'macos-overlay': isMacOS }"
+    :class="{
+      collapsed: ui.sidebarCollapsed,
+      'macos-overlay': isMacOS,
+      'sidebar-transitioning': sidebarTransitioning,
+    }"
   >
     <div class="sidebar-logo" @click="navigateTo('/')">
       <div class="logo-icon">

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -26,6 +26,7 @@ import {
   type LucideIcon,
 } from "lucide-vue-next";
 import logoSvg from "@assets/logo.svg";
+import { isMacOSPlatform } from "@utils/platform";
 
 const iconMap: Record<string, LucideIcon> = {
   home: Home,
@@ -56,7 +57,7 @@ const serverStore = useServerStore();
 const pluginStore = usePluginStore();
 const navIndicator = ref<HTMLElement | null>(null);
 const sidebarTransitioning = ref(false);
-const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
+const isMacOS = isMacOSPlatform();
 let indicatorSyncInterval: ReturnType<typeof setInterval> | null = null;
 let indicatorSyncTimeout: ReturnType<typeof setTimeout> | null = null;
 

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -55,6 +55,7 @@ const ui = useUiStore();
 const serverStore = useServerStore();
 const pluginStore = usePluginStore();
 const navIndicator = ref<HTMLElement | null>(null);
+const isMacOS = /Macintosh|Mac OS X/i.test(navigator.userAgent);
 
 interface NavItem {
   name: string;
@@ -390,7 +391,10 @@ function getAppName() {
 </script>
 
 <template>
-  <aside class="sidebar glass-strong" :class="{ collapsed: ui.sidebarCollapsed }">
+  <aside
+    class="sidebar glass-strong"
+    :class="{ collapsed: ui.sidebarCollapsed, 'macos-overlay': isMacOS }"
+  >
     <div class="sidebar-logo" @click="navigateTo('/')">
       <div class="logo-icon">
         <img :src="logoSvg" width="28" height="28" :alt="i18n.t('common.app_name')" />

--- a/src/components/views/download/DownloadForm.vue
+++ b/src/components/views/download/DownloadForm.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { computed } from "vue";
 import { FolderOpen, Link, FileText, Cpu } from "lucide-vue-next";
 import SLButton from "@components/common/SLButton.vue";
 import SLInput from "@components/common/SLInput.vue";
@@ -21,7 +20,6 @@ const emit = defineEmits<{
   (e: "update:filename", value: string): void;
   (e: "update:threadCount", value: string): void;
   (e: "checkUrl"): void;
-  (e: "checkFilename"): void;
   (e: "pickFolder"): void;
   (e: "checkThreadCount"): void;
 }>();
@@ -86,7 +84,6 @@ function handlePickFolder() {
         :placeholder="i18n.t('download-file.filename_placeholder')"
         :disabled="isDownloading"
         @update:modelValue="emit('update:filename', $event)"
-        @blur="emit('checkFilename')"
       >
         <template #prefix>
           <FileText :size="16" class="input-icon" />

--- a/src/components/views/download/DownloadServerForm.vue
+++ b/src/components/views/download/DownloadServerForm.vue
@@ -50,6 +50,8 @@ function handlePickFolder() {
           :placeholder="i18n.t('downloadServerView.form.typePlaceholder')"
           :disabled="loadingTypes || isDownloading"
           :loading="loadingTypes"
+          searchable
+          maxHeight="240px"
           @update:modelValue="emit('update:selectedType', $event)"
         />
       </div>
@@ -64,6 +66,8 @@ function handlePickFolder() {
           :placeholder="i18n.t('downloadServerView.form.versionPlaceholder')"
           :disabled="loadingVersions || !selectedType || isDownloading"
           :loading="loadingVersions"
+          searchable
+          maxHeight="240px"
           @update:modelValue="emit('update:selectedVersion', $event)"
         />
       </div>

--- a/src/components/views/home/QuickStartCard.vue
+++ b/src/components/views/home/QuickStartCard.vue
@@ -21,16 +21,14 @@ const emit = defineEmits<{
         {{ i18n.t("common.create_server") }}
       </SLButton>
     </div>
-    <div class="card-spacer"></div>
     <div class="quote-display" @click="updateQuote" :title="i18n.t('common.click_to_refresh')">
-      <span v-if="displayText && !isTyping" class="quote-text">「{{ displayText }}」</span>
-      <span v-if="currentQuote && !isTyping" class="quote-author"
-        >—— {{ currentQuote.author }}</span
+      <span v-if="displayText || isTyping" class="quote-text">「{{ displayText }}」</span>
+      <span v-else class="quote-loading">{{ i18n.t("common.loading") }}</span>
+      <span
+        class="quote-author"
+        :class="{ 'quote-author-hidden': isTyping || !currentQuote.author }"
+        >—— {{ currentQuote.author || " " }}</span
       >
-      <span v-if="isTyping" class="quote-text">「{{ displayText }}」</span>
-      <span v-if="!displayText && !isTyping" class="quote-loading">{{
-        i18n.t("common.loading")
-      }}</span>
     </div>
   </SLCard>
 </template>
@@ -39,7 +37,11 @@ const emit = defineEmits<{
 .quick-start-card {
   display: flex;
   flex-direction: column;
-  height: 280px;
+}
+
+.quick-start-card :deep(.sl-card-body) {
+  display: flex;
+  flex-direction: column;
 }
 
 .quick-actions {
@@ -47,10 +49,6 @@ const emit = defineEmits<{
   gap: var(--sl-space-sm);
   margin-top: var(--sl-space-sm);
   flex-wrap: wrap;
-}
-
-.card-spacer {
-  flex-grow: 1;
 }
 
 .quote-display {
@@ -94,6 +92,10 @@ const emit = defineEmits<{
   color: var(--sl-text-tertiary);
   transition: all 0.3s ease;
   opacity: 1;
+}
+
+.quote-author-hidden {
+  visibility: hidden;
 }
 
 .quote-author.fading {

--- a/src/components/views/home/SystemStatsCard.vue
+++ b/src/components/views/home/SystemStatsCard.vue
@@ -144,7 +144,6 @@ function toggleViewMode() {
 
 <style scoped>
 .stats-card {
-  height: 280px;
   display: flex;
   flex-direction: column;
 }
@@ -187,12 +186,12 @@ function toggleViewMode() {
   align-items: center;
   justify-content: center;
   gap: var(--sl-space-sm);
-  min-height: 240px;
+  min-height: 0;
   color: var(--sl-text-tertiary);
 }
 
 .gauge-view {
-  min-height: 240px;
+  min-height: 0;
 }
 
 .gauge-grid {
@@ -250,15 +249,15 @@ function toggleViewMode() {
 .stats-grid {
   display: flex;
   flex-direction: column;
-  gap: var(--sl-space-sm);
-  padding: var(--sl-space-xs) 0;
-  min-height: 240px;
+  gap: var(--sl-space-xs);
+  padding: 0;
+  min-height: 0;
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .stat-header {
@@ -288,7 +287,7 @@ function toggleViewMode() {
 
 .mini-chart {
   width: 100%;
-  height: 30px;
+  height: 22px;
   background: var(--sl-bg-secondary);
   border-radius: var(--sl-radius-xs);
   overflow: hidden;

--- a/src/language/de-DE.json
+++ b/src/language/de-DE.json
@@ -712,7 +712,7 @@
       "cancel": "Abbrechen",
       "startDownload": "Download starten",
       "downloading": "Wird heruntergeladen",
-      "goCreatePage": "Zur CreatePage"
+      "goCreatePage": "Zur Servererstellung"
     }
   }
 }

--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -1055,7 +1055,7 @@
       "cancel": "Cancel",
       "startDownload": "Start download",
       "downloading": "Downloading",
-      "goCreatePage": "Go to CreatePage"
+      "goCreatePage": "Go to Create Server"
     }
   }
 }

--- a/src/language/es-ES.json
+++ b/src/language/es-ES.json
@@ -697,7 +697,7 @@
       "cancel": "Cancelar",
       "startDownload": "Iniciar descarga",
       "downloading": "Descargando",
-      "goCreatePage": "Ir a CreatePage"
+      "goCreatePage": "Ir a crear servidor"
     }
   }
 }

--- a/src/language/fr-FA.json
+++ b/src/language/fr-FA.json
@@ -714,7 +714,7 @@
       "cancel": "Annuler",
       "startDownload": "Démarrer le téléchargement",
       "downloading": "Téléchargement en cours",
-      "goCreatePage": "Aller à CreatePage"
+      "goCreatePage": "Aller à la création de serveur"
     }
   }
 }

--- a/src/language/ja-JP.json
+++ b/src/language/ja-JP.json
@@ -715,7 +715,7 @@
       "cancel": "キャンセル",
       "startDownload": "ダウンロード開始",
       "downloading": "ダウンロード中",
-      "goCreatePage": "CreatePageへ"
+      "goCreatePage": "サーバー作成へ"
     }
   }
 }

--- a/src/language/ko-KR.json
+++ b/src/language/ko-KR.json
@@ -714,7 +714,7 @@
       "cancel": "취소",
       "startDownload": "다운로드 시작",
       "downloading": "다운로드 중",
-      "goCreatePage": "CreatePage로 이동"
+      "goCreatePage": "서버 생성으로 이동"
     }
   }
 }

--- a/src/language/ru-RU.json
+++ b/src/language/ru-RU.json
@@ -712,7 +712,7 @@
       "cancel": "Отмена",
       "startDownload": "Начать загрузку",
       "downloading": "Загрузка",
-      "goCreatePage": "Перейти на CreatePage"
+      "goCreatePage": "Перейти к созданию сервера"
     }
   }
 }

--- a/src/language/vi-VN.json
+++ b/src/language/vi-VN.json
@@ -712,7 +712,7 @@
       "cancel": "Hủy",
       "startDownload": "Bắt đầu tải xuống",
       "downloading": "Đang tải xuống",
-      "goCreatePage": "Đi tới CreatePage"
+      "goCreatePage": "Đi tới tạo máy chủ"
     }
   }
 }

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -1061,7 +1061,7 @@
       "cancel": "取消",
       "startDownload": "开始下载",
       "downloading": "下载中",
-      "goCreatePage": "前往 CreatePage"
+      "goCreatePage": "前往创建服务器"
     }
   }
 }

--- a/src/language/zh-TW.json
+++ b/src/language/zh-TW.json
@@ -715,7 +715,7 @@
       "cancel": "取消",
       "startDownload": "開始下載",
       "downloading": "下載中",
-      "goCreatePage": "前往 CreatePage"
+      "goCreatePage": "前往建立伺服器"
     }
   }
 }

--- a/src/styles/components/layout/AppHeader.css
+++ b/src/styles/components/layout/AppHeader.css
@@ -10,6 +10,22 @@
   user-select: none;
   position: relative;
   z-index: 100;
+  -webkit-app-region: no-drag;
+}
+
+.app-header.macos-overlay {
+  height: var(--sl-header-height);
+  padding-top: 0;
+  padding-left: calc(var(--sl-space-lg) + 84px);
+  border-bottom: 1px solid var(--sl-border-light);
+  background: var(--sl-bg);
+  -webkit-app-region: drag;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+[data-theme="dark"] .app-header.macos-overlay {
+  border-bottom: 1px solid var(--sl-border-light);
 }
 
 [data-acrylic="true"] .app-header {
@@ -38,6 +54,10 @@
   -webkit-app-region: drag;
 }
 
+.app-header.macos-overlay .header-center {
+  min-height: var(--sl-header-height);
+}
+
 .header-right {
   display: flex;
   align-items: center;
@@ -51,6 +71,10 @@
   padding: 4px 8px;
   background: var(--sl-bg-secondary);
   border-radius: var(--sl-radius-full);
+  -webkit-app-region: no-drag;
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .status-dot {
@@ -68,6 +92,9 @@
 .status-text {
   font-size: var(--sl-font-size-sm);
   color: var(--sl-text-secondary);
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .window-controls {

--- a/src/styles/components/layout/AppLayout.css
+++ b/src/styles/components/layout/AppLayout.css
@@ -8,6 +8,10 @@
   overflow: hidden;
 }
 
+.app-layout.macos-native-vibrancy {
+  background-color: transparent;
+}
+
 .app-background {
   position: absolute;
   top: 0;
@@ -28,6 +32,10 @@
   margin-left: var(--sl-sidebar-width);
   transition: margin-left 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   min-width: 0;
+}
+
+.app-main.macos-native-vibrancy {
+  background: transparent;
 }
 
 .app-main.sidebar-collapsed {

--- a/src/styles/components/layout/AppSidebar.css
+++ b/src/styles/components/layout/AppSidebar.css
@@ -37,6 +37,18 @@
   flex-shrink: 0;
 }
 
+.sidebar.macos-overlay .sidebar-logo {
+  margin-top: 16px;
+}
+
+.sidebar.macos-overlay .sidebar-nav {
+  padding-top: 0;
+}
+
+.sidebar.macos-overlay .server-selector {
+  padding-top: 0;
+}
+
 .logo-icon {
   flex-shrink: 0;
   display: flex;

--- a/src/styles/components/layout/AppSidebar.css
+++ b/src/styles/components/layout/AppSidebar.css
@@ -35,10 +35,18 @@
   height: 60px;
   cursor: pointer;
   flex-shrink: 0;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .sidebar.macos-overlay .sidebar-logo {
   margin-top: 16px;
+}
+
+.sidebar.macos-overlay {
+  background: var(--sl-bg);
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
 .sidebar.macos-overlay .sidebar-nav {
@@ -61,6 +69,8 @@
   font-weight: 700;
   white-space: nowrap;
   letter-spacing: -0.01em;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .sidebar-nav {
@@ -95,7 +105,13 @@
 }
 
 .sidebar.collapsed .server-selector {
-  padding: 1px;
+  padding: var(--sl-space-xs);
+  display: flex;
+  justify-content: center;
+}
+
+.sidebar.macos-overlay.collapsed .server-selector {
+  padding-top: 0;
 }
 
 .nav-item {

--- a/src/styles/components/layout/AppSidebar.css
+++ b/src/styles/components/layout/AppSidebar.css
@@ -81,6 +81,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .nav-group {
@@ -131,6 +133,8 @@
   white-space: nowrap;
   margin-top: 5px;
   min-height: 36px;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .nav-item:hover {

--- a/src/styles/components/layout/AppSidebar.css
+++ b/src/styles/components/layout/AppSidebar.css
@@ -97,8 +97,21 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
-  border-bottom: 1px solid var(--sl-border);
+  border-bottom: none;
   margin-bottom: var(--sl-space-xs);
+  position: relative;
+}
+
+.nav-group-label::after {
+  content: "";
+  position: absolute;
+  left: var(--sl-space-sm);
+  right: var(--sl-space-sm);
+  bottom: 0;
+  height: 1px;
+  border-radius: var(--sl-radius-full);
+  background: var(--sl-border);
+  opacity: 0.75;
 }
 
 .server-selector {
@@ -107,7 +120,7 @@
 }
 
 .sidebar.collapsed .server-selector {
-  padding: var(--sl-space-xs);
+  padding: var(--sl-space-sm);
   display: flex;
   justify-content: center;
 }
@@ -227,12 +240,18 @@
 }
 
 .sidebar.collapsed .nav-group-label {
-  visibility: hidden;
-  opacity: 0;
-  height: 0;
-  padding: 0;
-  margin-bottom: 0;
-  border-bottom: 1px solid var(--sl-border);
+  visibility: visible;
+  opacity: 1;
+  padding: var(--sl-space-xs) var(--sl-space-sm);
+  margin-bottom: var(--sl-space-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.sidebar.sidebar-transitioning .nav-active-indicator {
+  transition: none;
 }
 
 .sidebar.collapsed .nav-children {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,4 @@
+export function isMacOSPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Macintosh|Mac OS X/i.test(navigator.userAgent);
+}

--- a/src/views/DownloadView.vue
+++ b/src/views/DownloadView.vue
@@ -21,6 +21,7 @@ const { loading: submitting, start: startLoading, stop: stopLoading } = useLoadi
 
 // Tab state
 const activeTab = ref<"file" | "server">("server");
+const taskOriginTab = ref<"file" | "server" | null>(null);
 
 const tabs = computed(() => [
   { key: "server" as const, label: i18n.t("downloadServerView.title") },
@@ -62,6 +63,12 @@ const {
 } = downloadApi.useDownload();
 
 const isDownloading = computed(() => taskInfo.id !== "" && !taskInfo.isFinished);
+const isTaskVisibleForCurrentTab = computed(
+  () => taskInfo.id !== "" && taskOriginTab.value === activeTab.value,
+);
+const isDownloadCompleted = computed(
+  () => isTaskVisibleForCurrentTab.value && taskInfo.isFinished && !taskError.value,
+);
 const loadingAny = computed(() => loadingTypes.value || loadingVersions.value || loadingInfo.value);
 const combinedLoading = computed(() => submitting.value || isDownloading.value || loadingAny.value);
 
@@ -108,7 +115,24 @@ const canServerDownload = computed(() => {
 });
 
 const canGoCreate = computed(() => {
-  return taskInfo.isFinished && !taskError.value;
+  return (
+    taskOriginTab.value === "server" &&
+    isTaskVisibleForCurrentTab.value &&
+    taskInfo.isFinished &&
+    !taskError.value
+  );
+});
+
+const fileDownloadButtonLabel = computed(() => {
+  if (isDownloading.value) return i18n.t("download-file.downloading");
+  if (isDownloadCompleted.value) return i18n.t("downloadServerView.status.finished");
+  return i18n.t("download-file.download");
+});
+
+const serverDownloadButtonLabel = computed(() => {
+  if (isDownloading.value) return i18n.t("downloadServerView.actions.downloading");
+  if (isDownloadCompleted.value) return i18n.t("downloadServerView.status.finished");
+  return i18n.t("downloadServerView.actions.startDownload");
 });
 
 const savePathPreview = computed(() => {
@@ -246,6 +270,7 @@ async function cancelDownload() {
     }
 
     resetTask();
+    taskOriginTab.value = null;
   } catch (e) {
     showError(String(e));
   } finally {
@@ -273,6 +298,7 @@ async function handleFileDownload() {
 
   clearError();
   resetTask();
+  taskOriginTab.value = "file";
   startLoading();
 
   try {
@@ -296,6 +322,7 @@ async function handleServerDownload() {
 
   clearError();
   resetTask();
+  taskOriginTab.value = "server";
   startLoading();
 
   const targetPath = buildServerSavePath();
@@ -319,7 +346,7 @@ async function handleServerDownload() {
 
 const statusLabel = computed(() => {
   if (taskError.value) return i18n.t("download-file.failed");
-  if (taskInfo.isFinished) return i18n.t("download-file.completed");
+  if (taskInfo.isFinished) return i18n.t("downloadServerView.status.finished");
   return i18n.t("download-file.downloading");
 });
 
@@ -403,27 +430,23 @@ onMounted(() => {
       </SLButton>
       <SLButton
         v-if="activeTab === 'file'"
-        variant="primary"
+        :variant="isDownloadCompleted ? 'success' : 'primary'"
         size="lg"
         :disabled="!canFileDownload"
         @click="handleFileDownload"
         :loading="combinedLoading"
       >
-        {{ isDownloading ? i18n.t("download-file.downloading") : i18n.t("download-file.download") }}
+        {{ fileDownloadButtonLabel }}
       </SLButton>
       <SLButton
         v-else-if="activeTab === 'server'"
-        variant="primary"
+        :variant="isDownloadCompleted ? 'success' : 'primary'"
         size="lg"
         :disabled="!canServerDownload"
         @click="handleServerDownload"
         :loading="combinedLoading"
       >
-        {{
-          isDownloading
-            ? i18n.t("downloadServerView.actions.downloading")
-            : i18n.t("downloadServerView.actions.startDownload")
-        }}
+        {{ serverDownloadButtonLabel }}
       </SLButton>
       <SLButton
         v-if="activeTab === 'server'"
@@ -438,7 +461,7 @@ onMounted(() => {
 
     <!-- Download progress -->
     <Transition name="fade">
-      <div v-if="taskInfo.id" class="bottom-progress-area">
+      <div v-if="isTaskVisibleForCurrentTab" class="bottom-progress-area">
         <DownloadProgress :taskInfo="taskInfo" :taskError="taskError" :statusLabel="statusLabel" />
       </div>
     </Transition>

--- a/src/views/DownloadView.vue
+++ b/src/views/DownloadView.vue
@@ -66,6 +66,9 @@ const isDownloading = computed(() => taskInfo.id !== "" && !taskInfo.isFinished)
 const isTaskVisibleForCurrentTab = computed(
   () => taskInfo.id !== "" && taskOriginTab.value === activeTab.value,
 );
+const isDownloadingCurrentTab = computed(
+  () => isTaskVisibleForCurrentTab.value && !taskInfo.isFinished,
+);
 const isDownloadCompleted = computed(
   () => isTaskVisibleForCurrentTab.value && taskInfo.isFinished && !taskError.value,
 );
@@ -124,13 +127,13 @@ const canGoCreate = computed(() => {
 });
 
 const fileDownloadButtonLabel = computed(() => {
-  if (isDownloading.value) return i18n.t("download-file.downloading");
+  if (isDownloadingCurrentTab.value) return i18n.t("download-file.downloading");
   if (isDownloadCompleted.value) return i18n.t("downloadServerView.status.finished");
   return i18n.t("download-file.download");
 });
 
 const serverDownloadButtonLabel = computed(() => {
-  if (isDownloading.value) return i18n.t("downloadServerView.actions.downloading");
+  if (isDownloadingCurrentTab.value) return i18n.t("downloadServerView.actions.downloading");
   if (isDownloadCompleted.value) return i18n.t("downloadServerView.status.finished");
   return i18n.t("downloadServerView.actions.startDownload");
 });
@@ -152,10 +155,6 @@ function checkUrl() {
   } catch {
     // 当URL无效时，不重置filename，因为用户可能手动输入了文件名
   }
-}
-
-function checkFilename() {
-  // 文件名输入时不需要特殊处理
 }
 
 async function pickFileFolder() {
@@ -393,7 +392,6 @@ onMounted(() => {
         @update:filename="filename = $event"
         @update:threadCount="threadCount = $event"
         @checkUrl="checkUrl()"
-        @checkFilename="checkFilename()"
         @pickFolder="pickFileFolder"
         @checkThreadCount="checkThreadCount"
       />
@@ -434,7 +432,7 @@ onMounted(() => {
         size="lg"
         :disabled="!canFileDownload"
         @click="handleFileDownload"
-        :loading="combinedLoading"
+        :loading="isDownloadingCurrentTab"
       >
         {{ fileDownloadButtonLabel }}
       </SLButton>
@@ -444,7 +442,7 @@ onMounted(() => {
         size="lg"
         :disabled="!canServerDownload"
         @click="handleServerDownload"
-        :loading="combinedLoading"
+        :loading="isDownloadingCurrentTab"
       >
         {{ serverDownloadButtonLabel }}
       </SLButton>


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一）

- [x] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [x] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [x] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

统一窗口、交互体验以及 macOS 原生化

### 动机/背景

> 提示：可引用 Issue 作为背景说明

<!--为什么需要这个变更？解决了什么问题？-->

### 具体改动

<!--技术实现细节，以及关键说明-->

### 界面变动（如适用）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #`填写 Issue 编号`

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查说明

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

统一桌面应用的窗口 Chrome 与交互模式，引入原生的 macOS 标题栏和毛玻璃效果集成，同时打磨侧边栏/页眉布局、下载流程以及控制台/首页 UI 细节。

New Features:
- 启用原生的 macOS 窗口装饰、标题栏覆盖以及毛玻璃效果集成，并通过设置控制亚克力效果。
- 为每个标签页单独处理下载任务，使进度和完成状态仅显示在发起下载的标签页上，同时提供更清晰的按钮标签和成功状态样式。
- 使服务器下载类型/版本选择器支持搜索，并限制下拉列表高度，以便在长列表中更容易选择。

Bug Fixes:
- 通过保护并发轮询调用并确保任务状态被安全重置，防止下载任务轮询出现重叠或陈旧数据。
- 确保下载进度和完成操作不会在文件标签页和服务器标签页之间错误共享，避免跨标签页状态混淆。

Enhancements:
- 优化侧边栏、页眉和服务器选择器布局（包括 macOS 覆盖样式），提升一致性、间距，以及不可拖拽/不可选择区域的定义。
- 调整首页“快速开始”和“系统统计”卡片的垂直尺寸弹性，并改善引述和统计信息的展示效果。
- 改进控制台输出滚动条外观和标尺样式，使其更贴合应用主题。
- 将服务器标签页上的下载状态文案统一为“已完成”类标签，并为已完成下载新增成功状态样式。

Build:
- 在 Tauri 依赖上启用 `macos-private-api` 功能，以支持 macOS 特定的窗口行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the desktop app’s window chrome and interaction patterns, adding macOS-native title bar and vibrancy integration while polishing sidebar/header layout, download workflows, and console/home UI details.

New Features:
- Enable macOS-native window decorations, title bar overlay, and vibrancy integration with settings-driven acrylic control.
- Add per-tab handling of download tasks so progress and completion states are shown only on the originating tab with clearer button labels and success styling.
- Make server download type/version selectors searchable with constrained dropdown height for easier selection in long lists.

Bug Fixes:
- Prevent overlapping or stale download task polling by guarding concurrent poll calls and ensuring task state is reset safely.
- Ensure download progress and completion actions are not erroneously shared between file and server tabs, avoiding cross-tab status confusion.

Enhancements:
- Refine sidebar, header, and server selector layouts (including macOS overlay variants) to improve consistency, spacing, and non-draggable/non-selectable regions.
- Adjust home Quick Start and System Stats cards for more flexible vertical sizing and cleaner quote and stats presentation.
- Improve console output scrollbar appearance and ruler styling to better match the app theme.
- Change download status text to use a unified finished label on the server tab and add success variants for completed downloads.

Build:
- Enable the `macos-private-api` feature on the Tauri dependency to support macOS-specific window behaviors.

</details>