### PR TITLE
feat: 添加 SL.json 启动配置的读取和写入功能

### DIFF
--- a/src-tauri/src/commands/server/config.rs
+++ b/src-tauri/src/commands/server/config.rs
@@ -1,7 +1,17 @@
 use crate::models::config::ServerProperties;
 use crate::services::server::config as config_parser;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
+
+/// SL.json 启动配置结构
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SLStartupConfig {
+    #[serde(default)]
+    pub max_memory: Option<u32>,
+    #[serde(default)]
+    pub min_memory: Option<u32>,
+}
 
 fn validate_config_path(path: &str) -> Result<(), String> {
     let path = Path::new(path);
@@ -110,4 +120,39 @@ pub fn preview_server_properties_write_from_source(
     values: HashMap<String, String>,
 ) -> Result<String, String> {
     config_parser::preview_properties_write_from_source(&source, &values)
+}
+
+/// 读取服务器目录下的 SL.json 启动配置
+#[tauri::command]
+pub fn read_sl_config(server_path: String) -> Result<SLStartupConfig, String> {
+    validate_config_path(&server_path)?;
+    let sl_path = format!("{}/SL.json", server_path);
+    
+    let path = Path::new(&sl_path);
+    if !path.exists() {
+        return Ok(SLStartupConfig::default());
+    }
+    
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("读取 SL.json 失败: {}", e))?;
+    
+    let config: SLStartupConfig = serde_json::from_str(&content)
+        .map_err(|e| format!("解析 SL.json 失败: {}", e))?;
+    
+    Ok(config)
+}
+
+/// 写入服务器目录下的 SL.json 启动配置
+#[tauri::command]
+pub fn write_sl_config(server_path: String, config: SLStartupConfig) -> Result<(), String> {
+    validate_config_path(&server_path)?;
+    let sl_path = format!("{}/SL.json", server_path);
+    
+    let content = serde_json::to_string_pretty(&config)
+        .map_err(|e| format!("序列化 SL.json 失败: {}", e))?;
+    
+    std::fs::write(&sl_path, content)
+        .map_err(|e| format!("写入 SL.json 失败: {}", e))?;
+    
+    Ok(())
 }

--- a/src-tauri/src/commands/server/config.rs
+++ b/src-tauri/src/commands/server/config.rs
@@ -127,18 +127,17 @@ pub fn preview_server_properties_write_from_source(
 pub fn read_sl_config(server_path: String) -> Result<SLStartupConfig, String> {
     validate_config_path(&server_path)?;
     let sl_path = format!("{}/SL.json", server_path);
-    
+
     let path = Path::new(&sl_path);
     if !path.exists() {
         return Ok(SLStartupConfig::default());
     }
-    
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("读取 SL.json 失败: {}", e))?;
-    
-    let config: SLStartupConfig = serde_json::from_str(&content)
-        .map_err(|e| format!("解析 SL.json 失败: {}", e))?;
-    
+
+    let content = std::fs::read_to_string(path).map_err(|e| format!("读取 SL.json 失败: {}", e))?;
+
+    let config: SLStartupConfig =
+        serde_json::from_str(&content).map_err(|e| format!("解析 SL.json 失败: {}", e))?;
+
     Ok(config)
 }
 
