### PR TITLE
chore: 添加 libscv 等crate的支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6111,7 +6111,9 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shlex",
+ "sl-libscv",
  "sl-server-flavor-core",
+ "sl-server-info",
  "sysinfo",
  "tar",
  "tauri",
@@ -6715,18 +6717,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
-name = "sl-server-core-taxonomy"
-version = "0.1.0"
+name = "sl-libscv"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf3c330a6fc1d8cb36e8069f4b2118bcbf622411d52eba57034e4499a9e0f6"
+checksum = "646c83fa33d75e56c3a8b6eba7c77dc5a5be51c0de8a4ebe35629fdaa2d99f85"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sl-server-core-taxonomy",
+ "sl-server-flavor-core",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "sl-server-core-taxonomy"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f7b9792a823e98d394008b91cd217aff789235c3b2f41a943240a05803c278"
 
 [[package]]
 name = "sl-server-flavor-core"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bcc52d1040a884df468ef6f89ef9326bb85a3f3d2b52a039e92f81c879caca"
+checksum = "1922a226bd9624751d47064fd190276170e542c9df44f4f2d47c7919189202d8"
 dependencies = [
  "sl-server-core-taxonomy",
+]
+
+[[package]]
+name = "sl-server-info"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb9dd8c517689d968a2cd760079beeb788b01627882628732e3c7765a9239ab"
+dependencies = [
+ "rcon",
+ "regex",
+ "sl-server-core-taxonomy",
+ "tokio",
 ]
 
 [[package]]

--- a/backend/server-installer-core/Cargo.toml
+++ b/backend/server-installer-core/Cargo.toml
@@ -16,7 +16,7 @@ path = "tests/core_archive_checks.rs"
 [dependencies]
 flate2 = "1.0"
 serde = { version = "1", features = ["derive"] }
-sl-server-core-taxonomy = "0.1.0"
+sl-server-core-taxonomy = "0.1.1"
 tar = "0.4"
 uuid = { version = "1", features = ["v4"] }
 zip = "2.0"

--- a/backend/server-local-setup-core/Cargo.toml
+++ b/backend/server-local-setup-core/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.10"
 sea_lantern_runtime = { package = "sea-lantern-runtime", path = "../runtime-core" }
 sea_lantern_server_installer_core = { package = "sea-lantern-server-installer-core", path = "../server-installer-core" }
 shlex = "1.3.0"
-sl-server-core-taxonomy = "0.1.0"
+sl-server-core-taxonomy = "0.1.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/server-plugin-core/Cargo.toml
+++ b/backend/server-plugin-core/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 zip = "2.0"
 sea_lantern_server_installer_core = { package = "sea-lantern-server-installer-core", path = "../server-installer-core" }
