### PR TITLE
feat: 添加 Windows 原生窗口效果的禁用选项，优化透明窗口背景处理

### DIFF
--- a/backend/tauri-host/src/commands/app/settings.rs
+++ b/backend/tauri-host/src/commands/app/settings.rs
@@ -29,6 +29,8 @@ const PERSONALIZATION_PACKAGE_VERSION: u32 = 1;
 const PERSONALIZATION_PACKAGE_FILE_STEM: &str = "sea-lantern-personalization";
 const PERSONALIZATION_SETTINGS_ENTRY: &str = "personalization/settings.json";
 const PERSONALIZATION_BACKGROUND_ENTRY: &str = "personalization/background";
+#[cfg(target_os = "windows")]
+const WINDOWS_NATIVE_WINDOW_EFFECTS_DISABLED: bool = true;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct PersonalizationSettings {
@@ -277,6 +279,24 @@ fn clear_windows_effects(window: &WebviewWindow) {
     let _ = clear_blur(window);
 }
 
+#[cfg(target_os = "windows")]
+fn sync_windows_window_effect_fallback(
+    window: &WebviewWindow,
+    dark: Option<bool>,
+) -> Result<(), String> {
+    clear_windows_effects(window);
+
+    let color = match dark {
+        Some(true) => Color(15, 17, 23, 255),
+        Some(false) => Color(248, 250, 252, 255),
+        None => Color(248, 250, 252, 255),
+    };
+
+    window
+        .set_background_color(Some(color))
+        .map_err(|e| format!("Failed to set fallback Windows window background: {}", e))
+}
+
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn sync_window_background(window: &WebviewWindow, effect: &str) -> Result<(), String> {
     let use_transparent_background = !effect.trim().eq_ignore_ascii_case(WINDOW_EFFECT_OFF);
@@ -326,6 +346,11 @@ pub(crate) fn sync_native_window_effect(
 
     #[cfg(target_os = "windows")]
     {
+        if WINDOWS_NATIVE_WINDOW_EFFECTS_DISABLED {
+            let _ = effect;
+            return sync_windows_window_effect_fallback(window, dark);
+        }
+
         let normalized = effect.trim().to_ascii_lowercase();
         sync_window_background(window, &normalized)?;
         clear_windows_effects(window);

--- a/backend/tauri-host/src/runtime/desktop_setup.rs
+++ b/backend/tauri-host/src/runtime/desktop_setup.rs
@@ -65,12 +65,15 @@ pub(crate) fn apply_platform_window_style(app: &tauri::App) {
             _ => None,
         };
 
+        // Windows native blur/acrylic/mica flickers while dragging a transparent
+        // window with no app background. Keep the startup entry disabled for now
+        // and let the shared sync path clear effects and restore a solid fallback.
         if let Err(e) = crate::commands::app::settings::sync_native_window_effect(
             &window,
-            &settings.window_effect,
+            crate::models::settings::WINDOW_EFFECT_OFF,
             theme_pref,
         ) {
-            eprintln!("Failed to sync native Windows window effect: {}", e);
+            eprintln!("Failed to apply fallback Windows window effect: {}", e);
         }
     }
 }

--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -6,9 +6,13 @@ import type { WindowEffect } from "@api/settings";
 import { useClientSettingsSync } from "@composables/useClientSettingsSync";
 import { useUiStore } from "@stores/uiStore";
 import { useSettingsStore } from "@stores/settingsStore";
+import { isWindowsPlatform } from "@utils/platform";
+
+const WINDOWS_NATIVE_WINDOW_EFFECTS_DISABLED = true;
 
 const ui = useUiStore();
 const settingsStore = useSettingsStore();
+const isWindows = isWindowsPlatform();
 
 useClientSettingsSync();
 
@@ -31,7 +35,9 @@ const backgroundStyle = computed(() => {
 });
 
 const hasTransparentWindowBackdrop = computed(
-  () => (settingsStore.windowEffect as WindowEffect) !== "off" || !backgroundImage.value,
+  () =>
+    !(isWindows && WINDOWS_NATIVE_WINDOW_EFFECTS_DISABLED) &&
+    ((settingsStore.windowEffect as WindowEffect) !== "off" || !backgroundImage.value),
 );
 
 const layoutClasses = computed(() => ({

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -23,6 +23,7 @@ import {
 } from "@utils/theme";
 
 const THEME_CACHE_KEY = "sl_theme_cache";
+const WINDOWS_NATIVE_WINDOW_EFFECTS_DISABLED = true;
 
 function getThemeCache(): { theme: string; fontSize: number } | null {
   try {
@@ -160,7 +161,11 @@ export const useSettingsStore = defineStore("settings", () => {
 
   function applyWindowEffectAttributes(nextSettings: AppSettings): void {
     const effect = (nextSettings.window_effect || "off") as WindowEffect;
-    const enabled = effect !== "off" || !nextSettings.background_image;
+    const nativeWindowEffectEnabled = !(isWindows && WINDOWS_NATIVE_WINDOW_EFFECTS_DISABLED);
+    const hasBackgroundImage = Boolean(nextSettings.background_image);
+    const enabled = nativeWindowEffectEnabled
+      ? effect !== "off" || !hasBackgroundImage
+      : effect !== "off" && hasBackgroundImage;
     document.documentElement.setAttribute("data-acrylic", enabled ? "true" : "false");
     document.documentElement.setAttribute("data-window-effect", effect);
   }


### PR DESCRIPTION
## 提交前检查清单

- [ ] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [ ] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [x] 前端 Frontend
  - [x] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要
已知没有背景的情况下，windows 在使用模糊或者毛玻璃效果时拖动窗口会闪烁
  现在开发团队决定暂时将入口注释，顺便写个回退

## 由 Sourcery 提供的摘要

在 Windows 上禁用原生窗口效果，并引入纯色背景的后备方案，以避免透明窗口出现闪烁。

Bug 修复：
- 添加 Windows 专用的后备方案：当原生窗口效果被禁用时，清除原生效果，并根据主题应用纯色背景。
- 调整前端中透明背景和 `acrylic` 属性的逻辑，以遵循“原生窗口效果已禁用”的标志，并考虑背景图片的存在情况。

增强：
- 将 Windows 启动窗口的初始化流程通过共享的同步路径进行，并强制关闭窗口效果，从而提升后端和前端在效果处理上的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable Windows native window effects on Windows and introduce a solid-background fallback to avoid flicker with transparent windows.

Bug Fixes:
- Add a Windows-specific fallback that clears native effects and applies a solid background color based on theme when native window effects are disabled.
- Adjust frontend transparent backdrop and acrylic attribute logic to respect the disabled native window effects flag and background image presence.

Enhancements:
- Route Windows startup window initialization through the shared sync path with window effects forced off, improving consistency of effect handling between backend and frontend.

</details>