### PR TITLE
Fix/forge 和 neoforge端的启动错误

### DIFF
--- a/backend/server-installer-core/src/lib.rs
+++ b/backend/server-installer-core/src/lib.rs
@@ -4,6 +4,7 @@ mod mc_version;
 mod parser;
 
 use std::path::Path;
+use std::str::FromStr;
 
 pub use archive::{
     extract_modpack_archive, find_server_jar, find_server_jar_checked, resolve_extracted_root,
@@ -55,13 +56,31 @@ pub fn detect_mc_version_from_mods_checked(
 fn detect_core_type_with_main_class_checked(
     input: &str,
 ) -> Result<(String, Option<String>), String> {
+    let filename_core = detect_core_type_checked(input)?;
     let main_class = read_jar_main_class_checked(input)?;
     if let Some(ref class_name) = main_class {
         if let Some(core_type) = core_type_from_main_class(class_name) {
-            return Ok((core_type.to_string(), Some(class_name.clone())));
+            let resolved_core_type = reconcile_main_class_and_filename_core_type(
+                CoreType::from_str(&filename_core).unwrap_or(CoreType::Unknown),
+                core_type,
+            );
+            return Ok((resolved_core_type.to_string(), Some(class_name.clone())));
         }
     }
-    Ok((detect_core_type_checked(input)?, main_class))
+    Ok((filename_core, main_class))
+}
+
+fn reconcile_main_class_and_filename_core_type(
+    filename_core: CoreType,
+    main_class_core: CoreType,
+) -> CoreType {
+    match (filename_core, main_class_core) {
+        // NeoForge installers can still expose the legacy Forge SimpleInstaller main class.
+        (CoreType::Neoforge, CoreType::Forge) | (CoreType::ArclightNeoforge, CoreType::Forge) => {
+            filename_core
+        }
+        (_, main_class_core) => main_class_core,
+    }
 }
 
 fn core_type_from_main_class(main_class: &str) -> Option<CoreType> {

--- a/backend/server-installer-core/tests/core_archive_checks.rs
+++ b/backend/server-installer-core/tests/core_archive_checks.rs
@@ -207,6 +207,27 @@ fn parse_server_core_type_reads_folded_manifest_main_class() {
 }
 
 #[test]
+fn parse_server_core_type_keeps_neoforge_filename_when_installer_main_class_is_legacy_forge() {
+    let dir = tempfile::tempdir().expect("temp dir should exist");
+    let jar_path = dir
+        .path()
+        .join("neoforge-26.1.0.0-alpha.1+snapshot-1-installer.jar");
+    write_manifest_jar(
+        &jar_path,
+        "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.installer.SimpleInstaller\r\n\r\n",
+    );
+
+    let parsed = parse_server_core_type(jar_path.to_string_lossy().as_ref())
+        .expect("neoforge installer manifest should parse");
+
+    assert_eq!(parsed.core_type, "Neoforge");
+    assert_eq!(
+        parsed.main_class.as_deref(),
+        Some("net.minecraftforge.installer.SimpleInstaller")
+    );
+}
+
+#[test]
 fn parse_server_core_type_returns_relative_jar_path_for_archive_source() {
     let dir = tempfile::tempdir().expect("temp dir should exist");
     let archive_path = dir.path().join("modpack.zip");

--- a/backend/server-installer-core/tests/core_archive_checks.rs
+++ b/backend/server-installer-core/tests/core_archive_checks.rs
@@ -228,6 +228,28 @@ fn parse_server_core_type_keeps_neoforge_filename_when_installer_main_class_is_l
 }
 
 #[test]
+fn parse_server_core_type_keeps_arclight_neoforge_filename_when_installer_main_class_is_legacy_forge(
+) {
+    let dir = tempfile::tempdir().expect("temp dir should exist");
+    let jar_path = dir
+        .path()
+        .join("arclight-neoforge-26.1.0.0-alpha.1+snapshot-1-installer.jar");
+    write_manifest_jar(
+        &jar_path,
+        "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.installer.SimpleInstaller\r\n\r\n",
+    );
+
+    let parsed = parse_server_core_type(jar_path.to_string_lossy().as_ref())
+        .expect("arclight neoforge installer manifest should parse");
+
+    assert_eq!(parsed.core_type, "Arclight-Neoforge");
+    assert_eq!(
+        parsed.main_class.as_deref(),
+        Some("net.minecraftforge.installer.SimpleInstaller")
+    );
+}
+
+#[test]
 fn parse_server_core_type_returns_relative_jar_path_for_archive_source() {
     let dir = tempfile::tempdir().expect("temp dir should exist");
     let archive_path = dir.path().join("modpack.zip");

--- a/backend/server-local-setup-core/src/lib.rs
+++ b/backend/server-local-setup-core/src/lib.rs
@@ -874,7 +874,7 @@ fn startup_mode_prefers_direct_jar(startup_mode: &str) -> bool {
         normalize_cli_startup_mode(Some(startup_mode))
             .unwrap_or_else(|_| "jar".to_string())
             .as_str(),
-        "bat" | "sh" | "ps1"
+        "jar" | "starter"
     )
 }
 
@@ -1185,9 +1185,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_local_preferred_jar_path_prefers_configured_jar_for_script_modes() {
+    fn resolve_local_preferred_jar_path_prefers_configured_jar_for_jar_mode() {
         let resolved = resolve_local_preferred_jar_path(
-            "sh",
+            "jar",
             Some("E:/servers/paper/server.jar"),
             Path::new("E:/servers/paper"),
         );
@@ -1196,9 +1196,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_local_preferred_jar_path_ignores_non_script_modes() {
+    fn resolve_local_preferred_jar_path_ignores_script_mode_even_when_jar_exists() {
         let resolved = resolve_local_preferred_jar_path(
-            "custom",
+            "sh",
             Some("E:/servers/paper/server.jar"),
             Path::new("E:/servers/paper"),
         );
@@ -1207,7 +1207,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_local_preferred_jar_path_checked_surfaces_server_scan_failures() {
+    fn resolve_local_preferred_jar_path_checked_surfaces_server_scan_failures_for_jar_mode() {
         let dir = tempdir().expect("temp dir should exist");
         let folder = dir.path().join("paper-server");
         std::fs::create_dir_all(&folder).expect("folder should create");
@@ -1215,7 +1215,7 @@ mod tests {
             .expect("directory-backed jar path should create");
 
         let error = resolve_local_preferred_jar_path_checked(
-            "sh",
+            "jar",
             Some(folder.join("start.sh").to_string_lossy().as_ref()),
             &folder,
         )
@@ -1233,7 +1233,7 @@ mod tests {
             .expect("directory-backed jar path should create");
 
         let resolved = resolve_local_preferred_jar_path(
-            "sh",
+            "jar",
             Some(folder.join("start.sh").to_string_lossy().as_ref()),
             &folder,
         );

--- a/backend/server-startup-scan-core/src/lib.rs
+++ b/backend/server-startup-scan-core/src/lib.rs
@@ -495,6 +495,25 @@ mod tests {
     }
 
     #[test]
+    fn scan_startup_candidates_keeps_neoforge_type_for_legacy_simpleinstaller_manifest() {
+        let dir = tempfile::tempdir().expect("temp dir should exist");
+        let jar_path = dir
+            .path()
+            .join("neoforge-26.1.0.0-alpha.1+snapshot-1-installer.jar");
+        write_manifest_jar(
+            &jar_path,
+            "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.installer.SimpleInstaller\r\n\r\n",
+        );
+
+        let result = scan_startup_candidates(jar_path.to_string_lossy().as_ref(), "archive", &[])
+            .expect("archive jar scan should succeed");
+
+        assert_eq!(result.parsed_core.core_type, "Neoforge");
+        assert_eq!(result.detected_core_type_key.as_deref(), Some("neoforge"));
+        assert!(result.candidates[0].detail.contains("Neoforge"));
+    }
+
+    #[test]
     fn scan_startup_candidates_surfaces_broken_jar_candidates_in_folder_scan() {
         let dir = tempfile::tempdir().expect("temp dir should exist");
         fs::write(dir.path().join("paper-server.jar"), b"not a real jar archive")

--- a/backend/tauri-host/src/services/server/manager/common.rs
+++ b/backend/tauri-host/src/services/server/manager/common.rs
@@ -53,7 +53,7 @@ impl StartupMode {
 
     #[cfg(test)]
     pub(super) fn prefers_direct_jar(self) -> bool {
-        matches!(self, Self::Bat | Self::Sh | Self::Ps1)
+        matches!(self, Self::Jar | Self::Starter)
     }
 
     #[cfg(target_os = "windows")]
@@ -379,8 +379,10 @@ mod tests {
     fn startup_mode_parsing_and_flags_match_runtime_expectations() {
         assert_eq!(StartupMode::from_raw("CUSTOM"), StartupMode::Custom);
         assert_eq!(StartupMode::from_raw("unknown"), StartupMode::Jar);
-        assert!(StartupMode::Bat.prefers_direct_jar());
-        assert!(StartupMode::Sh.prefers_direct_jar());
+        assert!(StartupMode::Jar.prefers_direct_jar());
+        assert!(StartupMode::Starter.prefers_direct_jar());
+        assert!(!StartupMode::Bat.prefers_direct_jar());
+        assert!(!StartupMode::Sh.prefers_direct_jar());
         assert!(!StartupMode::Custom.prefers_direct_jar());
         assert!(StartupMode::Starter.is_starter());
         assert!(StartupMode::Custom.is_custom());

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/command_builder.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/command_builder.rs
@@ -284,10 +284,12 @@ mod tests {
     }
 
     #[test]
-    fn script_modes_still_prefer_direct_jar() {
-        assert!(StartupMode::Bat.prefers_direct_jar());
-        assert!(StartupMode::Sh.prefers_direct_jar());
-        assert!(StartupMode::Ps1.prefers_direct_jar());
+    fn only_jar_like_modes_prefer_direct_jar() {
+        assert!(StartupMode::Jar.prefers_direct_jar());
+        assert!(StartupMode::Starter.prefers_direct_jar());
+        assert!(!StartupMode::Bat.prefers_direct_jar());
+        assert!(!StartupMode::Sh.prefers_direct_jar());
+        assert!(!StartupMode::Ps1.prefers_direct_jar());
     }
 
     #[test]

--- a/backend/tauri-host/src/services/server/manager/runtime_start/local_launch_detail.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/local_launch_detail.rs
@@ -228,8 +228,6 @@ mod tests {
     fn build_local_launch_detail_uses_script_filename_for_sh_mode() {
         let temp_dir = tempdir().expect("temp dir should exist");
         let mut server = test_server(temp_dir.path().to_string_lossy().to_string(), "sh");
-        let server_jar_path = temp_dir.path().join("server.jar");
-        let _ = std::fs::remove_file(&server_jar_path);
         let script_path = temp_dir.path().join("start.sh");
         std::fs::write(&script_path, b"#!/bin/sh\nexit 0\n").expect("script fixture should exist");
         if let ServerRuntimeConfig::Local(runtime) = &mut server.runtime {
@@ -243,6 +241,7 @@ mod tests {
         assert_eq!(detail.launch_target, "start.sh");
         assert!(detail.effective_jvm_args.is_empty());
         assert!(detail.command_preview.contains("start.sh"));
+        assert!(!detail.command_preview.contains("server.jar"));
     }
 
     #[test]


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [x] 后端 Backend
  - [ ] API 接口变更
  - [x] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

<!-- 一句话概括本次变更 -->

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #724 

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

为 NeoForge 安装器统一服务器核心和启动检测行为，并优化直接 JAR 启动与脚本启动场景下的启动模式处理。

Bug Fixes:
- 确保那些仍然暴露旧版 Forge `SimpleInstaller` 主类的 NeoForge 安装器，仍可基于其文件名被正确识别为 NeoForge。
- 修正启动模式逻辑，使只有类似 JAR 的模式才优先使用直接 JAR 执行，而脚本模式则依赖其脚本文件。
- 修复本地启动详情生成逻辑，确保在使用 shell 脚本启动模式时，使用脚本文件名，而不会回退到缺失的 `server.jar` 路径。

Tests:
- 新增类似集成测试的用例，覆盖在使用旧版 Forge `SimpleInstaller` 主类时，NeoForge 安装器清单解析和启动候选扫描的行为。
- 更新并扩展与启动模式偏好及本地首选 JAR 解析相关的测试，以反映修正后的 JAR 与脚本模式行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align server core and startup detection behavior for NeoForge installers and refine startup mode handling for direct JAR vs script launches.

Bug Fixes:
- Ensure NeoForge installers that expose the legacy Forge SimpleInstaller main class are still classified as NeoForge based on their filename.
- Correct startup mode logic so only JAR-like modes prefer direct JAR execution while script modes rely on their script files.
- Fix local launch detail generation so shell script startup mode uses the script filename and does not fall back to a missing server.jar path.

Tests:
- Add integration-style tests covering NeoForge installer manifest parsing and startup candidate scanning when using the legacy Forge SimpleInstaller main class.
- Update and extend tests for startup mode preferences and local preferred JAR resolution to reflect the corrected JAR vs script mode behavior.

</details>