-sl-server-flavor-core = "0.1.0"
+sl-server-flavor-core = "0.2.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/server-startup-scan-core/Cargo.toml
+++ b/backend/server-startup-scan-core/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 sea_lantern_server_installer_core = { package = "sea-lantern-server-installer-core", path = "../server-installer-core" }
-sl-server-core-taxonomy = "0.1.0"
+sl-server-core-taxonomy = "0.1.1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/backend/tauri-host/Cargo.toml
+++ b/backend/tauri-host/Cargo.toml
@@ -25,7 +25,9 @@ sea_lantern_server_config_core = { package = "sea-lantern-server-config-core", p
 sea_lantern_starter_links_core = { package = "sea-lantern-starter-links-core", path = "../starter-links-core" }
 sea_lantern_update_core = { package = "sea-lantern-update-core", path = "../update-core" }
 sea_lantern_docker_core = { package = "sea-lantern-docker-core", path = "../docker-core" }
-sl-server-flavor-core = "0.1.0"
+sl-libscv = "0.1.2"
+sl-server-info = "0.1.0"
+sl-server-flavor-core = "0.2.1"
 tauri = { version = "2", features = ["protocol-asset", "tray-icon", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"

--- a/backend/tauri-host/src/adapters/http/command_registry/player.rs
+++ b/backend/tauri-host/src/adapters/http/command_registry/player.rs
@@ -8,6 +8,7 @@ pub(super) fn register_handlers(builder: &mut RegistryBuilder) {
     builder.register("get_whitelist", handle_get_whitelist as CommandHandler);
     builder.register("get_banned_players", handle_get_banned_players as CommandHandler);
     builder.register("get_ops", handle_get_ops as CommandHandler);
+    builder.register("parse_player_log_events", handle_parse_player_log_events as CommandHandler);
     builder.register("add_to_whitelist", handle_add_to_whitelist as CommandHandler);
     builder.register("remove_from_whitelist", handle_remove_from_whitelist as CommandHandler);
     builder.register("ban_player", handle_ban_player as CommandHandler);
@@ -42,6 +43,22 @@ fn handle_get_ops(params: Value) -> futures::future::BoxFuture<'static, Result<V
     Box::pin(async move {
         let req: ServerPathRequest = parse_params(params)?;
         let result = player_commands::get_ops(req.server_path)?;
+        serde_json::to_value(result).map_err(|e| e.to_string())
+    })
+}
+
+fn handle_parse_player_log_events(
+    params: Value,
+) -> futures::future::BoxFuture<'static, Result<Value, String>> {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ParsePlayerLogEventsRequest {
+        lines: Vec<String>,
+    }
+
+    Box::pin(async move {
+        let req: ParsePlayerLogEventsRequest = parse_params(params)?;
+        let result = player_commands::parse_player_log_events(req.lines);
         serde_json::to_value(result).map_err(|e| e.to_string())
     })
 }

--- a/backend/tauri-host/src/commands/server/players.rs
+++ b/backend/tauri-host/src/commands/server/players.rs
@@ -3,7 +3,15 @@ use crate::services::global;
 use crate::services::server::manager::ServerManager;
 use crate::services::server::player as player_manager;
 use crate::services::server::player::{BanEntry, OpEntry, PlayerEntry};
+use serde::Serialize;
+use sl_server_info::log::{parse_log_line, DomainEvent, LogLineInput, LogStream};
 use std::path::Path;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ParsedPlayerLogEvent {
+    pub event_kind: Option<String>,
+    pub player: Option<String>,
+}
 
 fn validate_player_name(name: &str) -> Result<(), String> {
     if name.len() < 3 || name.len() > 16 {
@@ -53,6 +61,35 @@ pub fn get_banned_players(server_path: String) -> Result<Vec<BanEntry>, String> 
 #[tauri::command]
 pub fn get_ops(server_path: String) -> Result<Vec<OpEntry>, String> {
     player_manager::read_ops(&server_path)
+}
+
+#[tauri::command]
+pub fn parse_player_log_events(lines: Vec<String>) -> Vec<ParsedPlayerLogEvent> {
+    lines
+        .into_iter()
+        .map(|line| {
+            let parsed = parse_log_line(
+                None,
+                LogLineInput {
+                    raw: line,
+                    stream: LogStream::Unknown,
+                },
+            );
+
+            let (event_kind, player) = match parsed.event {
+                Some(DomainEvent::ServerReady) => (Some("server_ready".to_string()), None),
+                Some(DomainEvent::PlayerJoin { player }) => {
+                    (Some("player_join".to_string()), Some(player))
+                }
+                Some(DomainEvent::PlayerLeave { player }) => {
+                    (Some("player_leave".to_string()), Some(player))
+                }
+                _ => (None, None),
+            };
+
+            ParsedPlayerLogEvent { event_kind, player }
+        })
+        .collect()
 }
 
 // ---- Modify via server console commands ----
@@ -166,7 +203,7 @@ pub fn export_logs(logs: Vec<String>, save_path: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{remove_from_whitelist_in, remove_player_from_whitelist_file};
+    use super::{parse_player_log_events, remove_from_whitelist_in, remove_player_from_whitelist_file};
     use crate::models::server::{LocalRuntimeConfig, ServerInstance, ServerRuntimeConfig};
     use crate::services::server::manager::ServerManager;
     use std::sync::Arc;
@@ -257,5 +294,22 @@ mod tests {
             .expect_err("lock failure should not be flattened into a fake server-not-found error");
 
         assert_eq!(error, "servers lock poisoned");
+    }
+
+    #[test]
+    fn parse_player_log_events_uses_shared_log_semantics() {
+        let events = parse_player_log_events(vec![
+            "[12:00:00] [Server thread/INFO]: Starting minecraft server".to_string(),
+            "[12:00:05] [Server thread/INFO]: Done (5.123s)! For help, type \"help\"".to_string(),
+            "[12:00:06] [Server thread/INFO]: Alex joined the game".to_string(),
+            "[12:00:07] [Server thread/INFO]: Alex left the game".to_string(),
+        ]);
+
+        assert_eq!(events[0].event_kind, None);
+        assert_eq!(events[1].event_kind.as_deref(), Some("server_ready"));
+        assert_eq!(events[2].event_kind.as_deref(), Some("player_join"));
+        assert_eq!(events[2].player.as_deref(), Some("Alex"));
+        assert_eq!(events[3].event_kind.as_deref(), Some("player_leave"));
+        assert_eq!(events[3].player.as_deref(), Some("Alex"));
     }
 }

--- a/backend/tauri-host/src/commands/server/players.rs
+++ b/backend/tauri-host/src/commands/server/players.rs
@@ -1,10 +1,11 @@
 use super::common::{server_t, server_t1};
 use crate::services::global;
+use crate::services::server::log_pipeline::map_domain_event;
 use crate::services::server::manager::ServerManager;
 use crate::services::server::player as player_manager;
 use crate::services::server::player::{BanEntry, OpEntry, PlayerEntry};
 use serde::Serialize;
-use sl_server_info::log::{parse_log_line, DomainEvent, LogLineInput, LogStream};
+use sl_server_info::log::{parse_log_line, LogLineInput, LogStream};
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize)]
@@ -64,30 +65,29 @@ pub fn get_ops(server_path: String) -> Result<Vec<OpEntry>, String> {
 }
 
 #[tauri::command]
+/// Parse historical player log lines into structured events.
+///
+/// Note:
+/// - Historical logs are treated as having an `Unknown` `LogStream`.
+/// - Live events from the log pipeline carry their actual stream (`Stdout` / `Stderr` / `Unknown`).
+/// If `parse_log_line` introduces stream-sensitive behavior in the future,
+/// callers must account for potential differences between historical and live parsing.
 pub fn parse_player_log_events(lines: Vec<String>) -> Vec<ParsedPlayerLogEvent> {
     lines
         .into_iter()
         .map(|line| {
-            let parsed = parse_log_line(
-                None,
-                LogLineInput {
-                    raw: line,
-                    stream: LogStream::Unknown,
-                },
-            );
+            // Historical log parsing does not know the original stream (stdout/stderr),
+            // so we explicitly mark it as `Unknown` to distinguish it from live events,
+            // which carry their actual stream information.
+            let parsed =
+                parse_log_line(None, LogLineInput { raw: line, stream: LogStream::Unknown });
 
-            let (event_kind, player) = match parsed.event {
-                Some(DomainEvent::ServerReady) => (Some("server_ready".to_string()), None),
-                Some(DomainEvent::PlayerJoin { player }) => {
-                    (Some("player_join".to_string()), Some(player))
-                }
-                Some(DomainEvent::PlayerLeave { player }) => {
-                    (Some("player_leave".to_string()), Some(player))
-                }
-                _ => (None, None),
-            };
+            let mapped = map_domain_event(parsed.event);
 
-            ParsedPlayerLogEvent { event_kind, player }
+            ParsedPlayerLogEvent {
+                event_kind: mapped.event_kind,
+                player: mapped.player,
+            }
         })
         .collect()
 }
@@ -203,7 +203,9 @@ pub fn export_logs(logs: Vec<String>, save_path: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_player_log_events, remove_from_whitelist_in, remove_player_from_whitelist_file};
+    use super::{
+        parse_player_log_events, remove_from_whitelist_in, remove_player_from_whitelist_file,
+    };
     use crate::models::server::{LocalRuntimeConfig, ServerInstance, ServerRuntimeConfig};
     use crate::services::server::manager::ServerManager;
     use std::sync::Arc;

--- a/backend/tauri-host/src/runtime/command_catalog.rs
+++ b/backend/tauri-host/src/runtime/command_catalog.rs
@@ -93,6 +93,7 @@ pub(crate) fn desktop_handler(
         player_commands::get_whitelist,
         player_commands::get_banned_players,
         player_commands::get_ops,
+        player_commands::parse_player_log_events,
         player_commands::add_to_whitelist,
         player_commands::remove_from_whitelist,
         player_commands::ban_player,

--- a/backend/tauri-host/src/runtime/plugin_bridge.rs
+++ b/backend/tauri-host/src/runtime/plugin_bridge.rs
@@ -3,6 +3,7 @@ use crate::plugins::runtime::PluginRuntime;
 use crate::services;
 use crate::services::global::i18n_service;
 use crate::utils::logger::{log_debug_ctx, log_warn_ctx};
+use sl_server_info::log::{parse_log_line, DomainEvent, LogLineInput, LogStream};
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
@@ -278,14 +279,66 @@ pub(crate) fn install_plugin_bridge(
             line: String,
         }
 
+        #[derive(Serialize, Clone)]
+        struct StructuredServerLogEvent {
+            server_id: String,
+            line: String,
+            stream: String,
+            event_kind: Option<String>,
+            player: Option<String>,
+            message: Option<String>,
+        }
+
         let app_handle = app.handle().clone();
         let _ = services::server::log_pipeline::set_server_log_event_handler(Arc::new(
-            move |server_id, line| {
+            move |server_id, line, stream| {
                 let event = ServerLogLineEvent {
                     server_id: server_id.to_string(),
                     line: line.to_string(),
                 };
                 app_handle.emit("server-log-line", event).map_err(|e| {
+                    plugin_bridge_t1("plugin.bridge.emit_server_log_line_failed", e.to_string())
+                })?;
+
+                let parsed = parse_log_line(
+                    None,
+                    LogLineInput {
+                        raw: line.to_string(),
+                        stream,
+                    },
+                );
+
+                let (event_kind, player, message) = match parsed.event {
+                    Some(DomainEvent::ServerReady) => (Some("server_ready".to_string()), None, None),
+                    Some(DomainEvent::PlayerJoin { player }) => {
+                        (Some("player_join".to_string()), Some(player), None)
+                    }
+                    Some(DomainEvent::PlayerLeave { player }) => {
+                        (Some("player_leave".to_string()), Some(player), None)
+                    }
+                    Some(DomainEvent::Chat { player, message }) => {
+                        (Some("chat".to_string()), Some(player), Some(message))
+                    }
+                    Some(DomainEvent::ErrorLike { message }) => {
+                        (Some("error".to_string()), None, Some(message))
+                    }
+                    None => (None, None, None),
+                };
+
+                let structured_event = StructuredServerLogEvent {
+                    server_id: server_id.to_string(),
+                    line: line.to_string(),
+                    stream: match stream {
+                        LogStream::Stdout => "stdout".to_string(),
+                        LogStream::Stderr => "stderr".to_string(),
+                        LogStream::Unknown => "unknown".to_string(),
+                    },
+                    event_kind,
+                    player,
+                    message,
+                };
+
+                app_handle.emit("server-log-structured", structured_event).map_err(|e| {
                     plugin_bridge_t1("plugin.bridge.emit_server_log_line_failed", e.to_string())
                 })
             },

--- a/backend/tauri-host/src/runtime/plugin_bridge.rs
+++ b/backend/tauri-host/src/runtime/plugin_bridge.rs
@@ -2,8 +2,9 @@ use crate::plugins;
 use crate::plugins::runtime::PluginRuntime;
 use crate::services;
 use crate::services::global::i18n_service;
+use crate::services::server::log_pipeline::map_domain_event;
 use crate::utils::logger::{log_debug_ctx, log_warn_ctx};
-use sl_server_info::log::{parse_log_line, DomainEvent, LogLineInput, LogStream};
+use sl_server_info::log::{parse_log_line, LogLineInput, LogStream};
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
@@ -300,30 +301,8 @@ pub(crate) fn install_plugin_bridge(
                     plugin_bridge_t1("plugin.bridge.emit_server_log_line_failed", e.to_string())
                 })?;
 
-                let parsed = parse_log_line(
-                    None,
-                    LogLineInput {
-                        raw: line.to_string(),
-                        stream,
-                    },
-                );
-
-                let (event_kind, player, message) = match parsed.event {
-                    Some(DomainEvent::ServerReady) => (Some("server_ready".to_string()), None, None),
-                    Some(DomainEvent::PlayerJoin { player }) => {
-                        (Some("player_join".to_string()), Some(player), None)
-                    }
-                    Some(DomainEvent::PlayerLeave { player }) => {
-                        (Some("player_leave".to_string()), Some(player), None)
-                    }
-                    Some(DomainEvent::Chat { player, message }) => {
-                        (Some("chat".to_string()), Some(player), Some(message))
-                    }
-                    Some(DomainEvent::ErrorLike { message }) => {
-                        (Some("error".to_string()), None, Some(message))
-                    }
-                    None => (None, None, None),
-                };
+                let parsed = parse_log_line(None, LogLineInput { raw: line.to_string(), stream });
+                let mapped = map_domain_event(parsed.event);
 
                 let structured_event = StructuredServerLogEvent {
                     server_id: server_id.to_string(),
@@ -333,14 +312,16 @@ pub(crate) fn install_plugin_bridge(
                         LogStream::Stderr => "stderr".to_string(),
                         LogStream::Unknown => "unknown".to_string(),
                     },
-                    event_kind,
-                    player,
-                    message,
+                    event_kind: mapped.event_kind,
+                    player: mapped.player,
+                    message: mapped.message,
                 };
 
-                app_handle.emit("server-log-structured", structured_event).map_err(|e| {
-                    plugin_bridge_t1("plugin.bridge.emit_server_log_line_failed", e.to_string())
-                })
+                app_handle
+                    .emit("server-log-structured", structured_event)
+                    .map_err(|e| {
+                        plugin_bridge_t1("plugin.bridge.emit_server_log_line_failed", e.to_string())
+                    })
             },
         ));
     }