@@ -147,12 +146,11 @@ pub fn read_sl_config(server_path: String) -> Result<SLStartupConfig, String> {
 pub fn write_sl_config(server_path: String, config: SLStartupConfig) -> Result<(), String> {
     validate_config_path(&server_path)?;
     let sl_path = format!("{}/SL.json", server_path);
-    
-    let content = serde_json::to_string_pretty(&config)
-        .map_err(|e| format!("序列化 SL.json 失败: {}", e))?;
-    
-    std::fs::write(&sl_path, content)
-        .map_err(|e| format!("写入 SL.json 失败: {}", e))?;
-    
+
+    let content =
+        serde_json::to_string_pretty(&config).map_err(|e| format!("序列化 SL.json 失败: {}", e))?;
+
+    std::fs::write(&sl_path, content).map_err(|e| format!("写入 SL.json 失败: {}", e))?;
+
     Ok(())
 }

--- a/src-tauri/src/commands/server/config.rs
+++ b/src-tauri/src/commands/server/config.rs
@@ -126,9 +126,7 @@ pub fn preview_server_properties_write_from_source(
 #[tauri::command]
 pub fn read_sl_config(server_path: String) -> Result<SLStartupConfig, String> {
     validate_config_path(&server_path)?;
-    let sl_path = format!("{}/SL.json", server_path);
-
-    let path = Path::new(&sl_path);
+    let path = Path::new(&server_path).join("SL.json");
     if !path.exists() {
         return Ok(SLStartupConfig::default());
     }

--- a/src-tauri/src/runtime/command_catalog.rs
+++ b/src-tauri/src/runtime/command_catalog.rs
@@ -63,6 +63,8 @@ pub(crate) fn desktop_handler(
         config_commands::parse_server_properties_source,
         config_commands::preview_server_properties_write,
         config_commands::preview_server_properties_write_from_source,
+        config_commands::read_sl_config,
+        config_commands::write_sl_config,
         system_commands::get_system_info,
         system_commands::get_server_resource_usage,
         system_commands::pick_jar_file,

--- a/src-tauri/src/services/server/manager.rs
+++ b/src-tauri/src/services/server/manager.rs
@@ -206,8 +206,8 @@ impl ServerManager {
         console_encoding: ManagedConsoleEncoding,
     ) -> Vec<String> {
         let java_encoding = console_encoding.java_name();
-        let (max_mem, min_mem) = Self::read_sl_startup_config(server)
-            .unwrap_or((server.max_memory, server.min_memory));
+        let (max_mem, min_mem) =
+            Self::read_sl_startup_config(server).unwrap_or((server.max_memory, server.min_memory));
         let mut args = vec![
             format!("-Xmx{}M", max_mem),
             format!("-Xms{}M", min_mem),

--- a/src-tauri/src/services/server/manager.rs
+++ b/src-tauri/src/services/server/manager.rs
@@ -179,7 +179,26 @@ impl ServerManager {
             .map_err(|_| "data_dir lock poisoned".to_string())
     }
 
+    /// 尝试从服务器目录下的 SL.json 读取启动配置
+    fn read_sl_startup_config(server: &ServerInstance) -> Option<(u32, u32)> {
+        let sl_path = std::path::Path::new(&server.path).join("SL.json");
+        if !sl_path.exists() {
+            return None;
+        }
+        let content = std::fs::read_to_string(&sl_path).ok()?;
+        let config: crate::commands::server::config::SLStartupConfig =
+            serde_json::from_str(&content).ok()?;
+        match (config.max_memory, config.min_memory) {
+            (Some(max), Some(min)) => Some((max, min)),
+            (Some(max), None) => Some((max, server.min_memory)),
+            (None, Some(min)) => Some((server.max_memory, min)),
+            (None, None) => None,
+        }
+    }
+
     /// 按当前设置拼出托管启动参数
+    ///
+    /// 优先从 SL.json 读取内存值，没有则回退到 ServerInstance 的默认值
     fn build_managed_jvm_args(
         &self,
         server: &ServerInstance,
@@ -187,9 +206,11 @@ impl ServerManager {
         console_encoding: ManagedConsoleEncoding,
     ) -> Vec<String> {
         let java_encoding = console_encoding.java_name();
+        let (max_mem, min_mem) = Self::read_sl_startup_config(server)
+            .unwrap_or((server.max_memory, server.min_memory));
         let mut args = vec![
-            format!("-Xmx{}M", server.max_memory),
-            format!("-Xms{}M", server.min_memory),
+            format!("-Xmx{}M", max_mem),
+            format!("-Xms{}M", min_mem),
             format!("-Dfile.encoding={}", java_encoding),
             format!("-Dsun.stdout.encoding={}", java_encoding),
             format!("-Dsun.stderr.encoding={}", java_encoding),

--- a/src-tauri/src/services/server/manager/provisioning/create.rs
+++ b/src-tauri/src/services/server/manager/provisioning/create.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::commands::server::config::SLStartupConfig;
 use crate::models::server::{CreateServerRequest, ServerInstance};
 
 use super::super::common::{current_timestamp_secs, normalize_startup_mode, validate_server_name};
@@ -24,7 +25,7 @@ pub(super) fn create_server(
         core_type: req.core_type,
         core_version: String::new(),
         mc_version: req.mc_version,
-        path: server_dir,
+        path: server_dir.clone(),
         jar_path: req.jar_path,
         startup_mode: normalize_startup_mode(&req.startup_mode).to_string(),
         custom_command: req.custom_command,
@@ -36,6 +37,16 @@ pub(super) fn create_server(
         created_at: now,
         last_started_at: None,
     };
+
+    // 自动生成 SL.json 启动配置文件
+    let sl_config = SLStartupConfig {
+        max_memory: Some(req.max_memory),
+        min_memory: Some(req.min_memory),
+    };
+    let sl_path = Path::new(&server_dir).join("SL.json");
+    if let Ok(content) = serde_json::to_string_pretty(&sl_config) {
+        let _ = std::fs::write(&sl_path, content);
+    }
 
     manager.lock_servers()?.push(server.clone());
     manager.save()?;

--- a/src-tauri/src/services/server/manager/provisioning/create.rs
+++ b/src-tauri/src/services/server/manager/provisioning/create.rs
@@ -38,15 +38,22 @@ pub(super) fn create_server(
         last_started_at: None,
     };
 
-    // 自动生成 SL.json 启动配置文件
-    let sl_config = SLStartupConfig {
-        max_memory: Some(req.max_memory),
-        min_memory: Some(req.min_memory),
-    };
-    let sl_path = Path::new(&server_dir).join("SL.json");
-    if let Ok(content) = serde_json::to_string_pretty(&sl_config) {
-        let _ = std::fs::write(&sl_path, content);
-    }
+ // 自动生成 SL.json 启动配置文件
+ let sl_config = SLStartupConfig {
+ max_memory: Some(req.max_memory),
+ min_memory: Some(req.min_memory),
+ };
+ let sl_path = Path::new(&server_dir).join("SL.json");
+ match serde_json::to_string_pretty(&sl_config) {
+ Ok(content) => {
+ if let Err(e) = std::fs::write(&sl_path, content) {
+ eprintln!("[WARN] 无法创建 SL.json 启动配置文件: {}", e);
+ }
+ }
+ Err(e) => {
+ eprintln!("[WARN] 无法序列化 SL.json 配置: {}", e);
+ }
+ }
 
     manager.lock_servers()?.push(server.clone());
     manager.save()?;

--- a/src-tauri/src/services/server/manager/provisioning/create.rs
+++ b/src-tauri/src/services/server/manager/provisioning/create.rs
@@ -38,22 +38,22 @@ pub(super) fn create_server(
         last_started_at: None,
     };
 
- // 自动生成 SL.json 启动配置文件
- let sl_config = SLStartupConfig {
- max_memory: Some(req.max_memory),
- min_memory: Some(req.min_memory),
- };
- let sl_path = Path::new(&server_dir).join("SL.json");
- match serde_json::to_string_pretty(&sl_config) {
- Ok(content) => {
- if let Err(e) = std::fs::write(&sl_path, content) {
- eprintln!("[WARN] 无法创建 SL.json 启动配置文件: {}", e);
- }
- }
- Err(e) => {
- eprintln!("[WARN] 无法序列化 SL.json 配置: {}", e);
- }
- }
+    // 自动生成 SL.json 启动配置文件
+    let sl_config = SLStartupConfig {
+        max_memory: Some(req.max_memory),
+        min_memory: Some(req.min_memory),
+    };
+    let sl_path = Path::new(&server_dir).join("SL.json");
+    match serde_json::to_string_pretty(&sl_config) {
+        Ok(content) => {
+            if let Err(e) = std::fs::write(&sl_path, content) {
+                eprintln!("[WARN] 无法创建 SL.json 启动配置文件: {}", e);
+            }
+        }
+        Err(e) => {
+            eprintln!("[WARN] 无法序列化 SL.json 配置: {}", e);
+        }
+    }
 
     manager.lock_servers()?.push(server.clone());
     manager.save()?;

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -21,6 +21,14 @@ export interface ServerProperties {
 }
 
 /**
+ * SL.json 启动配置
+ */
+export interface SLStartupConfig {
+  max_memory: number | null;
+  min_memory: number | null;
+}
+
+/**
  * 配置管理 API
  */
 export const configApi = {
@@ -113,5 +121,19 @@ export const configApi = {
     values: Record<string, string>,
   ): Promise<void> {
     return tauriInvoke("write_config", { serverPath, path, values });
+  },
+
+  /**
+   * 读取 SL.json 启动配置
+   */
+  async readSLConfig(serverPath: string): Promise<SLStartupConfig> {
+    return tauriInvoke("read_sl_config", { serverPath });
+  },
+
+  /**
+   * 写入 SL.json 启动配置
+   */
+  async writeSLConfig(serverPath: string, config: SLStartupConfig): Promise<void> {
+    return tauriInvoke("write_sl_config", { serverPath, config });
   },
 };

--- a/src/components/config/ConfigStartupSection.vue
+++ b/src/components/config/ConfigStartupSection.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from "vue";
+import SLButton from "@components/common/SLButton.vue";
+import { configApi, type SLStartupConfig } from "@api/config";
+import { i18n } from "@language";
+
+const props = defineProps<{
+  serverPath: string;
+  defaultMaxMemory: number;
+  defaultMinMemory: number;
+}>();
+
+const emit = defineEmits<{
+  (e: "saved"): void;
+}>();
+
+const maxMemory = ref(props.defaultMaxMemory);
+const minMemory = ref(props.defaultMinMemory);
+const loading = ref(false);
+const saving = ref(false);
+const saved = ref(false);
+const error = ref<string | null>(null);
+
+async function loadConfig() {
+  if (!props.serverPath) return;
+  loading.value = true;
+  error.value = null;
+  try {
+    const config = await configApi.readSLConfig(props.serverPath);
+    maxMemory.value = config.max_memory ?? props.defaultMaxMemory;
+    minMemory.value = config.min_memory ?? props.defaultMinMemory;
+  } catch (e: any) {
+    error.value = e?.toString() || "加载启动配置失败";
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function saveConfig() {
+  if (!props.serverPath) return;
+  if (maxMemory.value < 128) {
+    error.value = "最大内存不能小于 128MB";
+    return;
+  }
+  if (minMemory.value < 128) {
+    error.value = "最小内存不能小于 128MB";
+    return;
+  }
+  if (minMemory.value > maxMemory.value) {
+    error.value = "最小内存不能大于最大内存";
+    return;
+  }
+  saving.value = true;
+  error.value = null;
+  try {
+    const config: SLStartupConfig = {
+      max_memory: maxMemory.value,
+      min_memory: minMemory.value,
+    };
+    await configApi.writeSLConfig(props.serverPath, config);
+    saved.value = true;
+    setTimeout(() => {
+      saved.value = false;
+    }, 3000);
+    emit("saved");
+  } catch (e: any) {
+    error.value = e?.toString() || "保存启动配置失败";
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(loadConfig);
+watch(() => props.serverPath, loadConfig);
+</script>
+
+<template>
+  <div class="config-startup-section">
+    <div v-if="loading" class="startup-loading">
+      <p class="text-body">{{ i18n.t("common.loading") }}</p>
+    </div>
+    <template v-else>
+      <div v-if="error" class="error-banner">
+        <span>{{ error }}</span>
+        <button class="banner-close" @click="error = null">x</button>
+      </div>
+      <div v-if="saved" class="success-banner">
+        <span>{{ i18n.t("config.startup_config_saved") }}</span>
+      </div>
+      <div class="startup-settings-group">
+        <h3 class="startup-group-title">{{ i18n.t("config.memory_settings") }}</h3>
+        <p class="startup-group-desc">{{ i18n.t("config.memory_settings_desc") }}</p>
+        <div class="startup-field">
+          <label class="startup-field-label">{{ i18n.t("config.max_memory") }}</label>
+          <input
+            v-model.number="maxMemory"
+            type="number"
+            class="startup-field-input"
+            :placeholder="'2048'"
+            min="128"
+            step="128"
+          />
+        </div>
+        <div class="startup-field">
+          <label class="startup-field-label">{{ i18n.t("config.min_memory") }}</label>
+          <input
+            v-model.number="minMemory"
+            type="number"
+            class="startup-field-input"
+            :placeholder="'512'"
+            min="128"
+            step="128"
+          />
+        </div>
+      </div>
+      <div class="startup-actions">
+        <SLButton variant="primary" :loading="saving" @click="saveConfig">
+          {{ i18n.t("config.save_startup_config") }}
+        </SLButton>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.config-startup-section {
+  padding: 20px;
+}
+
+.startup-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.error-banner,
+.success-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.error-banner {
+  background: rgba(220, 38, 38, 0.1);
+  color: #dc2626;
+  border: 1px solid rgba(220, 38, 38, 0.2);
+}
+
+.success-banner {
+  background: rgba(22, 163, 74, 0.1);
+  color: #16a34a;
+  border: 1px solid rgba(22, 163, 74, 0.2);
+}
+
+.banner-close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+}
+
+.startup-settings-group {
+  margin-bottom: 24px;
+}
+
+.startup-group-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+}
+
+.startup-group-desc {
+  font-size: 13px;
+  color: var(--text-secondary, #888);
+  margin: 0 0 20px 0;
+}
+
+.startup-field {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.startup-field-label {
+  font-size: 14px;
+  min-width: 160px;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.startup-field-input {
+  width: 200px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--tertiary-background, rgba(255, 255, 255, 0.05));
+  color: var(--text-primary, #e0e0e0);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.startup-field-input:focus {
+  border-color: var(--primary-color, #3b82f6);
+}
+
+.startup-actions {
+  display: flex;
+  gap: 12px;
+}
+</style>

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -471,6 +471,13 @@
         "all_servers": "全部服务器"
       },
       "server_plugins": "服务器插件",
+      "startup_properties": "启动属性",
+      "max_memory": "最大内存 (MB)",
+      "min_memory": "最小内存 (MB)",
+      "memory_settings": "内存设置",
+      "memory_settings_desc": "配置服务器启动时的内存分配",
+      "save_startup_config": "保存启动配置",
+      "startup_config_saved": "启动配置已保存",
       "loading_plugins": "加载插件中...",
       "no_plugins": "没有找到插件",
       "author": "作者",

--- a/src/views/ConfigView.vue
+++ b/src/views/ConfigView.vue
@@ -13,6 +13,7 @@ import { FileDiff } from "lucide-vue-next";
 import ConfigSourceDiffView from "@components/config/ConfigSourceDiffView.vue";
 import ConfigPluginsSection from "@components/config/ConfigPluginsSection.vue";
 import ConfigPropertiesSection from "@components/config/ConfigPropertiesSection.vue";
+import ConfigStartupSection from "@components/config/ConfigStartupSection.vue";
 import { useConfigPlugins } from "@views/config/useConfigPlugins";
 import { useConfigCompare } from "@views/config/useConfigCompare";
 import { useConfigPropertiesEditor } from "@views/config/useConfigPropertiesEditor";
@@ -24,7 +25,7 @@ const store = useServerStore();
 
 const error = ref<string | null>(null);
 const successMsg = ref<string | null>(null);
-const activeTab = ref<"properties" | "plugins">("properties");
+const activeTab = ref<"properties" | "plugins" | "startup">("properties");
 const configSaveDiffModalWidth = "1040px";
 
 const currentServerId = computed(() => store.currentServerId);
@@ -121,6 +122,7 @@ const configTabs = computed(() => [
     count: "i",
     countTitle: serverPropertiesPath.value,
   },
+  { key: "startup", label: i18n.t("config.startup_properties") },
   { key: "plugins", label: i18n.t("config.server_plugins") },
 ]);
 
@@ -284,6 +286,14 @@ onActivated(async () => {
           @reloadCurrent="propertiesEditor.reloadPropertiesWithGuard"
           @reloadCompare="propertiesEditor.reloadComparePropertiesWithGuard"
           @saveProperties="propertiesEditor.saveProperties"
+        />
+      </template>
+
+      <template v-if="activeTab === 'startup'">
+        <ConfigStartupSection
+          :serverPath="serverPath"
+          :defaultMaxMemory="currentServer?.max_memory ?? 2048"
+          :defaultMinMemory="currentServer?.min_memory ?? 512"
         />
       </template>
 


### PR DESCRIPTION
## 提交前检查清单

- [ ] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [ ] 本地/CI 测试通过
- [ ] 代码审查 (Self-review) 完成

## 变更分类（必选其一）

- [x] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [x] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [x] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

用SL.json写配置，同时当时才生成启动脚本

### 动机/背景

> 提示：可引用 Issue 作为背景说明

<!--为什么需要这个变更？解决了什么问题？-->

### 界面变动（如适用）

依然在修改

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #235 
---

## 自动化审查说明

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

添加对基于 SL.json 的服务器启动配置的读取、写入和使用支持，包括一个用于管理 JVM 内存设置的新 UI 选项卡。

新特性：
- 引入 SL.json 启动配置模型以及 Tauri 命令，用于为每个服务器目录读取和写入该配置。
- 添加前端 API 方法和专用的启动配置选项卡，以便在 UI 中编辑服务器内存设置。
- 在创建新服务器时自动生成带有初始内存限制的 SL.json 文件，如果该文件存在，托管的 JVM 参数将优先使用其中的值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for reading, writing, and using SL.json-based server startup configuration, including a new UI tab for managing JVM memory settings.

New Features:
- Introduce SL.json startup configuration model and Tauri commands to read and write it for each server directory.
- Add front-end API methods and a dedicated startup configuration tab to edit server memory settings in the UI.
- Automatically generate an SL.json file with initial memory limits when creating a new server, and have managed JVM arguments prefer values from this file if present.

</details>