### PR TITLE
fix: 修复因为状态误判导致频繁调用 tasklist

### DIFF
--- a/backend/tauri-host/src/services/server/manager/process.rs
+++ b/backend/tauri-host/src/services/server/manager/process.rs
@@ -1,5 +1,8 @@
 use std::process::{Child, Command};
 
+#[cfg(windows)]
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
 #[cfg(unix)]
 use std::collections::HashSet;
 
@@ -104,37 +107,9 @@ pub(super) fn force_kill_process_tree(child: &mut Child) -> Result<(), String> {
 
 #[cfg(windows)]
 fn is_process_alive_windows(pid: u32) -> bool {
-    let filter = format!("PID eq {}", pid);
-    let output = Command::new("tasklist")
-        .args(["/FI", &filter, "/FO", "CSV", "/NH"])
-        .output();
-
-    let Ok(output) = output else {
-        return false;
-    };
-    if !output.status.success() {
-        return false;
-    }
-
-    tasklist_csv_has_pid(&String::from_utf8_lossy(&output.stdout), pid)
-}
-
-#[cfg(windows)]
-fn tasklist_csv_has_pid(stdout: &str, pid: u32) -> bool {
-    let expected_pid = pid.to_string();
-
-    stdout.lines().any(|line| {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || !trimmed.starts_with('"') {
-            return false;
-        }
-
-        let mut fields = trimmed.split("\",\"");
-        let _image_name = fields.next();
-        let pid_field = fields.next().map(|field| field.trim_matches('"'));
-
-        pid_field.is_some_and(|value| value == expected_pid)
-    })
+    let mut system = System::new_all();
+    system.refresh_processes(ProcessesToUpdate::Some(&[Pid::from_u32(pid)]), true);
+    system.process(Pid::from_u32(pid)).is_some()
 }
 
 pub(crate) fn is_process_alive(pid: u32) -> bool {
@@ -194,27 +169,4 @@ pub(super) fn force_kill_process_tree(child: &mut Child) -> Result<(), String> {
         .wait()
         .map(|_| ())
         .map_err(|e| manager_t1("server.manager.process_wait_failed", e.to_string()))
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(windows)]
-    use super::tasklist_csv_has_pid;
-
-    #[cfg(windows)]
-    #[test]
-    fn tasklist_csv_has_pid_matches_actual_csv_rows() {
-        let stdout = "\"java.exe\",\"25212\",\"Console\",\"1\",\"512,000 K\"\r\n";
-
-        assert!(tasklist_csv_has_pid(stdout, 25212));
-        assert!(!tasklist_csv_has_pid(stdout, 99999));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn tasklist_csv_has_pid_rejects_localized_no_match_text() {
-        let stdout = "INFO: 没有运行的任务匹配指定标准。\r\n";
-
-        assert!(!tasklist_csv_has_pid(stdout, 25212));
-    }
 }

--- a/backend/tauri-host/src/services/server/manager/process.rs
+++ b/backend/tauri-host/src/services/server/manager/process.rs
@@ -1,6 +1,10 @@
 use std::process::{Child, Command};
 
 #[cfg(windows)]
+use once_cell::sync::Lazy;
+#[cfg(windows)]
+use std::sync::Mutex;
+#[cfg(windows)]
 use sysinfo::{Pid, ProcessesToUpdate, System};
 
 #[cfg(unix)]
@@ -10,6 +14,9 @@ use std::collections::HashSet;
 use super::i18n::manager_t;
 #[cfg(any(windows, not(any(unix, windows))))]
 use super::i18n::manager_t1;
+
+#[cfg(windows)]
+static PROCESS_SYSTEM: Lazy<Mutex<System>> = Lazy::new(|| Mutex::new(System::new()));
 
 #[cfg(unix)]
 fn list_child_pids_unix(ppid: u32) -> Vec<u32> {
@@ -107,9 +114,14 @@ pub(super) fn force_kill_process_tree(child: &mut Child) -> Result<(), String> {
 
 #[cfg(windows)]
 fn is_process_alive_windows(pid: u32) -> bool {
-    let mut system = System::new_all();
-    system.refresh_processes(ProcessesToUpdate::Some(&[Pid::from_u32(pid)]), true);
-    system.process(Pid::from_u32(pid)).is_some()
+    let pid = Pid::from_u32(pid);
+    let mut system = match PROCESS_SYSTEM.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+
+    system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+    system.process(pid).is_some()
 }
 
 pub(crate) fn is_process_alive(pid: u32) -> bool {

--- a/backend/tauri-host/src/services/server/runtime/local_helper.rs
+++ b/backend/tauri-host/src/services/server/runtime/local_helper.rs
@@ -363,7 +363,7 @@ fn reconcile_terminal_state_after_fallback(
         server,
         state,
         snapshot.exit_code,
-        snapshot.error_message.clone(),
+        snapshot.error_message.as_ref().cloned(),
     ) {
         logger::log_warn_ctx(
             "server.runtime.local_helper",

--- a/backend/tauri-host/src/services/server/runtime/local_helper.rs
+++ b/backend/tauri-host/src/services/server/runtime/local_helper.rs
@@ -338,12 +338,48 @@ pub fn status_snapshot(
                     ),
                 );
 
-                return Ok(Some(fallback_snapshot_from_unreachable_helper(&state)));
+                let snapshot = fallback_snapshot_from_unreachable_helper(&state);
+                reconcile_terminal_state_after_fallback(server, &state, &snapshot);
+                return Ok(Some(snapshot));
             }
         }
     }
 
-    Ok(Some(fallback_snapshot_from_state_file(&state)))
+    let snapshot = fallback_snapshot_from_state_file(&state);
+    reconcile_terminal_state_after_fallback(server, &state, &snapshot);
+    Ok(Some(snapshot))
+}
+
+fn reconcile_terminal_state_after_fallback(
+    server: &ServerInstance,
+    state: &LocalRuntimeState,
+    snapshot: &LocalHelperStatusSnapshot,
+) {
+    if !state.running || snapshot.running {
+        return;
+    }
+
+    if let Err(error) = persist_terminal_state(
+        server,
+        state,
+        snapshot.exit_code,
+        snapshot.error_message.clone(),
+    ) {
+        logger::log_warn_ctx(
+            "server.runtime.local_helper",
+            "reconcile_terminal_state_after_fallback",
+            &format!(
+                "failed to persist terminal fallback state: server_id={} helper_pid={} child_pid={} error={}",
+                server.id,
+                state.helper_pid,
+                state
+                    .child_pid
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "none".to_string()),
+                error
+            ),
+        );
+    }
 }
 
 pub fn send_command(server: &ServerInstance, command: &str) -> Result<(), String> {
@@ -702,6 +738,64 @@ mod tests {
             "runtime=local running=false source=state_file helper=exited exit_code=none"
         );
         assert_eq!(snapshot.error_message, None);
+
+        let reconciled = read_state_checked(&server)
+            .expect("reconciled state should read")
+            .expect("reconciled state should exist");
+        assert!(!reconciled.running);
+        assert_eq!(reconciled.control_port, None);
+        assert_eq!(reconciled.child_pid, None);
+        assert_eq!(
+            reconciled.detail_message,
+            "runtime=local running=false source=state_file exit_code=none"
+        );
+        assert_eq!(reconciled.error_message, None);
+    }
+
+    #[test]
+    fn status_snapshot_reconciles_dead_child_fallback_to_terminal_state() {
+        let temp_dir = tempdir().expect("temp dir should exist");
+        let server = test_server(temp_dir.path().to_string_lossy().to_string());
+        let path = state_file_path(&server);
+
+        write_state_file(
+            &path,
+            &super::LocalRuntimeState {
+                server_id: server.id.clone(),
+                helper_pid: 999_999,
+                child_pid: Some(u32::MAX),
+                control_port: Some(25570),
+                auth_token: "token".to_string(),
+                running: true,
+                exit_code: None,
+                detail_message:
+                    "runtime=local running=true source=helper child_pid=4294967295 control_port=25570"
+                        .to_string(),
+                error_message: None,
+                updated_at: 123,
+            },
+        )
+        .expect("state file should be written");
+
+        let snapshot = status_snapshot(&server)
+            .expect("status should succeed")
+            .expect("fallback snapshot should exist");
+
+        assert!(!snapshot.running);
+        assert_eq!(snapshot.pid, None);
+        assert_eq!(snapshot.exit_code, None);
+
+        let reconciled = read_state_checked(&server)
+            .expect("reconciled state should read")
+            .expect("reconciled state should exist");
+        assert!(!reconciled.running);
+        assert_eq!(reconciled.control_port, None);
+        assert_eq!(reconciled.child_pid, Some(u32::MAX));
+        assert_eq!(
+            reconciled.detail_message,
+            "runtime=local running=false source=state_file exit_code=none"
+        );
+        assert_eq!(reconciled.error_message, None);
     }
 
     #[test]


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [ ] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [x] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

<!-- 一句话概括本次变更 -->

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #746 

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

在回退到状态文件时，对本地运行时辅助进程（helper）的状态进行对账，并用基于 sysinfo 的实现替换 Windows 进程存活性检查。

Bug 修复：
- 当状态从不可达的辅助进程或状态文件回退时，确保终端本地运行时状态被持久化，防止对运行状态的重复误分类。
- 通过将基于 tasklist 的解析替换为直接基于 sysinfo 的进程查找，避免错误的 Windows 进程存活性检测。

测试：
- 添加回归测试，验证在辅助进程或子进程已终止的情况下，回退的状态快照能够正确对账并持久化终端状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reconcile local runtime helper state when falling back to state files and replace Windows process liveness checks with a sysinfo-based implementation.

Bug Fixes:
- Ensure terminal local runtime state is persisted when status falls back from an unreachable helper or state file, preventing repeated misclassification of running status.
- Avoid incorrect Windows process liveness detection by replacing tasklist parsing with a direct sysinfo process lookup.

Tests:
- Add regression tests verifying that fallback status snapshots reconcile and persist terminal state correctly for dead helper or child processes.

</details>