--- a/backend/tauri-host/src/services/server/log_pipeline.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline.rs
@@ -10,7 +10,44 @@ mod writer;
 use std::sync::Arc;
 
 use self::state::{ServerLogEventHandler, ServerLogProcessor};
-use sl_server_info::log::LogStream;
+use sl_server_info::log::{DomainEvent, LogStream};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct StructuredLogEventFields {
+    pub(crate) event_kind: Option<String>,
+    pub(crate) player: Option<String>,
+    pub(crate) message: Option<String>,
+}
+
+pub(crate) fn map_domain_event(event: Option<DomainEvent>) -> StructuredLogEventFields {
+    match event {
+        Some(DomainEvent::ServerReady) => StructuredLogEventFields {
+            event_kind: Some("server_ready".to_string()),
+            ..StructuredLogEventFields::default()
+        },
+        Some(DomainEvent::PlayerJoin { player }) => StructuredLogEventFields {
+            event_kind: Some("player_join".to_string()),
+            player: Some(player),
+            ..StructuredLogEventFields::default()
+        },
+        Some(DomainEvent::PlayerLeave { player }) => StructuredLogEventFields {
+            event_kind: Some("player_leave".to_string()),
+            player: Some(player),
+            ..StructuredLogEventFields::default()
+        },
+        Some(DomainEvent::Chat { player, message }) => StructuredLogEventFields {
+            event_kind: Some("chat".to_string()),
+            player: Some(player),
+            message: Some(message),
+        },
+        Some(DomainEvent::ErrorLike { message }) => StructuredLogEventFields {
+            event_kind: Some("error".to_string()),
+            message: Some(message),
+            ..StructuredLogEventFields::default()
+        },
+        None => StructuredLogEventFields::default(),
+    }
+}
 
 pub fn set_server_log_event_handler(handler: Arc<ServerLogEventHandler>) -> Result<(), String> {
     writer::set_server_log_event_handler(handler)
@@ -60,4 +97,51 @@ where
     R: std::io::Read + Send + 'static,
 {
     output::spawn_server_output_reader(server_id, stream, reader)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_domain_event, StructuredLogEventFields};
+    use sl_server_info::log::DomainEvent;
+
+    #[test]
+    fn map_domain_event_returns_consistent_structured_fields() {
+        assert_eq!(
+            map_domain_event(Some(DomainEvent::ServerReady)),
+            StructuredLogEventFields {
+                event_kind: Some("server_ready".to_string()),
+                ..StructuredLogEventFields::default()
+            }
+        );
+
+        assert_eq!(
+            map_domain_event(Some(DomainEvent::PlayerJoin { player: "Alex".to_string() })),
+            StructuredLogEventFields {
+                event_kind: Some("player_join".to_string()),
+                player: Some("Alex".to_string()),
+                ..StructuredLogEventFields::default()
+            }
+        );
+
+        assert_eq!(
+            map_domain_event(Some(DomainEvent::Chat {
+                player: "Alex".to_string(),
+                message: "Hello".to_string(),
+            })),
+            StructuredLogEventFields {
+                event_kind: Some("chat".to_string()),
+                player: Some("Alex".to_string()),
+                message: Some("Hello".to_string()),
+            }
+        );
+
+        assert_eq!(
+            map_domain_event(Some(DomainEvent::ErrorLike { message: "boom".to_string() })),
+            StructuredLogEventFields {
+                event_kind: Some("error".to_string()),
+                message: Some("boom".to_string()),
+                ..StructuredLogEventFields::default()
+            }
+        );
+    }
 }

