### PR TITLE
fix: 修复前端检查与 Tauri 开发模式启动问题

### DIFF
--- a/.github/workflows/beta-check.yml
+++ b/.github/workflows/beta-check.yml
@@ -130,7 +130,7 @@ jobs:
         continue-on-error: true
         run: |
           corepack enable
-          corepack prepare pnpm@11.5.2 --activate
+          corepack prepare pnpm@11.5.3 --activate
 
       - name: PNPM 缓存
         id: pnpm_cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Prepare PNPM (固定版本)
         run: |
           corepack enable
-          corepack prepare pnpm@11.5.2 --activate
+          corepack prepare pnpm@11.5.3 --activate
 
       - name: 缓存 pnpm 依赖
         uses: actions/cache@v4

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: 安装前端依赖 (pnpm)
         run: |
-          corepack prepare pnpm@11.5.2 --activate
+          corepack prepare pnpm@11.5.3 --activate
           pnpm --dir frontend install --frozen-lockfile
 
       - name: 构建并上传 Nightly 产物

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: 安装前端依赖 (pnpm)
         run: |
-          corepack prepare pnpm@11.5.2 --activate
+          corepack prepare pnpm@11.5.3 --activate
           pnpm --dir frontend install --frozen-lockfile
 
       - name: 构建并发布

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,6 +9,19 @@
   "rules": {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "off",
+    "eslint/no-underscore-dangle": [
+      "warn",
+      {
+        "allow": [
+          "__TAURI__",
+          "__TAURI_INTERNALS__",
+          "__invoke",
+          "_path",
+          "_selectId",
+          "_themeProviderOverrides"
+        ]
+      }
+    ],
     "import/named": ["error"],
     "import/no-unassigned-import": [
       "error",

--- a/backend/tauri-host/capabilities/default.json
+++ b/backend/tauri-host/capabilities/default.json
@@ -17,6 +17,7 @@
     "core:app:allow-default-window-icon",
     "core:window:allow-hide",
     "core:window:allow-show",
+    "core:window:allow-set-title",
     "core:window:allow-set-skip-taskbar",
     "core:window:allow-set-focus",
     "dialog:default",

--- a/frontend/scripts/check-i18n.mjs
+++ b/frontend/scripts/check-i18n.mjs
@@ -28,7 +28,10 @@ function flattenKeys(value, prefix = "") {
 
 function readLocale(locale) {
   const localeDir = path.join(rootDir, locale);
-  const files = fs.readdirSync(localeDir).filter((file) => file.endsWith(".json")).sort();
+  const files = fs
+    .readdirSync(localeDir)
+    .filter((file) => file.endsWith(".json"))
+    .toSorted();
   const groups = {};
 
   for (const file of files) {
@@ -45,11 +48,11 @@ function readLocale(locale) {
 const locales = fs
   .readdirSync(rootDir)
   .filter((entry) => fs.statSync(path.join(rootDir, entry)).isDirectory())
-  .sort((a, b) => a.localeCompare(b));
+  .toSorted((a, b) => a.localeCompare(b));
 
 const baseGroups = readLocale(baseLocale);
 const fallbackGroups = readLocale(fallbackLocale);
-const groupNames = Object.keys(baseGroups).sort((a, b) => a.localeCompare(b));
+const groupNames = Object.keys(baseGroups).toSorted((a, b) => a.localeCompare(b));
 
 let hasMissing = false;
 
@@ -73,7 +76,9 @@ for (const locale of locales) {
       continue;
     }
 
-    const missingKeys = [...expectedKeys].filter((key) => !currentKeys.has(key)).sort((a, b) => a.localeCompare(b));
+    const missingKeys = [...expectedKeys]
+      .filter((key) => !currentKeys.has(key))
+      .toSorted((a, b) => a.localeCompare(b));
     if (missingKeys.length > 0) {
       incompleteGroups.push(`${group} (${currentKeys.size}/${expectedKeys.size})`);
     }

--- a/frontend/scripts/sync-i18n.mjs
+++ b/frontend/scripts/sync-i18n.mjs
@@ -88,7 +88,7 @@ function getLocaleDirs() {
   return fs
     .readdirSync(rootDir)
     .filter((entry) => fs.statSync(path.join(rootDir, entry)).isDirectory())
-    .sort((a, b) => a.localeCompare(b));
+    .toSorted((a, b) => a.localeCompare(b));
 }
 
 function getGroupFiles(locale) {
@@ -96,13 +96,15 @@ function getGroupFiles(locale) {
   return fs
     .readdirSync(localeDir)
     .filter((file) => file.endsWith(".json") && file !== "language.json")
-    .sort((a, b) => a.localeCompare(b));
+    .toSorted((a, b) => a.localeCompare(b));
 }
 
 const locales = getLocaleDirs();
 const baseFiles = getGroupFiles(baseLocale);
 const zhFiles = new Set(getGroupFiles(fallbackLocale));
-const groupFiles = Array.from(new Set([...baseFiles, ...zhFiles])).sort((a, b) => a.localeCompare(b));
+const groupFiles = Array.from(new Set([...baseFiles, ...zhFiles])).toSorted((a, b) =>
+  a.localeCompare(b),
+);
 
 for (const locale of locales) {
   const localeDir = path.join(rootDir, locale);

--- a/frontend/src/api/server.ts
+++ b/frontend/src/api/server.ts
@@ -81,6 +81,47 @@ function formatForceStopError(error: unknown): string {
   }
 }
 
+async function readSseStream(
+  reader: ReadableStreamDefaultReader<string>,
+  callback: (payload: ServerLogLineEvent) => void,
+  isDisposed: () => boolean,
+  buffer: string = "",
+): Promise<void> {
+  const { value, done } = await reader.read();
+  if (done || isDisposed()) {
+    return;
+  }
+
+  let nextBuffer = `${buffer}${value}`;
+  const frames = nextBuffer.split("\n\n");
+  nextBuffer = frames.pop() || "";
+
+  for (const frame of frames) {
+    const dataLines = frame
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim());
+
+    if (dataLines.length === 0) {
+      continue;
+    }
+
+    const raw = dataLines.join("\n");
+    if (raw === "ping") {
+      continue;
+    }
+
+    try {
+      const data = JSON.parse(raw) as ServerLogLineEvent;
+      callback(data);
+    } catch (error) {
+      console.warn("[SSE] Failed to parse log event:", error);
+    }
+  }
+
+  await readSseStream(reader, callback, isDisposed, nextBuffer);
+}
+
 export interface StartupCandidateItem {
   id: string;
   mode: "starter" | "jar" | "bat" | "sh" | "ps1" | "custom";
@@ -466,9 +507,7 @@ export const serverApi = {
     });
   },
 
-  onStructuredLogEvent(
-    callback: (payload: ServerLogStructuredEvent) => void,
-  ): Promise<UnlistenFn> {
+  onStructuredLogEvent(callback: (payload: ServerLogStructuredEvent) => void): Promise<UnlistenFn> {
     if (isBrowserEnv()) {
       return Promise.reject(new Error("Structured log events are only available in Tauri mode"));
     }
@@ -531,47 +570,13 @@ export const serverApi = {
               }
 
               const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-              let buffer = "";
-
-              while (!disposed) {
-                const { value, done } = await reader.read();
-                if (done) {
-                  break;
-                }
-
-                buffer += value;
-                const frames = buffer.split("\n\n");
-                buffer = frames.pop() || "";
-
-                for (const frame of frames) {
-                  const dataLines = frame
-                    .split("\n")
-                    .filter((line) => line.startsWith("data:"))
-                    .map((line) => line.slice(5).trim());
-
-                  if (dataLines.length === 0) {
-                    continue;
-                  }
-
-                  const raw = dataLines.join("\n");
-                  if (raw === "ping") {
-                    continue;
-                  }
-
-                  try {
-                    const data = JSON.parse(raw) as ServerLogLineEvent;
-                    callback(data);
-                  } catch (e) {
-                    console.warn("[SSE] Failed to parse log event:", e);
-                  }
-                }
-              }
-            } catch (e) {
+              await readSseStream(reader, callback, () => disposed);
+            } catch (error) {
               if (disposed) {
                 return;
               }
 
-              console.warn("[SSE] Connection error, reconnecting...", e);
+              console.warn("[SSE] Connection error, reconnecting...", error);
               abortController?.abort();
               abortController = null;
               clearReconnectTimer();

--- a/frontend/src/components/FileUploader.vue
+++ b/frontend/src/components/FileUploader.vue
@@ -186,7 +186,9 @@ defineExpose({
         <p class="text-gray-600">
           {{ isDragging ? i18n.t("upload.drop_to_upload") : i18n.t("upload.drag_or_click") }}
         </p>
-        <p v-if="accept" class="text-sm text-gray-400">{{ i18n.t("upload.supported_formats", { formats: accept }) }}</p>
+        <p v-if="accept" class="text-sm text-gray-400">
+          {{ i18n.t("upload.supported_formats", { formats: accept }) }}
+        </p>
         <p v-if="maxSize" class="text-sm text-gray-400">
           {{ i18n.t("upload.max_size_mb", { size: (maxSize / 1024 / 1024).toFixed(2) }) }}
         </p>

--- a/frontend/src/components/JavaDownloader.vue
+++ b/frontend/src/components/JavaDownloader.vue
@@ -70,7 +70,9 @@
               <CheckCircle :size="16" />
               <span>{{ i18n.t("settings.java_install_success").replace(":", "") }}</span>
             </div>
-            <SLButton size="sm" variant="ghost" @click="resetState">{{ i18n.t("common.ok") }}</SLButton>
+            <SLButton size="sm" variant="ghost" @click="resetState">{{
+              i18n.t("common.ok")
+            }}</SLButton>
           </div>
         </template>
       </div>

--- a/frontend/src/components/config/ConfigPluginsSection.vue
+++ b/frontend/src/components/config/ConfigPluginsSection.vue
@@ -10,6 +10,8 @@ import { Trash2, RefreshCw, Settings, FileText, RotateCcw, FolderOpen, Edit } fr
 interface Props {
   plugins: m_PluginInfo[];
   pluginsLoading: boolean;
+  pluginsSupported: boolean;
+  pluginsUnsupportedReason: string | null;
   selectedPlugin: m_PluginInfo | null;
 }
 
@@ -49,6 +51,7 @@ function setPluginRowRef(pluginFileName: string) {
       <SLButton
         @click="emit('refreshList')"
         :loading="pluginsLoading"
+        :disabled="!pluginsSupported"
         variant="secondary"
         size="sm"
       >
@@ -58,6 +61,7 @@ function setPluginRowRef(pluginFileName: string) {
       <SLButton
         @click="emit('reloadPlugins')"
         :loading="pluginsLoading"
+        :disabled="!pluginsSupported"
         variant="danger"
         size="sm"
         class="reload-btn"
@@ -75,7 +79,11 @@ function setPluginRowRef(pluginFileName: string) {
   </div>
 
   <div v-else class="plugins-container">
-    <div v-if="plugins.length === 0" class="empty-state">
+    <div v-if="!pluginsSupported" class="empty-state">
+      <p class="text-caption">{{ pluginsUnsupportedReason }}</p>
+    </div>
+
+    <div v-else-if="plugins.length === 0" class="empty-state">
       <p class="text-caption">{{ i18n.t("config.no_plugins") }}</p>
     </div>
 

--- a/frontend/src/components/config/ConfigPropertiesSection.vue
+++ b/frontend/src/components/config/ConfigPropertiesSection.vue
@@ -1,15 +1,19 @@
 <script setup lang="ts">
+import { defineAsyncComponent } from "vue";
 import SLSpinner from "@components/common/SLSpinner.vue";
 import SLButton from "@components/common/SLButton.vue";
 import SLTooltip from "@components/common/SLTooltip.vue";
 import ConfigCategories from "@components/config/ConfigCategories.vue";
-import ConfigSourceEditor from "@components/config/ConfigSourceEditor.vue";
 import ConfigPropertyEditorControl from "@components/config/ConfigPropertyEditorControl.vue";
 import ConfigComparePanel from "@components/config/ConfigComparePanel.vue";
 import type { ComparePanelRow } from "@views/config/useConfigCompare";
 import type { ConfigEntry as ConfigEntryType } from "@api/config";
 import { i18n } from "@language";
 import { RefreshCw, Save } from "@lucide/vue";
+
+const ConfigSourceEditor = defineAsyncComponent(
+  () => import("@components/config/ConfigSourceEditor.vue"),
+);
 
 interface Option {
   label: string;

--- a/frontend/src/components/views/create/startupUtils.ts
+++ b/frontend/src/components/views/create/startupUtils.ts
@@ -62,7 +62,7 @@ export function detectVersionCandidatesFromText(input: string, knownVersions: st
 
   const lowered = trimmed.toLowerCase();
   const matches = knownVersions.filter((version) => lowered.includes(version.toLowerCase()));
-  return [...new Set(matches)].sort((left, right) => right.length - left.length);
+  return [...new Set(matches)].toSorted((left, right) => right.length - left.length);
 }
 
 export function containsIoRedirection(command: string): boolean {

--- a/frontend/src/components/views/create/useCreateServerScan.ts
+++ b/frontend/src/components/views/create/useCreateServerScan.ts
@@ -12,6 +12,36 @@ interface UseCreateServerScanOptions {
   showError: (message: string) => void;
 }
 
+function prioritizeDetectedOption(values: string[], detected: string): string[] {
+  const unique = [...new Set(values.filter((value) => value.trim().length > 0))];
+  if (!detected.trim()) {
+    return unique;
+  }
+
+  return [detected, ...unique.filter((value) => value !== detected)];
+}
+
+function resolveDetectedMcVersion(
+  path: string,
+  discoveredOptions: string[],
+  apiDetectedVersion: string,
+  candidates: StartupCandidate[],
+): { detected: string; failed: boolean } {
+  if (apiDetectedVersion.trim()) {
+    return { detected: apiDetectedVersion.trim(), failed: false };
+  }
+
+  const fallbackInputs = [path, ...candidates.map((candidate) => candidate.path)];
+  for (const input of fallbackInputs) {
+    const matches = detectVersionCandidatesFromText(input, discoveredOptions);
+    if (matches.length > 0) {
+      return { detected: matches[0], failed: false };
+    }
+  }
+
+  return { detected: "", failed: true };
+}
+
 export function useCreateServerScan(options: UseCreateServerScanOptions) {
   const coreDetecting = ref(false);
   const detectedCoreTypeKey = ref("");
@@ -32,36 +62,6 @@ export function useCreateServerScan(options: UseCreateServerScanOptions) {
   let startupDetectRequestId = 0;
   const AUTO_SCAN_DEBOUNCE_MS = 120;
   let startupDetectTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function prioritizeDetectedOption(options: string[], detected: string): string[] {
-    const unique = [...new Set(options.filter((value) => value.trim().length > 0))];
-    if (!detected.trim()) {
-      return unique;
-    }
-
-    return [detected, ...unique.filter((value) => value !== detected)];
-  }
-
-  function resolveDetectedMcVersion(
-    path: string,
-    discoveredOptions: string[],
-    apiDetectedVersion: string,
-    candidates: StartupCandidate[],
-  ): { detected: string; failed: boolean } {
-    if (apiDetectedVersion.trim()) {
-      return { detected: apiDetectedVersion.trim(), failed: false };
-    }
-
-    const fallbackInputs = [path, ...candidates.map((candidate) => candidate.path)];
-    for (const input of fallbackInputs) {
-      const matches = detectVersionCandidatesFromText(input, discoveredOptions);
-      if (matches.length > 0) {
-        return { detected: matches[0], failed: false };
-      }
-    }
-
-    return { detected: "", failed: true };
-  }
 
   function resetScanState() {
     coreDetecting.value = false;

--- a/frontend/src/components/views/home/ChangePathModal.vue
+++ b/frontend/src/components/views/home/ChangePathModal.vue
@@ -120,13 +120,17 @@ const validationMessage = computed(() => {
           class="detected-info"
         >
           <div class="detected-item">
-            <span class="detected-label">{{ i18n.t("home.change_path_detected_startup_file") }}</span>
+            <span class="detected-label">{{
+              i18n.t("home.change_path_detected_startup_file")
+            }}</span>
             <code class="detected-value">{{
               homeServerActionsStore.changePathValidationResult.jarPath
             }}</code>
           </div>
           <div class="detected-item">
-            <span class="detected-label">{{ i18n.t("home.change_path_detected_startup_mode") }}</span>
+            <span class="detected-label">{{
+              i18n.t("home.change_path_detected_startup_mode")
+            }}</span>
             <span class="detected-value">{{
               homeServerActionsStore.changePathValidationResult.startupMode?.toUpperCase() || "JAR"
             }}</span>

--- a/frontend/src/components/views/plugins/PluginMarketDetailDialog.vue
+++ b/frontend/src/components/views/plugins/PluginMarketDetailDialog.vue
@@ -48,7 +48,11 @@ const emit = defineEmits<{
           <div class="detail-title">
             <h2>{{ resolveI18n(plugin.name) }}</h2>
             <span class="detail-version">{{ plugin.version ? "v" + plugin.version : "" }}</span>
-            <span class="detail-author">{{ i18n.t("common.by_author", { author: plugin.author?.name || i18n.t("market.author_unknown") }) }}</span>
+            <span class="detail-author">{{
+              i18n.t("common.by_author", {
+                author: plugin.author?.name || i18n.t("market.author_unknown"),
+              })
+            }}</span>
           </div>
         </div>
         <div v-if="detailLoading" class="detail-loading">

--- a/frontend/src/components/views/plugins/PluginMarketGrid.vue
+++ b/frontend/src/components/views/plugins/PluginMarketGrid.vue
@@ -38,7 +38,11 @@ const emit = defineEmits<{
           <span class="card-name">{{ resolveI18n(plugin.name) }}</span>
           <span class="card-version">{{ plugin.version ? "v" + plugin.version : "" }}</span>
         </div>
-        <span class="card-author">{{ i18n.t("common.by_author", { author: plugin.author?.name || i18n.t("market.author_unknown") }) }}</span>
+        <span class="card-author">{{
+          i18n.t("common.by_author", {
+            author: plugin.author?.name || i18n.t("market.author_unknown"),
+          })
+        }}</span>
         <p class="card-desc">{{ resolveI18n(plugin.description) }}</p>
 
         <div v-if="plugin.dependencies?.length" class="card-deps">

--- a/frontend/src/components/views/plugins/usePluginFeedback.ts
+++ b/frontend/src/components/views/plugins/usePluginFeedback.ts
@@ -1,6 +1,11 @@
 import { ref } from "vue";
 import { normalizeAppError, resolveErrorMessage } from "@utils/appError";
 
+function getPluginErrorMessage(error: unknown): string {
+  const normalized = normalizeAppError(error);
+  return normalized.message || resolveErrorMessage(normalized.code, normalized.args);
+}
+
 export function usePluginFeedback() {
   const alertDialog = ref({
     show: false,
@@ -40,11 +45,6 @@ export function usePluginFeedback() {
     permissionWarning.value.show = false;
   }
 
-  function getErrorMessage(error: unknown): string {
-    const normalized = normalizeAppError(error);
-    return normalized.message || resolveErrorMessage(normalized.code, normalized.args);
-  }
-
   return {
     alertDialog,
     permissionWarning,
@@ -52,6 +52,6 @@ export function usePluginFeedback() {
     closeAlertDialog,
     openPermissionWarning,
     closePermissionWarning,
-    getErrorMessage,
+    getErrorMessage: getPluginErrorMessage,
   };
 }

--- a/frontend/src/components/views/plugins/usePluginListActions.ts
+++ b/frontend/src/components/views/plugins/usePluginListActions.ts
@@ -58,6 +58,22 @@ function hasSettings(plugin: PluginInfo): boolean {
   return !!(plugin.manifest.settings && plugin.manifest.settings.length > 0);
 }
 
+function getPluginStatusLabel(state: PluginState): string {
+  if (typeof state === "object" && "error" in state) {
+    return i18n.t("plugins.status.error");
+  }
+  switch (state) {
+    case "enabled":
+      return i18n.t("plugins.status.enabled");
+    case "disabled":
+      return i18n.t("plugins.status.disabled");
+    case "loaded":
+      return i18n.t("plugins.status.loaded");
+    default:
+      return String(state);
+  }
+}
+
 export function usePluginListActions(options: UsePluginListActionsOptions) {
   const router = useRouter();
   const checkingUpdate = ref<string | null>(null);
@@ -199,22 +215,6 @@ export function usePluginListActions(options: UsePluginListActionsOptions) {
     }
   }
 
-  function getStatusLabel(state: PluginState): string {
-    if (typeof state === "object" && "error" in state) {
-      return i18n.t("plugins.status.error");
-    }
-    switch (state) {
-      case "enabled":
-        return i18n.t("plugins.status.enabled");
-      case "disabled":
-        return i18n.t("plugins.status.disabled");
-      case "loaded":
-        return i18n.t("plugins.status.loaded");
-      default:
-        return String(state);
-    }
-  }
-
   function getPluginMenuItems(pluginId: string) {
     return [
       {
@@ -260,7 +260,7 @@ export function usePluginListActions(options: UsePluginListActionsOptions) {
     handleCheckUpdate,
     handleCheckAllUpdates,
     getStatusColor,
-    getStatusLabel,
+    getStatusLabel: getPluginStatusLabel,
     isPluginEnabled,
     hasSettings,
     getPluginMenuItems,

--- a/frontend/src/components/views/plugins/usePluginMarket.ts
+++ b/frontend/src/components/views/plugins/usePluginMarket.ts
@@ -14,6 +14,18 @@ import { usePluginMarketViewState } from "@components/views/plugins/usePluginMar
 import { i18n } from "@language";
 import { usePluginStore } from "@stores/pluginStore";
 
+function getMarketPermissionLabel(perm: string): string {
+  return i18n.t(`plugins.permission.${perm}`) !== `plugins.permission.${perm}`
+    ? i18n.t(`plugins.permission.${perm}`)
+    : perm;
+}
+
+function getMarketPermissionDesc(perm: string): string {
+  return i18n.t(`plugins.permission.${perm}_desc`) !== `plugins.permission.${perm}_desc`
+    ? i18n.t(`plugins.permission.${perm}_desc`)
+    : "";
+}
+
 export function usePluginMarket() {
   const pluginStore = usePluginStore();
   const loading = ref(true);
@@ -109,18 +121,6 @@ export function usePluginMarket() {
     return i18n.t("market.install");
   }
 
-  function getPermissionLabel(perm: string): string {
-    return i18n.t(`plugins.permission.${perm}`) !== `plugins.permission.${perm}`
-      ? i18n.t(`plugins.permission.${perm}`)
-      : perm;
-  }
-
-  function getPermissionDesc(perm: string): string {
-    return i18n.t(`plugins.permission.${perm}_desc`) !== `plugins.permission.${perm}_desc`
-      ? i18n.t(`plugins.permission.${perm}_desc`)
-      : "";
-  }
-
   onMounted(() => {
     void loadMarket();
   });
@@ -160,8 +160,8 @@ export function usePluginMarket() {
     isInstalledAndEnabled,
     getInstallButtonText,
     getPermissionLevel: getMarketPermissionLevel,
-    getPermissionLabel,
-    getPermissionDesc,
+    getPermissionLabel: getMarketPermissionLabel,
+    getPermissionDesc: getMarketPermissionDesc,
     getCategoryLabel,
     getIconUrl,
     loadMarket,

--- a/frontend/src/components/views/plugins/usePluginsViewPage.ts
+++ b/frontend/src/components/views/plugins/usePluginsViewPage.ts
@@ -4,6 +4,28 @@ import { i18n } from "@language";
 import type { MissingDependency, PluginInfo } from "@type/plugin";
 import { getLocalizedPluginDescription, getLocalizedPluginName } from "@type/plugin";
 
+function getPluginPermissionLabel(permission: string): string {
+  const key = `plugins.permission.${permission}`;
+  return i18n.t(key) !== key ? i18n.t(key) : permission;
+}
+
+function getPluginPermissionDesc(permission: string): string {
+  const key = `plugins.permission.${permission}_desc`;
+  return i18n.t(key) !== key ? i18n.t(key) : "";
+}
+
+function openPluginRepository(url: string) {
+  void openUrl(url);
+}
+
+function getDisplayPluginName(plugin: PluginInfo): string {
+  return getLocalizedPluginName(plugin.manifest, i18n.getLocale());
+}
+
+function getDisplayPluginDescription(plugin: PluginInfo): string {
+  return getLocalizedPluginDescription(plugin.manifest, i18n.getLocale());
+}
+
 interface UsePluginsViewPageOptions {
   plugins: () => PluginInfo[];
   searchQuery: () => string;
@@ -38,16 +60,6 @@ export function usePluginsViewPage(options: UsePluginsViewPageOptions) {
     void options.refreshPlugins();
   }
 
-  function getPermissionLabel(permission: string): string {
-    const key = `plugins.permission.${permission}`;
-    return i18n.t(key) !== key ? i18n.t(key) : permission;
-  }
-
-  function getPermissionDesc(permission: string): string {
-    const key = `plugins.permission.${permission}_desc`;
-    return i18n.t(key) !== key ? i18n.t(key) : "";
-  }
-
   function updateSettingsField(key: string, value: string | number | boolean) {
     options.settingsForm[key] = value;
   }
@@ -58,18 +70,6 @@ export function usePluginsViewPage(options: UsePluginsViewPageOptions) {
     const optional = options.getMissingOptionalDependencies(plugin);
     options.setMissingDependencies([...required, ...optional]);
     options.setShowDependencyModal(true);
-  }
-
-  function openRepository(url: string) {
-    void openUrl(url);
-  }
-
-  function getPluginName(plugin: PluginInfo): string {
-    return getLocalizedPluginName(plugin.manifest, i18n.getLocale());
-  }
-
-  function getPluginDescription(plugin: PluginInfo): string {
-    return getLocalizedPluginDescription(plugin.manifest, i18n.getLocale());
   }
 
   async function handleSaveSettings() {
@@ -87,13 +87,13 @@ export function usePluginsViewPage(options: UsePluginsViewPageOptions) {
   return {
     filteredPlugins,
     handleRefresh,
-    getPermissionLabel,
-    getPermissionDesc,
+    getPermissionLabel: getPluginPermissionLabel,
+    getPermissionDesc: getPluginPermissionDesc,
     updateSettingsField,
     showMissingDependenciesModal,
-    openRepository,
-    getPluginName,
-    getPluginDescription,
+    openRepository: openPluginRepository,
+    getPluginName: getDisplayPluginName,
+    getPluginDescription: getDisplayPluginDescription,
     handleSaveSettings,
     handleGoToMarket,
   };

--- a/frontend/src/components/views/settings/NetworkSettingsCard.vue
+++ b/frontend/src/components/views/settings/NetworkSettingsCard.vue
@@ -8,11 +8,7 @@ const testing = ref(false);
 const showDetail = ref(false);
 const result = ref<IPv6TestResult | null>(null);
 
-function translateByKey(
-  key?: string,
-  args?: Record<string, string>,
-  fallback = "",
-): string {
+function translateByKey(key?: string, args?: Record<string, string>, fallback = ""): string {
   if (!key) {
     return fallback;
   }

--- a/frontend/src/composables/useAboutLinks.ts
+++ b/frontend/src/composables/useAboutLinks.ts
@@ -1,17 +1,17 @@
 import { ref } from "vue";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
+async function openExternalLink(url: string) {
+  if (!url) return;
+  try {
+    await openUrl(url);
+  } catch (error) {
+    console.error("[useAboutLinks] 打开URL失败:", error);
+  }
+}
+
 export function useAboutLinks() {
   const copiedQQ = ref<string | null>(null);
-
-  async function openLink(url: string) {
-    if (!url) return;
-    try {
-      await openUrl(url);
-    } catch (e) {
-      console.error("[useAboutLinks] 打开URL失败:", e);
-    }
-  }
 
   async function copyQQ(qq: string) {
     try {
@@ -29,13 +29,13 @@ export function useAboutLinks() {
     if (platform === "qq") {
       await copyQQ(value);
     } else {
-      await openLink(value);
+      await openExternalLink(value);
     }
   }
 
   return {
     copiedQQ,
-    openLink,
+    openLink: openExternalLink,
     copyQQ,
     openSocialLink,
   };

--- a/frontend/src/composables/useDeveloperTools.ts
+++ b/frontend/src/composables/useDeveloperTools.ts
@@ -24,6 +24,22 @@ interface LogFilterOption {
 const ALL_LOG_LEVELS = "__all_levels__";
 const ALL_LOG_MODULES = "__all_modules__";
 
+function formatUptime(totalSeconds: number): string {
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0 || days > 0) {
+    parts.push(`${hours}h`);
+  }
+  parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
 export function useDeveloperTools(options: UseDeveloperToolsOptions) {
   const globalMessage = useGlobalMessage();
   const settingsStore = useSettingsStore();
@@ -44,14 +60,14 @@ export function useDeveloperTools(options: UseDeveloperToolsOptions) {
   const selectedLogModule = ref(ALL_LOG_MODULES);
 
   const logLevelOptions = computed<LogFilterOption[]>(() => {
-    const levels = Array.from(new Set(logs.value.map((entry) => entry.level))).sort();
+    const levels = Array.from(new Set(logs.value.map((entry) => entry.level))).toSorted();
     return [
       { label: i18n.t("developer.all_log_levels"), value: ALL_LOG_LEVELS },
       ...levels.map((level) => ({ label: level, value: level })),
     ];
   });
   const logModuleOptions = computed<LogFilterOption[]>(() => {
-    const modules = Array.from(new Set(logs.value.map((entry) => entry.module))).sort();
+    const modules = Array.from(new Set(logs.value.map((entry) => entry.module))).toSorted();
     return [
       { label: i18n.t("developer.all_log_modules"), value: ALL_LOG_MODULES },
       ...modules.map((module) => ({ label: module, value: module })),
@@ -91,22 +107,6 @@ export function useDeveloperTools(options: UseDeveloperToolsOptions) {
     const unitIndex = Math.min(Math.floor(Math.log(value) / Math.log(base)), units.length - 1);
     const scaled = value / Math.pow(base, unitIndex);
     return `${scaled.toFixed(memoryDisplayPrecision.value)} ${units[unitIndex]}`;
-  }
-
-  function formatUptime(totalSeconds: number): string {
-    const days = Math.floor(totalSeconds / 86400);
-    const hours = Math.floor((totalSeconds % 86400) / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const parts: string[] = [];
-
-    if (days > 0) {
-      parts.push(`${days}d`);
-    }
-    if (hours > 0 || days > 0) {
-      parts.push(`${hours}h`);
-    }
-    parts.push(`${minutes}m`);
-    return parts.join(" ");
   }
 
   const systemSummary = computed(() => {

--- a/frontend/src/language/index.ts
+++ b/frontend/src/language/index.ts
@@ -21,12 +21,32 @@ export type LocaleMetadata = {
 
 type LocaleModule = { default: unknown };
 type LocaleMetadataModule = { default: LocaleMetadata };
+type LocaleModuleLoader = () => Promise<LocaleModule>;
 
-const localeModules = import.meta.glob<LocaleModule>("./*/*.json", { eager: true });
+const DEFAULT_SYNC_LOCALE = "zh-CN";
+const localeMetadataModules = import.meta.glob<LocaleMetadataModule>("./*/language.json", {
+  eager: true,
+});
+const localeGroupModuleLoaders = import.meta.glob<LocaleModule>("./*/*.json");
+const defaultLocaleModules = import.meta.glob<LocaleModule>("./zh-CN/*.json", {
+  eager: true,
+});
 const builtInLocaleMetadata: Record<string, LocaleMetadata> = {};
 const builtInLocaleGroups: Record<string, Record<string, TranslationValue>> = {};
+const builtInLocaleGroupLoaders: Record<string, Record<string, LocaleModuleLoader>> = {};
+const localeLoadPromises: Record<string, Promise<boolean> | undefined> = {};
 
-for (const [path, module] of Object.entries(localeModules)) {
+for (const [path, module] of Object.entries(localeMetadataModules)) {
+  const match = path.match(/^\.\/([^/]+)\/language\.json$/);
+  if (!match) {
+    continue;
+  }
+
+  const [, locale] = match;
+  builtInLocaleMetadata[locale] = module.default;
+}
+
+for (const [path, loader] of Object.entries(localeGroupModuleLoaders)) {
   const match = path.match(/^\.\/([^/]+)\/([^/]+)\.json$/);
   if (!match) {
     continue;
@@ -34,7 +54,23 @@ for (const [path, module] of Object.entries(localeModules)) {
 
   const [, locale, group] = match;
   if (group === "language") {
-    builtInLocaleMetadata[locale] = (module as LocaleMetadataModule).default;
+    continue;
+  }
+
+  if (!builtInLocaleGroupLoaders[locale]) {
+    builtInLocaleGroupLoaders[locale] = {};
+  }
+  builtInLocaleGroupLoaders[locale][group] = loader;
+}
+
+for (const [path, module] of Object.entries(defaultLocaleModules)) {
+  const match = path.match(/^\.\/([^/]+)\/([^/]+)\.json$/);
+  if (!match) {
+    continue;
+  }
+
+  const [, locale, group] = match;
+  if (group === "language") {
     continue;
   }
 
@@ -46,14 +82,16 @@ for (const [path, module] of Object.entries(localeModules)) {
 
 const translations: Record<string, LanguageFile> = {};
 const supportedLocales: string[] = Array.from(
-  new Set([...Object.keys(builtInLocaleGroups), ...Object.keys(builtInLocaleMetadata)]),
-).sort((a, b) => a.localeCompare(b));
+  new Set([
+    ...Object.keys(builtInLocaleGroupLoaders),
+    ...Object.keys(builtInLocaleGroups),
+    ...Object.keys(builtInLocaleMetadata),
+  ]),
+).toSorted((a, b) => a.localeCompare(b));
 
-for (const locale of Object.keys(builtInLocaleGroups)) {
-  const localeTranslations = buildLocaleTranslations(locale);
-  if (localeTranslations) {
-    translations[locale] = localeTranslations;
-  }
+const defaultLocaleTranslations = buildLocaleTranslations(DEFAULT_SYNC_LOCALE);
+if (defaultLocaleTranslations) {
+  translations[DEFAULT_SYNC_LOCALE] = defaultLocaleTranslations;
 }
 
 const backendFlatTranslations: Record<string, Record<string, string>> = {};
@@ -76,16 +114,27 @@ export async function ensureLocaleLoaded(locale: LocaleCode): Promise<boolean> {
     return true;
   }
 
-  const localeTranslations = buildLocaleTranslations(locale);
-  if (!localeTranslations) {
-    return false;
+  if (localeLoadPromises[locale]) {
+    return localeLoadPromises[locale];
   }
 
-  translations[locale] = localeTranslations;
-  if (!supportedLocales.includes(locale)) {
-    supportedLocales.push(locale);
-  }
-  return true;
+  localeLoadPromises[locale] = loadBuiltInLocaleTranslations(locale)
+    .then((localeTranslations) => {
+      if (!localeTranslations) {
+        return false;
+      }
+
+      translations[locale] = localeTranslations;
+      if (!supportedLocales.includes(locale)) {
+        supportedLocales.push(locale);
+      }
+      return true;
+    })
+    .finally(() => {
+      delete localeLoadPromises[locale];
+    });
+
+  return localeLoadPromises[locale]!;
 }
 
 export function setLocaleBundle(
@@ -231,7 +280,38 @@ function buildLocaleTranslations(locale: string): LanguageFile | undefined {
   return localeTranslations;
 }
 
-function resolveNestedValue(source: TranslationNode | undefined, keys: string[]): string | undefined {
+async function loadBuiltInLocaleTranslations(locale: string): Promise<LanguageFile | undefined> {
+  const loaders = builtInLocaleGroupLoaders[locale];
+  if (!loaders && !builtInLocaleGroups[locale]) {
+    return undefined;
+  }
+
+  const localeGroups = builtInLocaleGroups[locale] ?? (builtInLocaleGroups[locale] = {});
+  const missingGroups = Object.entries(loaders ?? {}).filter(([group]) => !(group in localeGroups));
+
+  if (missingGroups.length > 0) {
+    const loadedGroups = await Promise.all(
+      missingGroups.map(async ([group, loader]) => {
+        const module = await loader();
+        return {
+          group,
+          value: normalizeGroupValue(module.default),
+        };
+      }),
+    );
+
+    for (const { group, value } of loadedGroups) {
+      localeGroups[group] = value;
+    }
+  }
+
+  return buildLocaleTranslations(locale);
+}
+
+function resolveNestedValue(
+  source: TranslationNode | undefined,
+  keys: string[],
+): string | undefined {
   let current: TranslationValue | undefined = source;
   for (const key of keys) {
     if (!current || typeof current === "string") {
@@ -299,7 +379,9 @@ class I18n {
       for (const pluginMap of Object.values(pluginFlatTranslations)) {
         const currentLocaleValue = this.currentLocale.value;
         const val =
-          pluginMap[currentLocaleValue]?.[key] ?? pluginMap["en-US"]?.[key] ?? pluginMap["zh-CN"]?.[key];
+          pluginMap[currentLocaleValue]?.[key] ??
+          pluginMap["en-US"]?.[key] ??
+          pluginMap["zh-CN"]?.[key];
         if (val !== undefined) {
           resolved = val;
           break;
@@ -336,7 +418,10 @@ class I18n {
   }
 
   getLocaleMetadata(locale: string): LocaleMetadata | undefined {
-    return builtInLocaleMetadata[locale] ?? (pluginLocaleNames[locale] ? { language: pluginLocaleNames[locale] } : undefined);
+    return (
+      builtInLocaleMetadata[locale] ??
+      (pluginLocaleNames[locale] ? { language: pluginLocaleNames[locale] } : undefined)
+    );
   }
 
   getLocaleDisplayName(locale: string): string | undefined {

--- a/frontend/src/stores/homeServerActionsStore.ts
+++ b/frontend/src/stores/homeServerActionsStore.ts
@@ -7,6 +7,21 @@ import { useServerStore } from "@stores/serverStore";
 import { i18n } from "@language";
 import type { ServerInstance } from "@type/server";
 
+function getHomeServerStatusText(status: string | undefined): string {
+  switch (status) {
+    case "Running":
+      return i18n.t("home.running");
+    case "Starting":
+      return i18n.t("home.starting");
+    case "Stopping":
+      return i18n.t("home.stopping");
+    case "Error":
+      return i18n.t("home.error");
+    default:
+      return i18n.t("home.stopped");
+  }
+}
+
 export const useHomeServerActionsStore = defineStore("homeServerActions", () => {
   const actionLoading = ref<Record<string, boolean>>({});
   const actionError = ref<string | null>(null);
@@ -224,21 +239,6 @@ export const useHomeServerActionsStore = defineStore("homeServerActions", () => 
     }
   }
 
-  function getStatusText(status: string | undefined): string {
-    switch (status) {
-      case "Running":
-        return i18n.t("home.running");
-      case "Starting":
-        return i18n.t("home.starting");
-      case "Stopping":
-        return i18n.t("home.stopping");
-      case "Error":
-        return i18n.t("home.error");
-      default:
-        return i18n.t("home.stopped");
-    }
-  }
-
   return {
     actionLoading,
     actionError,
@@ -268,6 +268,6 @@ export const useHomeServerActionsStore = defineStore("homeServerActions", () => 
     selectNewPath,
     validateNewPath,
     confirmChangePath,
-    getStatusText,
+    getStatusText: getHomeServerStatusText,
   };
 });

--- a/frontend/src/stores/i18nStore.ts
+++ b/frontend/src/stores/i18nStore.ts
@@ -13,6 +13,33 @@ import { tryLoadLocaleBundle } from "@composables/useI18nBundles";
 import { useSettingsStore } from "@stores/settingsStore";
 import { normalizeAppError, resolveErrorMessage } from "@utils/appError";
 
+async function ensureLocaleReady(nextLocale: string): Promise<boolean> {
+  if (!i18n.isSupportedLocale(nextLocale)) {
+    return false;
+  }
+
+  const bundleLoaded = await tryLoadLocaleBundle(nextLocale);
+  if (bundleLoaded) {
+    return true;
+  }
+
+  return ensureLocaleLoaded(nextLocale as LocaleCode);
+}
+
+async function downloadLocale(localeCode: string) {
+  if (!i18n.isSupportedLocale(localeCode)) return;
+  try {
+    const data = await fetchLocale(localeCode as LocaleCode);
+    if (data && typeof data === "object" && !("sealantern" in data)) {
+      setLocaleBundle(localeCode, data as Record<string, string>);
+    } else {
+      setTranslations(localeCode as LocaleCode, data as any);
+    }
+  } catch (error) {
+    console.error("Failed to load locale:", localeCode, error);
+  }
+}
+
 export const useI18nStore = defineStore("i18n", () => {
   const localeRef = i18n.getLocaleRef();
   const supportedLocales = i18n.getAvailableLocales();
@@ -30,19 +57,6 @@ export const useI18nStore = defineStore("i18n", () => {
       label: i18n.getLocaleDisplayName(code) ?? code,
     })),
   );
-  async function ensureLocaleReady(nextLocale: string): Promise<boolean> {
-    if (!i18n.isSupportedLocale(nextLocale)) {
-      return false;
-    }
-
-    const bundleLoaded = await tryLoadLocaleBundle(nextLocale);
-    if (bundleLoaded) {
-      return true;
-    }
-
-    return ensureLocaleLoaded(nextLocale as LocaleCode);
-  }
-
   async function setLocale(nextLocale: string) {
     const localeReady = await ensureLocaleReady(nextLocale);
     if (!localeReady) {
@@ -64,20 +78,6 @@ export const useI18nStore = defineStore("i18n", () => {
     }
 
     return true;
-  }
-
-  async function downloadLocale(localeCode: string) {
-    if (!i18n.isSupportedLocale(localeCode)) return;
-    try {
-      const data = await fetchLocale(localeCode as LocaleCode);
-      if (data && typeof data === "object" && !("sealantern" in data)) {
-        setLocaleBundle(localeCode, data as Record<string, string>);
-      } else {
-        setTranslations(localeCode as LocaleCode, data as any);
-      }
-    } catch (e) {
-      console.error("Failed to load locale:", localeCode, e);
-    }
   }
 
   function toggleLocale() {

--- a/frontend/src/stores/serverStore.ts
+++ b/frontend/src/stores/serverStore.ts
@@ -6,6 +6,23 @@ import { useAsyncByKey, useLoading } from "@composables/useAsync";
 import type { ServerInstance } from "@type/server";
 import type { ServerStatusInfo } from "@api/server";
 
+async function scanServerPort(server: ServerInstance) {
+  try {
+    const serverPath = server.path;
+    if (!serverPath) return;
+
+    const data = await configApi.readServerProperties(serverPath);
+    if (data.raw && data.raw["server-port"]) {
+      const port = parseInt(data.raw["server-port"]);
+      if (!isNaN(port)) {
+        server.port = port;
+      }
+    }
+  } catch (error) {
+    console.warn(`Failed to scan port for server ${server.id}:`, error);
+  }
+}
+
 /**
  * 服务器状态管理 Store
  * 管理服务器列表、当前选择、状态等
@@ -64,25 +81,6 @@ export const useServerStore = defineStore("server", () => {
   /**
    * 扫描单个服务器的端口信息
    */
-  async function scanServerPort(server: ServerInstance) {
-    try {
-      // 使用 configApi 读取 server.properties 文件
-      const serverPath = server.path;
-      if (!serverPath) return;
-
-      // 读取 server.properties 文件
-      const data = await configApi.readServerProperties(serverPath);
-      if (data.raw && data.raw["server-port"]) {
-        const port = parseInt(data.raw["server-port"]);
-        if (!isNaN(port)) {
-          server.port = port;
-        }
-      }
-    } catch (e) {
-      console.warn(`Failed to scan port for server ${server.id}:`, e);
-    }
-  }
-
   /**
    * 刷新指定服务器的状态
    */

--- a/frontend/src/stores/settingsStore.ts
+++ b/frontend/src/stores/settingsStore.ts
@@ -41,6 +41,31 @@ function saveThemeCache(theme: string, fontSize: number): void {
   } catch (e) {}
 }
 
+function cloneSettingsSnapshot(source: AppSettings): AppSettings {
+  const plainSource = toRaw(source) as AppSettings;
+
+  if (typeof structuredClone === "function") {
+    try {
+      return structuredClone(plainSource);
+    } catch (error) {
+      console.warn("Failed to structuredClone settings, falling back to JSON clone.", error);
+    }
+  }
+  return JSON.parse(JSON.stringify(plainSource)) as AppSettings;
+}
+
+async function exportSettingsJson(): Promise<string> {
+  return settingsApi.exportJson();
+}
+
+async function getPersonalizationPackageSuggestedName(): Promise<string> {
+  return settingsApi.getPersonalizationPackageSuggestedName();
+}
+
+async function exportPersonalizationPackage(path: string): Promise<void> {
+  return settingsApi.exportPersonalizationPackage(path);
+}
+
 export function getInitialTheme(): string {
   const cache = getThemeCache();
   if (cache && cache.theme) {
@@ -133,16 +158,7 @@ export const useSettingsStore = defineStore("settings", () => {
   const backgroundSize = computed(() => settings.value.background_size);
 
   function cloneSettings(source: AppSettings = settings.value): AppSettings {
-    const plainSource = toRaw(source) as AppSettings;
-
-    if (typeof structuredClone === "function") {
-      try {
-        return structuredClone(plainSource);
-      } catch (error) {
-        console.warn("Failed to structuredClone settings, falling back to JSON clone.", error);
-      }
-    }
-    return JSON.parse(JSON.stringify(plainSource)) as AppSettings;
+    return cloneSettingsSnapshot(source);
   }
 
   function syncSettings(nextSettings: AppSettings): void {
@@ -284,18 +300,6 @@ export const useSettingsStore = defineStore("settings", () => {
   ): Promise<AppSettings> {
     const importedSettings = await settingsApi.importJson(json);
     return replaceSettings(importedSettings, changedGroups);
-  }
-
-  async function exportSettingsJson(): Promise<string> {
-    return settingsApi.exportJson();
-  }
-
-  async function getPersonalizationPackageSuggestedName(): Promise<string> {
-    return settingsApi.getPersonalizationPackageSuggestedName();
-  }
-
-  async function exportPersonalizationPackage(path: string): Promise<void> {
-    return settingsApi.exportPersonalizationPackage(path);
   }
 
   async function importPersonalizationPackage(path: string): Promise<ImportPersonalizationResult> {

--- a/frontend/src/utils/quoteUtils.ts
+++ b/frontend/src/utils/quoteUtils.ts
@@ -114,6 +114,15 @@ function shouldCacheQuote(quote: Quote): boolean {
   return !isCurrentQuote(quote) && !isQuoteInCache(quote);
 }
 
+async function requestUniqueHitokoto(remainingRetries: number): Promise<Quote> {
+  const quote = await requestHitokoto();
+  if (!isCurrentQuote(quote) || remainingRetries <= 0) {
+    return quote;
+  }
+
+  return requestUniqueHitokoto(remainingRetries - 1);
+}
+
 /**
  * 获取一句名言/引用
  * @returns 名言/引用对象
@@ -146,12 +155,7 @@ async function fetchHitokoto(): Promise<Quote> {
   }
 
   try {
-    let quote = await requestHitokoto();
-    let retryCount = 0;
-    while (isCurrentQuote(quote) && retryCount < 3) {
-      quote = await requestHitokoto();
-      retryCount++;
-    }
+    const quote = await requestUniqueHitokoto(3);
     void replenishCache();
     return quote;
   } catch (error) {

--- a/frontend/src/utils/serverExtensionSupport.ts
+++ b/frontend/src/utils/serverExtensionSupport.ts
@@ -1,0 +1,59 @@
+import type { ServerInstance } from "@type/server";
+import { formatServerCoreTypeLabel } from "@utils/serverCoreLabel";
+
+const LEGACY_CORE_TYPE_ALIASES: Record<string, string> = {
+  banner: "fabric",
+  "arclight-fabric": "fabric",
+  pufferfish_purpur: "pufferfish",
+  "vanilla-snapshot": "vanilla",
+  nukkitx: "nukkit",
+  bedrock: "bds",
+  leaf: "leaves",
+  spongevanilla: "sponge",
+  spongeforge: "forge",
+};
+
+const PLUGIN_SUPPORTED_CORE_TYPES = new Set([
+  "allay",
+  "arclight",
+  "arclight-forge",
+  "arclight-neoforge",
+  "bdsx",
+  "bukkit",
+  "bungeecord",
+  "catserver",
+  "endstone",
+  "flamecord",
+  "folia",
+  "glowstone",
+  "leaves",
+  "levilamina",
+  "lightfall",
+  "minestom",
+  "mohist",
+  "nukkit",
+  "paper",
+  "pocketmine",
+  "powernukkitx",
+  "pufferfish",
+  "purpur",
+  "sponge",
+  "spigot",
+  "travertine",
+  "tuinity",
+  "velocity",
+  "waterfall",
+]);
+
+function normalizeServerCoreTypeKey(coreType: string): string {
+  const normalized = coreType.trim().toLowerCase();
+  return LEGACY_CORE_TYPE_ALIASES[normalized] ?? normalized;
+}
+
+export function serverSupportsPluginExtensions(server: ServerInstance): boolean {
+  return PLUGIN_SUPPORTED_CORE_TYPES.has(normalizeServerCoreTypeKey(server.core_type));
+}
+
+export function getPluginUnsupportedReason(server: ServerInstance): string {
+  return `当前服务端类型 ${formatServerCoreTypeLabel(server.core_type)} 不支持插件式扩展`;
+}

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { defineAsyncComponent } from "vue";
 import { useRoute } from "vue-router";
 import SLButton from "@components/common/SLButton.vue";
 import SLModal from "@components/common/SLModal.vue";
@@ -7,14 +8,16 @@ import SLTooltip from "@components/common/SLTooltip.vue";
 import { SLTabBar } from "@components/common";
 import { i18n } from "@language";
 import { FileDiff } from "@lucide/vue";
-
-import ConfigSourceDiffView from "@components/config/ConfigSourceDiffView.vue";
 import ConfigPluginsSection from "@components/config/ConfigPluginsSection.vue";
 import ConfigPropertiesSection from "@components/config/ConfigPropertiesSection.vue";
 import ConfigStartupSection from "@components/config/ConfigStartupSection.vue";
 import { useConfigViewModel } from "@views/config/useConfigViewModel";
 import "@styles/plugin-list.css";
 import "@styles/views/ConfigView.css";
+
+const ConfigSourceDiffView = defineAsyncComponent(
+  () => import("@components/config/ConfigSourceDiffView.vue"),
+);
 
 const route = useRoute();
 const viewModel = useConfigViewModel({ route });
@@ -112,6 +115,8 @@ const setError = viewModel.setError;
         <ConfigPluginsSection
           :plugins="pluginsState.plugins.value"
           :pluginsLoading="pluginsState.pluginsLoading.value"
+          :pluginsSupported="pluginsState.pluginsSupported.value"
+          :pluginsUnsupportedReason="pluginsState.pluginsUnsupportedReason.value"
           :selectedPlugin="pluginsState.selectedPlugin.value"
           @refreshList="pluginsState.loadPlugins"
           @reloadPlugins="pluginsState.reloadPlugins"

--- a/frontend/src/views/ConsoleView.vue
+++ b/frontend/src/views/ConsoleView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  defineAsyncComponent,
   ref,
   onMounted,
   onUnmounted,
@@ -15,7 +16,6 @@ import SLConfirmDialog from "@components/common/SLConfirmDialog.vue";
 import SLStatusIndicator from "@components/common/SLStatusIndicator.vue";
 import ConsoleInput from "@components/console/ConsoleInput.vue";
 import CommandModal from "@components/console/CommandModal.vue";
-import ConsoleOutput from "@components/console/ConsoleOutput.vue";
 import { useConsoleDisplaySettings } from "@composables/useConsoleDisplaySettings";
 import { useConsoleLogStream } from "@views/useConsoleLogStream";
 import { useConsoleServerStats } from "@views/useConsoleServerStats";
@@ -36,6 +36,8 @@ interface ConsoleOutputExpose {
   clear: () => void;
   getAllPlainText: () => string;
 }
+
+const ConsoleOutput = defineAsyncComponent(() => import("@components/console/ConsoleOutput.vue"));
 
 const commandInput = ref("");
 const consoleOutputRef = ref<ConsoleOutputExpose | null>(null);

--- a/frontend/src/views/PlayerView.vue
+++ b/frontend/src/views/PlayerView.vue
@@ -5,7 +5,13 @@ import { useSettingsStore } from "@stores/settingsStore";
 import { useRoute } from "vue-router";
 import { useConsoleStore } from "@stores/consoleStore";
 import { serverApi } from "@api/server";
-import { playerApi, type PlayerEntry, type BanEntry, type OpEntry, type ParsedPlayerLogEvent } from "@api/player";
+import {
+  playerApi,
+  type PlayerEntry,
+  type BanEntry,
+  type OpEntry,
+  type ParsedPlayerLogEvent,
+} from "@api/player";
 import { TIME, MESSAGES, getMessage } from "@utils/constants";
 import { validatePlayerName, handleError } from "@utils/errorHandler";
 import { i18n } from "@language";
@@ -54,9 +60,7 @@ const isRunning = computed(() => {
   return store.statuses[selectedServerId.value]?.status === "Running";
 });
 
-const onlinePlayers = computed(() =>
-  resolveOnlinePlayers(selectedServerId.value),
-);
+const onlinePlayers = computed(() => resolveOnlinePlayers(selectedServerId.value));
 
 function getAddLabel(): string {
   switch (activeTab.value) {
@@ -151,10 +155,13 @@ async function hydrateStructuredOnlinePlayers(serverId: string) {
     const events = await playerApi.parsePlayerLogEvents(logs);
     structuredOnlinePlayers.value[serverId] = replayOnlinePlayers(events);
     structuredPlayerEventSupport.value[serverId] = hasStructuredPlayerEvents(events);
-  } catch (error) {
+  } catch (caughtError) {
     structuredOnlinePlayers.value[serverId] = [];
     structuredPlayerEventSupport.value[serverId] = false;
-    console.warn("[PlayerView] structured player log hydration unavailable, falling back to legacy parsing", error);
+    console.warn(
+      "[PlayerView] structured player log hydration unavailable, falling back to legacy parsing",
+      caughtError,
+    );
   }
 }
 
@@ -172,8 +179,11 @@ async function startPlayerLogSubscription() {
     unlistenStructuredLog = await serverApi.onStructuredLogEvent((event) => {
       applyStructuredPlayerEvent(event);
     });
-  } catch (error) {
-    console.warn("[PlayerView] structured log stream unavailable, falling back to legacy parsing", error);
+  } catch (caughtError) {
+    console.warn(
+      "[PlayerView] structured log stream unavailable, falling back to legacy parsing",
+      caughtError,
+    );
   }
 }
 
@@ -204,7 +214,9 @@ function resolveOnlinePlayers(serverId: string): string[] {
 function isStructuredPlayerEventKind(
   eventKind: ParsedPlayerLogEvent["event_kind"] | ServerLogStructuredEvent["event_kind"],
 ): eventKind is "server_ready" | "player_join" | "player_leave" {
-  return eventKind === "server_ready" || eventKind === "player_join" || eventKind === "player_leave";
+  return (
+    eventKind === "server_ready" || eventKind === "player_join" || eventKind === "player_leave"
+  );
 }
 
 function hasStructuredPlayerEvents(events: ParsedPlayerLogEvent[]): boolean {

--- a/frontend/src/views/config/useConfigPluginSelection.ts
+++ b/frontend/src/views/config/useConfigPluginSelection.ts
@@ -14,6 +14,10 @@ function shouldLoadConfigFiles(plugin: m_PluginInfo) {
 export function useConfigPluginSelection(options: UseConfigPluginSelectionOptions) {
   const selectedPlugin = ref<m_PluginInfo | null>(null);
 
+  function clearSelection() {
+    selectedPlugin.value = null;
+  }
+
   function clearSelectedPlugin(pluginFileName: string) {
     if (selectedPlugin.value?.file_name === pluginFileName) {
       selectedPlugin.value = null;
@@ -75,6 +79,7 @@ export function useConfigPluginSelection(options: UseConfigPluginSelectionOption
 
   return {
     selectedPlugin,
+    clearSelection,
     clearSelectedPlugin,
     handlePluginClick,
   };

--- a/frontend/src/views/config/useConfigPlugins.ts
+++ b/frontend/src/views/config/useConfigPlugins.ts
@@ -3,6 +3,10 @@ import { m_pluginApi, type m_PluginConfigFile, type m_PluginInfo } from "@api/mc
 import { systemApi } from "@api/system";
 import { i18n } from "@language";
 import type { ServerInstance } from "@type/server";
+import {
+  getPluginUnsupportedReason,
+  serverSupportsPluginExtensions,
+} from "@utils/serverExtensionSupport";
 import { useConfigPluginSelection } from "@views/config/useConfigPluginSelection";
 
 interface UseConfigPluginsOptions {
@@ -20,6 +24,8 @@ function formatFileSize(bytes: number) {
 export function useConfigPlugins(options: UseConfigPluginsOptions) {
   const plugins = ref<m_PluginInfo[]>([]);
   const pluginsLoading = ref(false);
+  const pluginsSupported = ref(true);
+  const pluginsUnsupportedReason = ref<string | null>(null);
   const pluginRowElements = ref<Map<string, HTMLElement>>(new Map());
   const selection = useConfigPluginSelection({
     currentServerId: options.currentServerId,
@@ -33,8 +39,30 @@ export function useConfigPlugins(options: UseConfigPluginsOptions) {
     pluginRowElements.value.delete(pluginFileName);
   }
 
+  function syncPluginSupportState() {
+    const server = options.getCurrentServer();
+    if (!server) {
+      pluginsSupported.value = true;
+      pluginsUnsupportedReason.value = null;
+      return true;
+    }
+
+    const supported = serverSupportsPluginExtensions(server);
+    pluginsSupported.value = supported;
+    pluginsUnsupportedReason.value = supported ? null : getPluginUnsupportedReason(server);
+    if (!supported) {
+      plugins.value = [];
+      selection.clearSelection();
+    }
+    return supported;
+  }
+
   async function loadPlugins() {
     if (!options.currentServerId.value) return;
+    if (!syncPluginSupportState()) {
+      options.setError(null);
+      return;
+    }
 
     pluginsLoading.value = true;
     options.setError(null);
@@ -62,6 +90,7 @@ export function useConfigPlugins(options: UseConfigPluginsOptions) {
 
   async function togglePlugin(plugin: m_PluginInfo) {
     if (!options.currentServerId.value) return;
+    if (!syncPluginSupportState()) return;
 
     if (!plugin.file_name.endsWith(".jar") && !plugin.file_name.endsWith(".jar.disabled")) {
       alert(i18n.t("config.not_jar_file", { file: plugin.file_name }));
@@ -83,6 +112,7 @@ export function useConfigPlugins(options: UseConfigPluginsOptions) {
   async function deletePlugin(plugin: m_PluginInfo) {
     const activeServerId = options.currentServerId.value;
     if (!activeServerId) return;
+    if (!syncPluginSupportState()) return;
 
     try {
       const pluginElement = pluginRowElements.value.get(plugin.file_name);
@@ -109,6 +139,7 @@ export function useConfigPlugins(options: UseConfigPluginsOptions) {
 
   async function reloadPlugins() {
     if (!options.currentServerId.value) return;
+    if (!syncPluginSupportState()) return;
     try {
       await m_pluginApi.m_reloadPlugins(options.currentServerId.value);
       await loadPlugins();
@@ -120,6 +151,7 @@ export function useConfigPlugins(options: UseConfigPluginsOptions) {
   async function openPluginFolder(plugin: m_PluginInfo) {
     const server = options.getCurrentServer();
     if (!server) return;
+    if (!syncPluginSupportState()) return;
 
     const basePath = server.path.replace(/[/\\]$/, "");
     const separator = basePath.includes("\\") ? "\\" : "/";
@@ -143,6 +175,8 @@ export function useConfigPlugins(options: UseConfigPluginsOptions) {
   return {
     plugins,
     pluginsLoading,
+    pluginsSupported,
+    pluginsUnsupportedReason,
     selectedPlugin: selection.selectedPlugin,
     loadPlugins,
     reloadPlugins,

--- a/frontend/src/views/config/useConfigPropertiesEditor.ts
+++ b/frontend/src/views/config/useConfigPropertiesEditor.ts
@@ -39,6 +39,12 @@ interface UseConfigPropertiesEditorOptions {
   updateCurrentServerPort: (port: string) => void;
 }
 
+function getTranslatedPropertyDescription(key: string) {
+  const translationKey = `config.properties.${key}`;
+  const translated = i18n.t(translationKey);
+  return translated === translationKey ? "" : translated;
+}
+
 export function useConfigPropertiesEditor(options: UseConfigPropertiesEditorOptions) {
   const entries = ref<ConfigEntryType[]>([]);
   const editValues = ref<Record<string, string>>({});
@@ -136,12 +142,6 @@ export function useConfigPropertiesEditor(options: UseConfigPropertiesEditorOpti
 
   function bindCompareContext(context: CompareContext) {
     compareContext.value = context;
-  }
-
-  function getTranslatedPropertyDescription(key: string) {
-    const translationKey = `config.properties.${key}`;
-    const translated = i18n.t(translationKey);
-    return translated === translationKey ? "" : translated;
   }
 
   async function applyParsedSourceState(

--- a/frontend/src/views/config/useConfigPropertiesModeSwitch.ts
+++ b/frontend/src/views/config/useConfigPropertiesModeSwitch.ts
@@ -22,6 +22,10 @@ interface UseConfigPropertiesModeSwitchOptions {
   getCompareContext: () => ModeSwitchCompareContext | null;
 }
 
+function parseSourceToVisualState(sourceText: string) {
+  return configApi.parseServerPropertiesSource(sourceText);
+}
+
 export function useConfigPropertiesModeSwitch(options: UseConfigPropertiesModeSwitchOptions) {
   const modeSwitching = ref(false);
   const visualDraftDirty = ref(false);
@@ -32,11 +36,6 @@ export function useConfigPropertiesModeSwitch(options: UseConfigPropertiesModeSw
 
   function clearSourceParseError() {
     options.sourceParseError.value = null;
-  }
-
-  function applyParsedSourceToVisualState(sourceText: string) {
-    const parsed = configApi.parseServerPropertiesSource(sourceText);
-    return parsed;
   }
 
   async function handleEditorModeChange(mode: string | null) {
@@ -69,7 +68,7 @@ export function useConfigPropertiesModeSwitch(options: UseConfigPropertiesModeSw
         return null;
       }
 
-      const parsed = await applyParsedSourceToVisualState(options.sourceDraftText.value);
+      const parsed = await parseSourceToVisualState(options.sourceDraftText.value);
       const compareContext = options.getCompareContext();
       if (compareContext?.compareMode.value) {
         await compareContext.applyCompareTargetSourceDraftToVisualState(

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -45,6 +45,12 @@ export default defineConfig({
             if (id.includes("@tauri-apps")) {
               return "tauri-vendor";
             }
+            if (id.includes("@xterm/") || id.includes("xterm")) {
+              return "xterm-vendor";
+            }
+            if (id.includes("@codemirror/") || id.includes("@lezer/")) {
+              return "codemirror-vendor";
+            }
             if (id.includes("echarts") || id.includes("vue-echarts")) {
               return "echarts-vendor";
             }


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

<!-- 一句话概括本次变更 -->

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #`填写 Issue 编号`

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Sourcery 总结

在 Tauri 模式下改进前端 i18n 加载和插件配置支持，同时重构共享工具函数并对大型组件进行按需加载。

新功能：
- 基于 core-type 增加插件扩展支持检测，并在不支持时向用户显示提示信息。
- 为内置语言包增加异步且去重的加载机制，并默认预加载 `zh-CN`。
- 对大型配置和控制台组件进行懒加载，以提升首屏加载性能。

缺陷修复：
- 通过集中化流解析并改进错误处理，修复 Tauri 模式下结构化日志 SSE 的处理问题。
- 解决语言包重复加载或缺失的问题，并在切换语言时确保语言环境已就绪。
- 确保插件列表和启用/禁用操作遵循服务端的插件支持能力。
- 通过在多个视图间抽取共享辅助函数，避免重复或不一致的检测逻辑。
- 修复前端 i18n 检查/同步脚本在现代 Node 环境中的兼容性及排序一致性问题。

增强优化：
- 将多个工具函数从 composables 和 stores 中抽离，便于复用并提升代码清晰度。
- 在不改变行为的前提下，改进开发者工具过滤逻辑和系统运行时长格式化逻辑。
- 规范插件权限和配置属性描述的翻译回退策略。
- 改进播放器视图中结构化日志的回退行为和日志可读性。
- 清理部分 UI 模板和计算属性，以提升可读性和一致性。

构建：
- 调整 Vite 分包策略，将 xterm 和 CodeMirror 相关依赖拆分为独立 bundle。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve frontend i18n loading and plugin configuration support in Tauri mode while refactoring shared utilities and lazy-loading heavy components.

New Features:
- Add core-type based detection of plugin extension support with user-visible messaging when unsupported.
- Add async, deduplicated loading for built-in locale groups with default zh-CN preload.
- Lazy-load large configuration and console components to improve initial load performance.

Bug Fixes:
- Fix structured log SSE handling in Tauri mode by centralizing stream parsing and improving error handling.
- Address duplicate or missing locale loading and ensure locale readiness when switching languages.
- Ensure plugin listing and toggling operations respect server plugin support capabilities.
- Prevent repeated or inconsistent detection logic by extracting shared helper functions across views.
- Fix frontend i18n check/sync scripts for modern Node environments and consistent ordering.

Enhancements:
- Refactor multiple utility functions out of composables and stores for reuse and clarity.
- Improve developer tools filtering and system uptime formatting logic without changing behavior.
- Standardize translation lookup fallbacks for plugin permissions and config property descriptions.
- Improve player view structured log fallback behavior and logging clarity.
- Tidy various UI templates and computed properties for readability and consistency.

Build:
- Adjust Vite chunking to split xterm and CodeMirror vendors into dedicated bundles.

</details>