### PR TITLE
[Feature] Request to Build and Publish Official Docker Images via Git…

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,67 +1,55 @@
-name: "Docker 镜像发布"
+name: Docker Release Build
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - release
+  release:
+    types: [published]
 
-permissions:
-  contents: write
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: sealantern
 
 jobs:
-  build-and-upload-docker:
-    runs-on: ubuntu-24.04
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - name: 检出代码
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: 设置 Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: 获取版本号
-        id: version
-        run: |
-          VERSION=$(grep '"version"' src-tauri/tauri.conf.json | sed 's/.*"version": *"\([^"]*\)".*/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PUSH_TOKEN }}
 
-      - name: 构建 Docker 镜像（启用 docker feature）
-        run: |
-          # 构建镜像时通过 build-arg 传入 cargo 特性标志，以启用 docker-only 依赖
-          # 输出两个 tag：按版本号的 tag 以及 latest
-          docker build --build-arg CARGO_FEATURES=docker -t sealantern:${{ steps.version.outputs.version }} -t sealantern:latest .
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
 
-      - name: 导出 Docker 镜像
-        run: |
-          # 导出按版本 tag 的镜像为归档，便于上传到 Release
-          docker save sealantern:${{ steps.version.outputs.version }} | gzip > sealantern-docker-v${{ steps.version.outputs.version }}.tar.gz
-
-      - name: 获取 Release ID
-        id: get_release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # 查找匹配版本的 Release
-          RELEASE_ID=$(gh release list --limit 10 --search "v${{ steps.version.outputs.version }}" --json id,name --jq '.[] | select(.name | contains("${{ steps.version.outputs.version }}")) | .id' | head -1)
-
-          if [ -z "$RELEASE_ID" ]; then
-            echo "未找到匹配的 Release，可能需要先创建 Release"
-            echo "release_id=" >> $GITHUB_OUTPUT
-          else
-            echo "找到 Release ID: $RELEASE_ID"
-            echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
-          fi
-
-      - name: 上传到 Release
-        if: steps.get_release.outputs.release_id != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload ${{ steps.get_release.outputs.release_id }} sealantern-docker-v${{ steps.version.outputs.version }}.tar.gz
-
-      - name: 上传到 Release（通过标签）
-        if: steps.get_release.outputs.release_id == ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload sea-lantern-v${{ steps.version.outputs.version }} sealantern-docker-v${{ steps.version.outputs.version }}.tar.gz || echo "Release 可能还未创建，请稍后手动上传"
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -35,11 +35,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ secrets.DOCKER_HUB_USERNAME }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
…Hub Actions

Fixes #658

## 提交前检查清单

- [ ] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [ ] 本地/CI 测试通过
- [ ] 代码审查 (Self-review) 完成

## 变更分类（必选其一）

- [ ] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [x] 基础设施 Infrastructure
  - [x] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

.github/workflows/docker-release.yml
修改

### 具体改动

自动在发行版发布时编译上传docker image

### 界面变动（如适用）

<!--截图/GIF，前后对比-->


> 如果不存在关联，此项请忽略

- Fix #658
---

## 自动化审查说明

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

在 GitHub 发布 Release 时触发 Docker 镜像构建并推送到 Docker Hub。

新功能：
- 在发布 Release 时自动构建并将 Docker 镜像推送到 Docker Hub。

改进：
- 使用 `docker/metadata-action` 和 `build-push-action` 以及标准化的标签简化 Docker 发布工作流。
- 将发布的 Docker 镜像限制为 `linux/amd64` 平台，并为 Docker 构建启用 GitHub Actions 缓存。

CI：
- 将 Docker 工作流触发条件从手动触发和 Release 分支推送改为 GitHub Release 发布事件。
- 在发布工作流中通过 GitHub Secrets 配置 Docker Hub 认证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Trigger Docker image builds and pushes to Docker Hub on GitHub release publication.

New Features:
- Automatically build and push Docker images to Docker Hub when a release is published.

Enhancements:
- Simplify the Docker release workflow by using docker/metadata-action and build-push-action with standardized tagging.
- Restrict published Docker images to linux/amd64 platform and enable GitHub Actions cache for Docker builds.

CI:
- Change the Docker workflow trigger from manual dispatch and release branch pushes to GitHub release publication events.
- Configure Docker Hub authentication via GitHub Secrets for the release workflow.

</details>