--- a/backend/tauri-host/src/services/server/log_pipeline.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline.rs
@@ -10,6 +10,7 @@ mod writer;
 use std::sync::Arc;
 
 use self::state::{ServerLogEventHandler, ServerLogProcessor};
+use sl_server_info::log::LogStream;
 
 pub fn set_server_log_event_handler(handler: Arc<ServerLogEventHandler>) -> Result<(), String> {
     writer::set_server_log_event_handler(handler)
@@ -54,9 +55,9 @@ pub fn get_all_logs_checked() -> Result<Vec<(String, Vec<String>)>, String> {
     reader::get_all_logs_checked()
 }
 
-pub fn spawn_server_output_reader<R>(server_id: String, reader: R)
+pub fn spawn_server_output_reader<R>(server_id: String, stream: LogStream, reader: R)
 where
     R: std::io::Read + Send + 'static,
 {
-    output::spawn_server_output_reader(server_id, reader)
+    output::spawn_server_output_reader(server_id, stream, reader)
 }

--- a/backend/tauri-host/src/services/server/log_pipeline/output.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline/output.rs
@@ -51,13 +51,7 @@ where
                         ));
                     }
 
-                    let parsed = parse_log_line(
-                        None,
-                        LogLineInput {
-                            raw: line.clone(),
-                            stream,
-                        },
-                    );
+                    let parsed = parse_log_line(None, LogLineInput { raw: line.clone(), stream });
 
                     if matches!(parsed.event, Some(DomainEvent::ServerReady)) {
                         crate::services::global::server_manager().clear_starting(&server_id);

--- a/backend/tauri-host/src/services/server/log_pipeline/output.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline/output.rs
@@ -5,6 +5,7 @@ use std::io::{BufRead, BufReader, Read};
 use std::sync::Arc;
 
 use crate::utils::logger;
+use sl_server_info::log::{parse_log_line, DomainEvent, LogLineInput, LogStream};
 
 pub fn add_server_log_processor(processor: Arc<ServerLogProcessor>) -> Result<(), String> {
     let processors = server_log_processors();
@@ -24,7 +25,7 @@ pub fn clear_server_log_processors() -> Result<(), String> {
     Ok(())
 }
 
-pub fn spawn_server_output_reader<R>(server_id: String, reader: R)
+pub fn spawn_server_output_reader<R>(server_id: String, stream: LogStream, reader: R)
 where
     R: Read + Send + 'static,
 {
@@ -50,7 +51,15 @@ where
                         ));
                     }
 
-                    if line.contains("Done (") && line.contains(")! For help") {
+                    let parsed = parse_log_line(
+                        None,
+                        LogLineInput {
+                            raw: line.clone(),
+                            stream,
+                        },
+                    );
+
+                    if matches!(parsed.event, Some(DomainEvent::ServerReady)) {
                         crate::services::global::server_manager().clear_starting(&server_id);
                         let _ = crate::plugins::api::emit_server_ready(&server_id);
                     }
@@ -71,10 +80,15 @@ where
     });
 }
 
+#[allow(dead_code)] // compatibility entrypoint for existing callers
 pub fn emit_server_log_line(server_id: &str, line: &str) {
+    emit_server_log_line_with_stream(server_id, line, LogStream::Unknown)
+}
+
+pub fn emit_server_log_line_with_stream(server_id: &str, line: &str, stream: LogStream) {
     let processed_line = process_log_line(server_id, line);
     if let Some(handler) = SERVER_LOG_EVENT_HANDLER.get() {
-        let _ = handler(server_id, &processed_line);
+        let _ = handler(server_id, &processed_line, stream);
     }
 
     #[cfg(feature = "docker")]

--- a/backend/tauri-host/src/services/server/log_pipeline/state.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline/state.rs
@@ -1,11 +1,12 @@
 use rusqlite::Connection;
 use sea_lantern_server_local_setup_core::decode_console_bytes as decode_shared_console_bytes;
+use sl_server_info::log::LogStream;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::thread;
 
-pub type ServerLogEventHandler = dyn Fn(&str, &str) -> Result<(), String> + Send + Sync;
+pub type ServerLogEventHandler = dyn Fn(&str, &str, LogStream) -> Result<(), String> + Send + Sync;
 pub type ServerLogProcessor = dyn Fn(&str, &str) -> String + Send + Sync;
 pub type ServerLogProcessorList = Arc<Mutex<Vec<Arc<ServerLogProcessor>>>>;
 

--- a/backend/tauri-host/src/services/server/log_pipeline/writer.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline/writer.rs
@@ -2,6 +2,7 @@ use super::state::{
     log_writers, open_or_create_log_db, resolve_server_path, LogSource, LogWriteEntry,
     ServerLogEventHandler, ServerLogWriter, WriterCommand, SERVER_LOG_EVENT_HANDLER,
 };
+use sl_server_info::log::LogStream;
 use rusqlite::{params, Connection, TransactionBehavior};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
@@ -229,7 +230,7 @@ pub fn append_log(
             .send(WriterCommand::Append(entry))
             .map_err(|e| format!("提交日志写入队列失败: {}", e))?;
     }
-    super::output::emit_server_log_line(server_id, message);
+    super::output::emit_server_log_line_with_stream(server_id, message, LogStream::Unknown);
     Ok(())
 }
 

--- a/backend/tauri-host/src/services/server/log_pipeline/writer.rs
+++ b/backend/tauri-host/src/services/server/log_pipeline/writer.rs
@@ -2,8 +2,8 @@ use super::state::{
     log_writers, open_or_create_log_db, resolve_server_path, LogSource, LogWriteEntry,
     ServerLogEventHandler, ServerLogWriter, WriterCommand, SERVER_LOG_EVENT_HANDLER,
 };
-use sl_server_info::log::LogStream;
 use rusqlite::{params, Connection, TransactionBehavior};
+use sl_server_info::log::LogStream;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::Arc;

--- a/backend/tauri-host/src/services/server/manager.rs
+++ b/backend/tauri-host/src/services/server/manager.rs
@@ -26,6 +26,7 @@ use sea_lantern_server_local_setup_core::{
     normalize_cli_startup_mode, refresh_local_server_core_type,
 };
 use serde::{Deserialize, Serialize};
+use sl_server_info::log::LogStream;
 
 use super::log_pipeline as server_log_pipeline;
 use super::manager::process::force_kill_process_tree;
@@ -433,10 +434,18 @@ impl ServerManager {
                     self.mark_starting(id);
 
                     if let Some(stdout) = stdout {
-                        server_log_pipeline::spawn_server_output_reader(id.to_string(), stdout);
+                        server_log_pipeline::spawn_server_output_reader(
+                            id.to_string(),
+                            LogStream::Stdout,
+                            stdout,
+                        );
                     }
                     if let Some(stderr) = stderr {
-                        server_log_pipeline::spawn_server_output_reader(id.to_string(), stderr);
+                        server_log_pipeline::spawn_server_output_reader(
+                            id.to_string(),
+                            LogStream::Stderr,
+                            stderr,
+                        );
                     }
                 }
             }

--- a/backend/tauri-host/src/services/server/player.rs
+++ b/backend/tauri-host/src/services/server/player.rs
@@ -54,10 +54,7 @@ pub fn read_ops(server_path: &str) -> Result<Vec<OpEntry>, String> {
 fn map_whitelist_entries(entries: Vec<sl_libscv::state::WhitelistEntry>) -> Vec<PlayerEntry> {
     entries
         .into_iter()
-        .map(|entry| PlayerEntry {
-            uuid: entry.uuid,
-            name: entry.name,
-        })
+        .map(|entry| PlayerEntry { uuid: entry.uuid, name: entry.name })
         .collect()
 }
 
@@ -89,9 +86,8 @@ fn map_op_entries(entries: Vec<sl_libscv::state::OpEntry>) -> Vec<OpEntry> {
 
 fn render_state_error(error: sl_libscv::StateFileError) -> String {
     match error {
-        sl_libscv::StateFileError::Io(message) | sl_libscv::StateFileError::ParseFailed(message) => {
-            message
-        }
+        sl_libscv::StateFileError::Io(message)
+        | sl_libscv::StateFileError::ParseFailed(message) => message,
     }
 }
 
@@ -102,13 +98,11 @@ mod tests {
     #[test]
     fn whitelist_reader_uses_sl_libscv_conventions() {
         let temp_dir = tempfile::tempdir().expect("temp dir should exist");
-        std::fs::write(
-            temp_dir.path().join("whitelist.json"),
-            r#"[{"uuid":"1","name":"Alex"}]"#,
-        )
-        .expect("whitelist should write");
+        std::fs::write(temp_dir.path().join("whitelist.json"), r#"[{"uuid":"1","name":"Alex"}]"#)
+            .expect("whitelist should write");
 
-        let entries = read_whitelist(&temp_dir.path().to_string_lossy()).expect("whitelist should parse");
+        let entries =
+            read_whitelist(&temp_dir.path().to_string_lossy()).expect("whitelist should parse");
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "Alex");

--- a/backend/tauri-host/src/services/server/player.rs
+++ b/backend/tauri-host/src/services/server/player.rs
@@ -31,30 +31,101 @@ pub struct OpEntry {
 }
 
 pub fn read_whitelist(server_path: &str) -> Result<Vec<PlayerEntry>, String> {
-    read_json_list(server_path, "whitelist.json")
+    let files = sl_libscv::state::discover_state_files(server_path);
+    sl_libscv::state::read_whitelist(&files.whitelist_path)
+        .map(map_whitelist_entries)
+        .map_err(render_state_error)
 }
 
 pub fn read_banned_players(server_path: &str) -> Result<Vec<BanEntry>, String> {
-    read_json_list(server_path, "banned-players.json")
+    let files = sl_libscv::state::discover_state_files(server_path);
+    sl_libscv::state::read_banned_players(&files.banned_players_path)
+        .map(map_ban_entries)
+        .map_err(render_state_error)
 }
 
 pub fn read_ops(server_path: &str) -> Result<Vec<OpEntry>, String> {
-    read_json_list(server_path, "ops.json")
+    let files = sl_libscv::state::discover_state_files(server_path);
+    sl_libscv::state::read_ops(&files.ops_path)
+        .map(map_op_entries)
+        .map_err(render_state_error)
 }
 
-fn read_json_list<T: serde::de::DeserializeOwned>(
-    server_path: &str,
-    filename: &str,
-) -> Result<Vec<T>, String> {
-    let path = std::path::Path::new(server_path).join(filename);
-    if !path.exists() {
-        return Ok(Vec::new());
+fn map_whitelist_entries(entries: Vec<sl_libscv::state::WhitelistEntry>) -> Vec<PlayerEntry> {
+    entries
+        .into_iter()
+        .map(|entry| PlayerEntry {
+            uuid: entry.uuid,
+            name: entry.name,
+        })
+        .collect()
+}
+
+fn map_ban_entries(entries: Vec<sl_libscv::state::BannedPlayerEntry>) -> Vec<BanEntry> {
+    entries
+        .into_iter()
+        .map(|entry| BanEntry {
+            uuid: entry.uuid,
+            name: entry.name,
+            reason: entry.reason,
+            source: entry.source,
+            created: entry.created,
+            expires: entry.expires,
+        })
+        .collect()
+}
+
+fn map_op_entries(entries: Vec<sl_libscv::state::OpEntry>) -> Vec<OpEntry> {
+    entries
+        .into_iter()
+        .map(|entry| OpEntry {
+            uuid: entry.uuid,
+            name: entry.name,
+            level: entry.level,
+            bypasses_player_limit: entry.bypasses_player_limit,
+        })
+        .collect()
+}
+
+fn render_state_error(error: sl_libscv::StateFileError) -> String {
+    match error {
+        sl_libscv::StateFileError::Io(message) | sl_libscv::StateFileError::ParseFailed(message) => {
+            message
+        }
     }
-    let content =
-        std::fs::read_to_string(&path).map_err(|e| format!("读取{}失败: {}", filename, e))?;
-    let trimmed = content.trim();
-    if trimmed.is_empty() || trimmed == "[]" {
-        return Ok(Vec::new());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_ops, read_whitelist};
+
+    #[test]
+    fn whitelist_reader_uses_sl_libscv_conventions() {
+        let temp_dir = tempfile::tempdir().expect("temp dir should exist");
+        std::fs::write(
+            temp_dir.path().join("whitelist.json"),
+            r#"[{"uuid":"1","name":"Alex"}]"#,
+        )
+        .expect("whitelist should write");
+
+        let entries = read_whitelist(&temp_dir.path().to_string_lossy()).expect("whitelist should parse");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "Alex");
     }
-    serde_json::from_str(trimmed).map_err(|e| format!("解析{}失败: {}", filename, e))
+
+    #[test]
+    fn ops_reader_keeps_bypass_alias_compatibility() {
+        let temp_dir = tempfile::tempdir().expect("temp dir should exist");
+        std::fs::write(
+            temp_dir.path().join("ops.json"),
+            r#"[{"uuid":"1","name":"Alex","level":4,"bypassesPlayerLimit":true}]"#,
+        )
+        .expect("ops should write");
+
+        let entries = read_ops(&temp_dir.path().to_string_lossy()).expect("ops should parse");
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].bypasses_player_limit);
+    }
 }

--- a/backend/tauri-host/src/services/server/runtime/docker_itzg.rs
+++ b/backend/tauri-host/src/services/server/runtime/docker_itzg.rs
@@ -22,6 +22,7 @@ use crate::utils::logger;
 use sea_lantern_docker_core::{
     docker_image_ref, requested_stop_timeout_secs, runtime_env_value, ActiveProcessorCountDecision,
 };
+use sl_server_info::log::LogStream;
 use std::path::Path;
 use std::process::Command;
 use std::thread;
@@ -748,10 +749,18 @@ impl DockerCliAdapter {
             })?;
 
         if let Some(stdout) = child.stdout.take() {
-            server_log_pipeline::spawn_server_output_reader(server_id.to_string(), stdout);
+            server_log_pipeline::spawn_server_output_reader(
+                server_id.to_string(),
+                LogStream::Stdout,
+                stdout,
+            );
         }
         if let Some(stderr) = child.stderr.take() {
-            server_log_pipeline::spawn_server_output_reader(server_id.to_string(), stderr);
+            server_log_pipeline::spawn_server_output_reader(
+                server_id.to_string(),
+                LogStream::Stderr,
+                stderr,
+            );
         }
 
         std::thread::spawn(move || {

--- a/backend/tauri-host/src/services/server/runtime/local_helper.rs
+++ b/backend/tauri-host/src/services/server/runtime/local_helper.rs
@@ -5,6 +5,7 @@ mod state;
 mod status;
 
 use serde::{Deserialize, Serialize};
+use sl_server_info::log::LogStream;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -554,10 +555,18 @@ fn run_helper(server_id: &str) -> Result<(), String> {
         .insert(server_id.to_string(), child);
 
     if let Some(stdout) = stdout {
-        server_log_pipeline::spawn_server_output_reader(server_id.to_string(), stdout);
+        server_log_pipeline::spawn_server_output_reader(
+            server_id.to_string(),
+            LogStream::Stdout,
+            stdout,
+        );
     }
     if let Some(stderr) = stderr {
-        server_log_pipeline::spawn_server_output_reader(server_id.to_string(), stderr);
+        server_log_pipeline::spawn_server_output_reader(
+            server_id.to_string(),
+            LogStream::Stderr,
+            stderr,
+        );
     }
 
     state = started_state(

--- a/frontend/src/api/player.ts
+++ b/frontend/src/api/player.ts
@@ -30,6 +30,11 @@ export interface OpEntry {
   bypasses_player_limit: boolean;
 }
 
+export interface ParsedPlayerLogEvent {
+  event_kind: "server_ready" | "player_join" | "player_leave" | null;
+  player: string | null;
+}
+
 /**
  * 玩家管理 API
  */
@@ -53,6 +58,13 @@ export const playerApi = {
    */
   async getOps(serverPath: string): Promise<OpEntry[]> {
     return tauriInvoke("get_ops", { serverPath });
+  },
+
+  /**
+   * 解析已有日志中的玩家相关事件
+   */
+  async parsePlayerLogEvents(lines: string[]): Promise<ParsedPlayerLogEvent[]> {
+    return tauriInvoke("parse_player_log_events", { lines });
   },
 
   /**

--- a/frontend/src/api/server.ts
+++ b/frontend/src/api/server.ts
@@ -36,6 +36,15 @@ export interface ServerLogLineEvent {
   line: string;
 }
 
+export interface ServerLogStructuredEvent {
+  server_id: string;
+  line: string;
+  stream: "stdout" | "stderr" | "unknown";
+  event_kind: "server_ready" | "player_join" | "player_leave" | "chat" | "error" | null;
+  player: string | null;
+  message: string | null;
+}
+
 export interface ForceStopPreparation {
   token: string;
   expiresAt: number;
@@ -453,6 +462,17 @@ export const serverApi = {
     }
     // Tauri 环境使用事件监听
     return listen<ServerLogLineEvent>("server-log-line", (event) => {
+      callback(event.payload);
+    });
+  },
+
+  onStructuredLogEvent(
+    callback: (payload: ServerLogStructuredEvent) => void,
+  ): Promise<UnlistenFn> {
+    if (isBrowserEnv()) {
+      return Promise.reject(new Error("Structured log events are only available in Tauri mode"));
+    }
+    return listen<ServerLogStructuredEvent>("server-log-structured", (event) => {
       callback(event.payload);
     });
   },

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -41,6 +41,7 @@ const settingsStore = useSettingsStore();
 let unlistenLogLine: UnlistenFn | null = null;
 let unlistenStructuredLog: UnlistenFn | null = null;
 const structuredOnlinePlayers = ref<Record<string, string[]>>({});
+const structuredPlayerEventSupport = ref<Record<string, boolean>>({});
 
 const selectedServerId = computed(() => store.currentServerId || "");
 
@@ -107,6 +108,7 @@ watch(
       bannedPlayers.value = [];
       ops.value = [];
       structuredOnlinePlayers.value = {};
+      structuredPlayerEventSupport.value = {};
       return;
     }
 
@@ -141,11 +143,19 @@ async function hydrateStructuredOnlinePlayers(serverId: string) {
   const logs = consoleStore.logs[serverId] || [];
   if (logs.length === 0) {
     structuredOnlinePlayers.value[serverId] = [];
+    structuredPlayerEventSupport.value[serverId] = false;
     return;
   }
 
-  const events = await playerApi.parsePlayerLogEvents(logs);
-  structuredOnlinePlayers.value[serverId] = replayOnlinePlayers(events);
+  try {
+    const events = await playerApi.parsePlayerLogEvents(logs);
+    structuredOnlinePlayers.value[serverId] = replayOnlinePlayers(events);
+    structuredPlayerEventSupport.value[serverId] = hasStructuredPlayerEvents(events);
+  } catch (error) {
+    structuredOnlinePlayers.value[serverId] = [];
+    structuredPlayerEventSupport.value[serverId] = false;
+    console.warn("[PlayerView] structured player log hydration unavailable, falling back to legacy parsing", error);
+  }
 }
 
 async function startPlayerLogSubscription() {
@@ -158,9 +168,13 @@ async function startPlayerLogSubscription() {
     consoleStore.setLogCursor(server_id, (consoleStore.logs[server_id] || []).length);
   });
 
-  unlistenStructuredLog = await serverApi.onStructuredLogEvent((event) => {
-    applyStructuredPlayerEvent(event);
-  });
+  try {
+    unlistenStructuredLog = await serverApi.onStructuredLogEvent((event) => {
+      applyStructuredPlayerEvent(event);
+    });
+  } catch (error) {
+    console.warn("[PlayerView] structured log stream unavailable, falling back to legacy parsing", error);
+  }
 }
 
 function stopPlayerLogSubscription() {
@@ -175,11 +189,26 @@ function stopPlayerLogSubscription() {
 }
 
 function resolveOnlinePlayers(serverId: string): string[] {
+  if (!serverId) {
+    return [];
+  }
+
   const structured = structuredOnlinePlayers.value[serverId];
-  if (structured) {
+  if (structuredPlayerEventSupport.value[serverId] && structured) {
     return structured;
   }
-  return [];
+
+  return parseOnlinePlayers(consoleStore.logs[serverId] || []);
+}
+
+function isStructuredPlayerEventKind(
+  eventKind: ParsedPlayerLogEvent["event_kind"] | ServerLogStructuredEvent["event_kind"],
+): eventKind is "server_ready" | "player_join" | "player_leave" {
+  return eventKind === "server_ready" || eventKind === "player_join" || eventKind === "player_leave";
+}
+
+function hasStructuredPlayerEvents(events: ParsedPlayerLogEvent[]): boolean {
+  return events.some((event) => isStructuredPlayerEventKind(event.event_kind));
 }
 
 function ensureStructuredOnlinePlayerList(serverId: string): string[] {
@@ -191,9 +220,11 @@ function ensureStructuredOnlinePlayerList(serverId: string): string[] {
 
 function applyStructuredPlayerEvent(event: ServerLogStructuredEvent) {
   const { server_id, event_kind, player } = event;
-  if (!event_kind) {
+  if (!isStructuredPlayerEventKind(event_kind)) {
     return;
   }
+
+  structuredPlayerEventSupport.value[server_id] = true;
 
   if (event_kind === "server_ready") {
     structuredOnlinePlayers.value[server_id] = [];
@@ -242,6 +273,50 @@ function replayOnlinePlayers(events: ParsedPlayerLogEvent[]): string[] {
 
     if (event.event_kind === "player_leave") {
       const idx = players.indexOf(event.player);
+      if (idx > -1) {
+        players.splice(idx, 1);
+      }
+    }
+  }
+
+  return players;
+}
+
+function parseOnlinePlayers(logs: string[]): string[] {
+  const players: string[] = [];
+
+  let startIndex = 0;
+  for (let i = logs.length - 1; i >= 0; i -= 1) {
+    const line = logs[i];
+    if (/Done \([\d.]+s\)! For help/.test(line) || /Starting minecraft server/i.test(line)) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  for (let i = startIndex; i < logs.length; i += 1) {
+    const line = logs[i];
+    const joinMatch = line.match(/\]: (\w+) joined the game/);
+    const loginMatch = line.match(/\]: UUID of player (\w+) is/);
+    const leftMatch = line.match(/\]: (\w+) left the game/);
+
+    if (joinMatch) {
+      const name = joinMatch[1];
+      if (!players.includes(name)) {
+        players.push(name);
+      }
+    }
+
+    if (loginMatch) {
+      const name = loginMatch[1];
+      if (!players.includes(name)) {
+        players.push(name);
+      }
+    }
+
+    if (leftMatch) {
+      const name = leftMatch[1];
+      const idx = players.indexOf(name);
       if (idx > -1) {
         players.splice(idx, 1);
       }

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -5,12 +5,13 @@ import { useSettingsStore } from "@stores/settingsStore";
 import { useRoute } from "vue-router";
 import { useConsoleStore } from "@stores/consoleStore";
 import { serverApi } from "@api/server";
-import { playerApi, type PlayerEntry, type BanEntry, type OpEntry } from "@api/player";
+import { playerApi, type PlayerEntry, type BanEntry, type OpEntry, type ParsedPlayerLogEvent } from "@api/player";
 import { TIME, MESSAGES, getMessage } from "@utils/constants";
 import { validatePlayerName, handleError } from "@utils/errorHandler";
 import { i18n } from "@language";
 import { useMessage } from "@composables/useMessage";
 import { useLoading } from "@composables/useAsync";
+import type { ServerLogStructuredEvent } from "@api/server";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import PlayerTabs from "@components/views/player/PlayerTabs.vue";
 import PlayerActionBar from "@components/views/player/PlayerActionBar.vue";
@@ -38,6 +39,8 @@ const addBanReason = ref("");
 const addLoading = ref(false);
 const settingsStore = useSettingsStore();
 let unlistenLogLine: UnlistenFn | null = null;
+let unlistenStructuredLog: UnlistenFn | null = null;
+const structuredOnlinePlayers = ref<Record<string, string[]>>({});
 
 const selectedServerId = computed(() => store.currentServerId || "");
 
@@ -51,7 +54,7 @@ const isRunning = computed(() => {
 });
 
 const onlinePlayers = computed(() =>
-  parseOnlinePlayers(consoleStore.logs[selectedServerId.value] || []),
+  resolveOnlinePlayers(selectedServerId.value),
 );
 
 function getAddLabel(): string {
@@ -103,11 +106,13 @@ watch(
       whitelist.value = [];
       bannedPlayers.value = [];
       ops.value = [];
+      structuredOnlinePlayers.value = {};
       return;
     }
 
     await store.refreshStatus(serverId);
     await Promise.all([loadAll(), ensureRecentLogsLoaded(serverId)]);
+    await hydrateStructuredOnlinePlayers(serverId);
   },
   { immediate: true },
 );
@@ -132,6 +137,17 @@ async function ensureRecentLogsLoaded(serverId: string) {
   consoleStore.setLogCursor(serverId, (consoleStore.logs[serverId] || []).length);
 }
 
+async function hydrateStructuredOnlinePlayers(serverId: string) {
+  const logs = consoleStore.logs[serverId] || [];
+  if (logs.length === 0) {
+    structuredOnlinePlayers.value[serverId] = [];
+    return;
+  }
+
+  const events = await playerApi.parsePlayerLogEvents(logs);
+  structuredOnlinePlayers.value[serverId] = replayOnlinePlayers(events);
+}
+
 async function startPlayerLogSubscription() {
   if (unlistenLogLine) {
     return;
@@ -141,6 +157,10 @@ async function startPlayerLogSubscription() {
     consoleStore.appendLocal(server_id, line);
     consoleStore.setLogCursor(server_id, (consoleStore.logs[server_id] || []).length);
   });
+
+  unlistenStructuredLog = await serverApi.onStructuredLogEvent((event) => {
+    applyStructuredPlayerEvent(event);
+  });
 }
 
 function stopPlayerLogSubscription() {
@@ -148,38 +168,83 @@ function stopPlayerLogSubscription() {
     unlistenLogLine();
     unlistenLogLine = null;
   }
+  if (unlistenStructuredLog) {
+    unlistenStructuredLog();
+    unlistenStructuredLog = null;
+  }
 }
 
-function parseOnlinePlayers(logs: string[]): string[] {
-  const players: string[] = [];
+function resolveOnlinePlayers(serverId: string): string[] {
+  const structured = structuredOnlinePlayers.value[serverId];
+  if (structured) {
+    return structured;
+  }
+  return [];
+}
 
-  let startIndex = 0;
-  for (let i = logs.length - 1; i >= 0; i--) {
-    const line = logs[i];
-    if (/Done \([\d.]+s\)! For help/.test(line) || /Starting minecraft server/i.test(line)) {
-      startIndex = i;
-      break;
-    }
+function ensureStructuredOnlinePlayerList(serverId: string): string[] {
+  if (!structuredOnlinePlayers.value[serverId]) {
+    structuredOnlinePlayers.value[serverId] = [];
+  }
+  return structuredOnlinePlayers.value[serverId];
+}
+
+function applyStructuredPlayerEvent(event: ServerLogStructuredEvent) {
+  const { server_id, event_kind, player } = event;
+  if (!event_kind) {
+    return;
   }
 
-  for (let i = startIndex; i < logs.length; i++) {
-    const line = logs[i];
-    const joinMatch = line.match(/\]: (\w+) joined the game/);
-    const loginMatch = line.match(/\]: UUID of player (\w+) is/);
-    const leftMatch = line.match(/\]: (\w+) left the game/);
+  if (event_kind === "server_ready") {
+    structuredOnlinePlayers.value[server_id] = [];
+    return;
+  }
 
-    if (joinMatch) {
-      const name = joinMatch[1];
-      if (!players.includes(name)) players.push(name);
+  if (!player) {
+    return;
+  }
+
+  const players = ensureStructuredOnlinePlayerList(server_id);
+  if (event_kind === "player_join") {
+    if (!players.includes(player)) {
+      players.push(player);
     }
-    if (loginMatch) {
-      const name = loginMatch[1];
-      if (!players.includes(name)) players.push(name);
+    return;
+  }
+
+  if (event_kind === "player_leave") {
+    const index = players.indexOf(player);
+    if (index >= 0) {
+      players.splice(index, 1);
     }
-    if (leftMatch) {
-      const name = leftMatch[1];
-      const idx = players.indexOf(name);
-      if (idx > -1) players.splice(idx, 1);
+  }
+}
+
+function replayOnlinePlayers(events: ParsedPlayerLogEvent[]): string[] {
+  const players: string[] = [];
+
+  for (const event of events) {
+    if (event.event_kind === "server_ready") {
+      players.length = 0;
+      continue;
+    }
+
+    if (!event.player) {
+      continue;
+    }
+
+    if (event.event_kind === "player_join") {
+      if (!players.includes(event.player)) {
+        players.push(event.player);
+      }
+      continue;
+    }
+
+    if (event.event_kind === "player_leave") {
+      const idx = players.indexOf(event.player);
+      if (idx > -1) {
+        players.splice(idx, 1);
+      }
     }
   }
 


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [ ] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

<!-- 一句话概括本次变更 -->

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #`填写 Issue 编号`

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

采用共享的 `libscv/server-info` crate 来处理玩家状态和日志，并向前端暴露结构化日志事件，以实现更精确的在线玩家追踪。

New Features:
- 通过新的 Tauri 和 HTTP API 接口，将结构化的服务器日志事件（包括玩家加入/离开和聊天）从后端暴露给前端。
- 添加后端命令和前端 API，使用共享的日志语义来解析现有的与玩家相关的日志事件。

Bug Fixes:
- 通过使用解析后的结构化玩家事件，而不是临时的日志行正则表达式来计算在线玩家列表，从而使状态与服务器日志保持同步。

Enhancements:
- 将白名单、被封禁玩家和 OP 的读取逻辑切换到 `libscv` 的状态辅助工具，同时保持现有字段兼容性。
- 统一服务器输出处理，纳入日志流元数据，并使用共享的 `server-info` 解析来检测服务器就绪状态。
- 添加测试，以确保新的状态读取器和玩家日志解析在行为上与现有实现兼容。

Build:
- 更新 Rust 依赖至较新的 `sl-*` crate 版本，以在各组件之间支持共享状态和日志语义。

Tests:
- 扩展后端测试，以覆盖新的白名单/OP 读取器以及玩家日志事件解析语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adopt shared libscv/server-info crates for player state and log processing, and expose structured log events to the frontend for accurate online-player tracking.

New Features:
- Expose structured server log events (including player joins/leaves and chat) from the backend to the frontend via a new Tauri and HTTP API surface.
- Add a backend command and frontend API to parse existing player-related log events using shared log semantics.

Bug Fixes:
- Improve online player list calculation by using parsed structured player events instead of ad-hoc log line regexes, keeping state in sync with server logs.

Enhancements:
- Switch whitelist, banned players, and ops reading to libscv state helpers while preserving existing field compatibility.
- Unify server output handling to include log stream metadata and use shared server-info parsing for server readiness detection.
- Add tests to ensure compatibility of new state readers and player log parsing with existing behavior.

Build:
- Update Rust dependencies to newer sl-* crate versions to support shared state and log semantics across components.

Tests:
- Extend backend tests to cover new whitelist/ops readers and player log event parsing semantics.

</details>