### PR TITLE
fix: 修复不需要 Java 的服务端也强制要求 Java 的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6221,6 +6221,8 @@ dependencies = [
  "regex",
  "sea-lantern-runtime",
  "sea-lantern-server-installer-core",
+ "serde",
+ "serde_json",
  "shlex",
  "sl-server-core-taxonomy",
  "tempfile",

--- a/backend/server-local-setup-core/Cargo.toml
+++ b/backend/server-local-setup-core/Cargo.toml
@@ -17,6 +17,8 @@ path = "tests/core_local_paths.rs"
 encoding_rs = "0.8"
 once_cell = "1"
 regex = "1.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 sea_lantern_runtime = { package = "sea-lantern-runtime", path = "../runtime-core" }
 sea_lantern_server_installer_core = { package = "sea-lantern-server-installer-core", path = "../server-installer-core" }
 shlex = "1.3.0"

--- a/backend/server-local-setup-core/src/lib.rs
+++ b/backend/server-local-setup-core/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -8,10 +9,22 @@ use sea_lantern_server_installer_core::{
     detect_core_key, detect_core_key_checked, find_server_jar, find_server_jar_checked,
     parse_server_core_key, CoreType,
 };
+use serde::Deserialize;
 
 static MC_VERSION_PATTERN: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?i)(1\.\d{1,2}(?:\.\d{1,2})?)").expect("mc version regex should compile")
 });
+
+static STARTUP_MODE_METADATA: Lazy<HashMap<String, StartupModeMetadata>> = Lazy::new(|| {
+    serde_json::from_str(include_str!("../../../shared/startup-modes.json"))
+        .expect("shared startup mode metadata should be valid json")
+});
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct StartupModeMetadata {
+    requires_java: bool,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LocalFolderInspection {
@@ -997,12 +1010,14 @@ pub fn startup_mode_is_starter(startup_mode: &str) -> bool {
 }
 
 pub fn startup_mode_requires_java(startup_mode: &str) -> bool {
-    matches!(
-        normalize_cli_startup_mode(Some(startup_mode))
-            .unwrap_or_else(|_| "jar".to_string())
-            .as_str(),
-        "jar" | "starter"
-    )
+    let normalized_mode =
+        normalize_cli_startup_mode(Some(startup_mode)).unwrap_or_else(|_| "jar".to_string());
+
+    STARTUP_MODE_METADATA
+        .get(normalized_mode.as_str())
+        .or_else(|| STARTUP_MODE_METADATA.get("jar"))
+        .map(|metadata| metadata.requires_java)
+        .unwrap_or(true)
 }
 
 pub fn startup_mode_uses_windows_script_encoding_detection(startup_mode: &str) -> bool {

--- a/backend/server-local-setup-core/src/lib.rs
+++ b/backend/server-local-setup-core/src/lib.rs
@@ -996,6 +996,15 @@ pub fn startup_mode_is_starter(startup_mode: &str) -> bool {
         == "starter"
 }
 
+pub fn startup_mode_requires_java(startup_mode: &str) -> bool {
+    matches!(
+        normalize_cli_startup_mode(Some(startup_mode))
+            .unwrap_or_else(|_| "jar".to_string())
+            .as_str(),
+        "jar" | "starter"
+    )
+}
+
 pub fn startup_mode_uses_windows_script_encoding_detection(startup_mode: &str) -> bool {
     matches!(
         normalize_cli_startup_mode(Some(startup_mode))
@@ -1372,6 +1381,18 @@ pub fn build_windows_java_env_prefix(java_home_dir_str: &str, java_bin_dir_str: 
 }
 
 #[cfg(target_os = "windows")]
+pub fn build_windows_bat_command_text_without_java(
+    startup_filename: &str,
+    cmd_code_page: &str,
+) -> String {
+    format!(
+        "chcp {}>nul & call \"{}\" nogui",
+        cmd_code_page,
+        escape_windows_cmd_arg(startup_filename)
+    )
+}
+
+#[cfg(target_os = "windows")]
 pub fn build_windows_bat_command_text(
     startup_filename: &str,
     cmd_code_page: &str,
@@ -1505,7 +1526,7 @@ mod tests {
         resolve_local_startup_entry_checked, resolve_modpack_run_dir_startup_selection,
         resolve_modpack_startup_selection, resolve_run_dir_startup_file_path,
         resolve_starter_install_launch_selection, script_bytes_prefer_utf8, startup_filename,
-        startup_mode_is_custom, startup_mode_is_starter,
+        startup_mode_is_custom, startup_mode_is_starter, startup_mode_requires_java,
         startup_mode_uses_windows_script_encoding_detection, trim_optional_text,
         validate_local_create_folder, validate_local_create_startup_exists,
         validate_local_create_startup_path_binding, windows_script_prefers_utf8,
@@ -1891,6 +1912,10 @@ mod tests {
         assert!(startup_mode_is_starter("starter"));
         assert!(startup_mode_is_starter("STARTER"));
         assert!(!startup_mode_is_starter("sh"));
+        assert!(startup_mode_requires_java("jar"));
+        assert!(startup_mode_requires_java("STARTER"));
+        assert!(!startup_mode_requires_java("bat"));
+        assert!(!startup_mode_requires_java("custom"));
         assert!(startup_mode_uses_windows_script_encoding_detection("bat"));
         assert!(startup_mode_uses_windows_script_encoding_detection("PS1"));
         assert!(!startup_mode_uses_windows_script_encoding_detection("sh"));

--- a/backend/tauri-host/src/services/server/manager/runtime_start.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start.rs
@@ -38,6 +38,18 @@ pub(crate) fn get_local_launch_detail(
     local_launch_detail::build_local_launch_detail(server, settings)
 }
 
+pub(in crate::services::server::manager::runtime_start) fn resolve_launch_java_dirs(
+    startup_mode: StartupMode,
+    java_path: &str,
+) -> Result<(Option<String>, Option<String>), String> {
+    if startup_mode_requires_java(startup_mode.as_str()) || !java_path.trim().is_empty() {
+        let (java_bin_dir_str, java_home_dir_str) = resolve_java_paths(java_path)?;
+        Ok((Some(java_bin_dir_str), Some(java_home_dir_str)))
+    } else {
+        Ok((None, None))
+    }
+}
+
 pub(crate) fn start_local_runtime(
     manager: &ServerManager,
     request: RuntimeStartRequest<'_>,
@@ -92,12 +104,8 @@ pub(crate) fn start_local_runtime(
     let startup_path_obj = std::path::Path::new(startup_path.as_str());
     let managed_console_encoding =
         resolve_managed_console_encoding(startup_mode.as_str(), startup_path_obj);
-    let (java_bin_dir_str, java_home_dir_str) = if startup_mode_requires_java(startup_mode.as_str())
-    {
-        resolve_java_paths(java_path.as_str())?
-    } else {
-        (String::new(), String::new())
-    };
+    let (java_bin_dir_str, java_home_dir_str) =
+        resolve_launch_java_dirs(startup_mode, java_path.as_str())?;
     let startup_filename = startup_filename(startup_path.as_str());
     let starter_core_key = launch::context::resolve_starter_core_key(server)?;
     let launch_context = launch::context::LaunchContext {

--- a/backend/tauri-host/src/services/server/manager/runtime_start.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start.rs
@@ -14,6 +14,7 @@ use crate::services::server::runtime::{
 };
 use sea_lantern_server_local_setup_core::{
     resolve_java_paths, resolve_managed_console_encoding, startup_filename,
+    startup_mode_requires_java,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -91,7 +92,12 @@ pub(crate) fn start_local_runtime(
     let startup_path_obj = std::path::Path::new(startup_path.as_str());
     let managed_console_encoding =
         resolve_managed_console_encoding(startup_mode.as_str(), startup_path_obj);
-    let (java_bin_dir_str, java_home_dir_str) = resolve_java_paths(java_path.as_str())?;
+    let (java_bin_dir_str, java_home_dir_str) = if startup_mode_requires_java(startup_mode.as_str())
+    {
+        resolve_java_paths(java_path.as_str())?
+    } else {
+        (String::new(), String::new())
+    };
     let startup_filename = startup_filename(startup_path.as_str());
     let starter_core_key = launch::context::resolve_starter_core_key(server)?;
     let launch_context = launch::context::LaunchContext {

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/command_builder.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/command_builder.rs
@@ -6,7 +6,7 @@ use super::script_launch_support;
 use crate::services::server::manager::common::StartupMode;
 use crate::services::server::manager::i18n::manager_t;
 use sea_lantern_server_local_setup_core::{
-    resolve_direct_jar_launch_target, resolve_local_preferred_jar_path,
+    resolve_direct_jar_launch_target, resolve_local_preferred_jar_path, startup_mode_requires_java,
 };
 use std::path::Path;
 use std::process::Command;
@@ -151,8 +151,16 @@ fn build_bat_command(context: &LaunchContext<'_>) -> Result<Command, String> {
         let bat_cmd = script_launch_support::build_windows_bat_command(
             &context.startup_filename,
             context.managed_console_encoding,
-            &context.java_home_dir_str,
-            &context.java_bin_dir_str,
+            if startup_mode_requires_java(context.startup_mode.as_str()) {
+                Some(context.java_home_dir_str.as_str())
+            } else {
+                None
+            },
+            if startup_mode_requires_java(context.startup_mode.as_str()) {
+                Some(context.java_bin_dir_str.as_str())
+            } else {
+                None
+            },
         );
         Ok(bat_cmd)
     }

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/command_builder.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/command_builder.rs
@@ -6,7 +6,7 @@ use super::script_launch_support;
 use crate::services::server::manager::common::StartupMode;
 use crate::services::server::manager::i18n::manager_t;
 use sea_lantern_server_local_setup_core::{
-    resolve_direct_jar_launch_target, resolve_local_preferred_jar_path, startup_mode_requires_java,
+    resolve_direct_jar_launch_target, resolve_local_preferred_jar_path,
 };
 use std::path::Path;
 use std::process::Command;
@@ -118,11 +118,13 @@ fn build_custom_command(context: &LaunchContext<'_>) -> Result<Command, String> 
     {
         let mut custom_cmd = build_windows_cmd_command(custom_command);
         if has_java_path {
-            script_launch_support::apply_java_process_env(
-                &mut custom_cmd,
-                &context.java_home_dir_str,
-                &context.java_bin_dir_str,
-            );
+            if let Some((java_home_dir_str, java_bin_dir_str)) = context.java_env() {
+                script_launch_support::apply_java_process_env(
+                    &mut custom_cmd,
+                    java_home_dir_str,
+                    java_bin_dir_str,
+                );
+            }
         }
         Ok(custom_cmd)
     }
@@ -132,11 +134,13 @@ fn build_custom_command(context: &LaunchContext<'_>) -> Result<Command, String> 
         custom_cmd.arg("-c");
         custom_cmd.arg(custom_command);
         if has_java_path {
-            script_launch_support::apply_java_process_env(
-                &mut custom_cmd,
-                &context.java_home_dir_str,
-                &context.java_bin_dir_str,
-            );
+            if let Some((java_home_dir_str, java_bin_dir_str)) = context.java_env() {
+                script_launch_support::apply_java_process_env(
+                    &mut custom_cmd,
+                    java_home_dir_str,
+                    java_bin_dir_str,
+                );
+            }
         }
         Ok(custom_cmd)
     }
@@ -148,19 +152,12 @@ fn build_bat_command(context: &LaunchContext<'_>) -> Result<Command, String> {
 
     #[cfg(target_os = "windows")]
     {
+        let java_env = context.java_env();
         let bat_cmd = script_launch_support::build_windows_bat_command(
             &context.startup_filename,
             context.managed_console_encoding,
-            if startup_mode_requires_java(context.startup_mode.as_str()) {
-                Some(context.java_home_dir_str.as_str())
-            } else {
-                None
-            },
-            if startup_mode_requires_java(context.startup_mode.as_str()) {
-                Some(context.java_bin_dir_str.as_str())
-            } else {
-                None
-            },
+            java_env.map(|(java_home_dir_str, _)| java_home_dir_str),
+            java_env.map(|(_, java_bin_dir_str)| java_bin_dir_str),
         );
         Ok(bat_cmd)
     }
@@ -295,8 +292,8 @@ mod tests {
             settings,
             startup_mode,
             managed_console_encoding: ManagedConsoleEncoding::Utf8,
-            java_bin_dir_str: "C:/Java/JDK 21/bin".to_string(),
-            java_home_dir_str: "C:/Java/JDK 21".to_string(),
+            java_bin_dir_str: Some("C:/Java/JDK 21/bin".to_string()),
+            java_home_dir_str: Some("C:/Java/JDK 21".to_string()),
             startup_filename: startup_filename.to_string(),
             starter_core_key: String::new(),
         }

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/context.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/context.rs
@@ -9,10 +9,18 @@ pub(in crate::services::server::manager::runtime_start) struct LaunchContext<'a>
     pub settings: &'a crate::models::settings::AppSettings,
     pub startup_mode: StartupMode,
     pub managed_console_encoding: ManagedConsoleEncoding,
-    pub java_bin_dir_str: String,
-    pub java_home_dir_str: String,
+    pub java_bin_dir_str: Option<String>,
+    pub java_home_dir_str: Option<String>,
     pub startup_filename: String,
     pub starter_core_key: String,
+}
+
+impl LaunchContext<'_> {
+    pub(in crate::services::server::manager::runtime_start) fn java_env(
+        &self,
+    ) -> Option<(&str, &str)> {
+        Some((self.java_home_dir_str.as_deref()?, self.java_bin_dir_str.as_deref()?))
+    }
 }
 
 pub(in crate::services::server::manager::runtime_start) fn resolve_starter_core_key(

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/runner.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/runner.rs
@@ -178,6 +178,9 @@ fn install_and_launch_starter(
             })?;
     let startup_mode = StartupMode::from_raw(&selection.startup_mode);
     let startup_filename = selection.startup_filename;
+    let (java_home_dir_str, java_bin_dir_str) = context
+        .java_env()
+        .expect("starter install launch script requires java env");
 
     let launch_phase = manager_t("server.manager.launch_phase_starter_script");
     let command = match startup_mode {
@@ -187,8 +190,8 @@ fn install_and_launch_starter(
                 super::script_launch_support::build_windows_bat_command(
                     &startup_filename,
                     context.managed_console_encoding,
-                    Some(context.java_home_dir_str.as_str()),
-                    Some(context.java_bin_dir_str.as_str()),
+                    Some(java_home_dir_str),
+                    Some(java_bin_dir_str),
                 )
             }
             #[cfg(not(target_os = "windows"))]
@@ -202,8 +205,8 @@ fn install_and_launch_starter(
             sh_cmd.arg("nogui");
             super::script_launch_support::apply_java_process_env(
                 &mut sh_cmd,
-                &context.java_home_dir_str,
-                &context.java_bin_dir_str,
+                java_home_dir_str,
+                java_bin_dir_str,
             );
             sh_cmd
         }
@@ -220,8 +223,8 @@ fn install_and_launch_starter(
                 ps_cmd.arg("nogui");
                 super::script_launch_support::apply_java_process_env(
                     &mut ps_cmd,
-                    &context.java_home_dir_str,
-                    &context.java_bin_dir_str,
+                    java_home_dir_str,
+                    java_bin_dir_str,
                 );
                 ps_cmd
             }

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/runner.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/runner.rs
@@ -187,8 +187,8 @@ fn install_and_launch_starter(
                 super::script_launch_support::build_windows_bat_command(
                     &startup_filename,
                     context.managed_console_encoding,
-                    &context.java_home_dir_str,
-                    &context.java_bin_dir_str,
+                    Some(context.java_home_dir_str.as_str()),
+                    Some(context.java_bin_dir_str.as_str()),
                 )
             }
             #[cfg(not(target_os = "windows"))]

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/script_launch_support.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/script_launch_support.rs
@@ -32,11 +32,9 @@ pub(super) fn prepare_script_startup(context: &LaunchContext<'_>) -> Result<(), 
 }
 
 pub(super) fn apply_script_process_env(cmd: &mut Command, context: &LaunchContext<'_>) {
-    if context.java_bin_dir_str.trim().is_empty() || context.java_home_dir_str.trim().is_empty() {
-        return;
+    if let Some((java_home_dir_str, java_bin_dir_str)) = context.java_env() {
+        apply_java_process_env(cmd, java_home_dir_str, java_bin_dir_str);
     }
-
-    apply_java_process_env(cmd, &context.java_home_dir_str, &context.java_bin_dir_str);
 }
 
 #[cfg(target_os = "windows")]

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/script_launch_support.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/script_launch_support.rs
@@ -5,10 +5,11 @@ use super::context::LaunchContext;
 #[cfg(target_os = "windows")]
 use sea_lantern_server_local_setup_core::build_windows_bat_command_text as build_shared_windows_bat_command_text;
 #[cfg(target_os = "windows")]
+use sea_lantern_server_local_setup_core::build_windows_bat_command_text_without_java as build_shared_windows_bat_command_text_without_java;
+#[cfg(target_os = "windows")]
 use sea_lantern_server_local_setup_core::ManagedConsoleEncoding;
 use sea_lantern_server_local_setup_core::{
     build_java_launch_path_value as build_shared_java_launch_path_value,
-    build_windows_bat_command_text_without_java as build_shared_windows_bat_command_text_without_java,
     detect_java_major_version as detect_shared_java_major_version,
     ensure_supported_script_java_major_version, startup_mode_requires_java,
 };
@@ -81,10 +82,9 @@ pub(super) fn apply_java_process_env(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        apply_java_process_env, build_windows_bat_command,
-        ensure_supported_script_java_major_version,
-    };
+    use super::{apply_java_process_env, ensure_supported_script_java_major_version};
+    #[cfg(target_os = "windows")]
+    use super::build_windows_bat_command;
     use sea_lantern_server_local_setup_core::prepend_path_entry;
     #[cfg(target_os = "windows")]
     use sea_lantern_server_local_setup_core::{

--- a/backend/tauri-host/src/services/server/manager/runtime_start/launch/script_launch_support.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/launch/script_launch_support.rs
@@ -8,12 +8,17 @@ use sea_lantern_server_local_setup_core::build_windows_bat_command_text as build
 use sea_lantern_server_local_setup_core::ManagedConsoleEncoding;
 use sea_lantern_server_local_setup_core::{
     build_java_launch_path_value as build_shared_java_launch_path_value,
+    build_windows_bat_command_text_without_java as build_shared_windows_bat_command_text_without_java,
     detect_java_major_version as detect_shared_java_major_version,
-    ensure_supported_script_java_major_version,
+    ensure_supported_script_java_major_version, startup_mode_requires_java,
 };
 use std::process::Command;
 
 pub(super) fn prepare_script_startup(context: &LaunchContext<'_>) -> Result<(), String> {
+    if !startup_mode_requires_java(context.startup_mode.as_str()) {
+        return Ok(());
+    }
+
     let java_path = context
         .server
         .java_path()
@@ -27,6 +32,10 @@ pub(super) fn prepare_script_startup(context: &LaunchContext<'_>) -> Result<(), 
 }
 
 pub(super) fn apply_script_process_env(cmd: &mut Command, context: &LaunchContext<'_>) {
+    if context.java_bin_dir_str.trim().is_empty() || context.java_home_dir_str.trim().is_empty() {
+        return;
+    }
+
     apply_java_process_env(cmd, &context.java_home_dir_str, &context.java_bin_dir_str);
 }
 
@@ -34,15 +43,27 @@ pub(super) fn apply_script_process_env(cmd: &mut Command, context: &LaunchContex
 pub(super) fn build_windows_bat_command(
     startup_filename: &str,
     managed_console_encoding: ManagedConsoleEncoding,
-    java_home_dir_str: &str,
-    java_bin_dir_str: &str,
+    java_home_dir_str: Option<&str>,
+    java_bin_dir_str: Option<&str>,
 ) -> Command {
-    build_windows_cmd_command(&build_shared_windows_bat_command_text(
-        startup_filename,
-        managed_console_encoding.cmd_code_page(),
-        java_home_dir_str,
-        java_bin_dir_str,
-    ))
+    let command_text = match (java_home_dir_str, java_bin_dir_str) {
+        (Some(java_home), Some(java_bin))
+            if !java_home.trim().is_empty() && !java_bin.trim().is_empty() =>
+        {
+            build_shared_windows_bat_command_text(
+                startup_filename,
+                managed_console_encoding.cmd_code_page(),
+                java_home,
+                java_bin,
+            )
+        }
+        _ => build_shared_windows_bat_command_text_without_java(
+            startup_filename,
+            managed_console_encoding.cmd_code_page(),
+        ),
+    };
+
+    build_windows_cmd_command(&command_text)
 }
 
 pub(super) fn apply_java_process_env(
@@ -62,16 +83,16 @@ pub(super) fn apply_java_process_env(
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_java_process_env, ensure_supported_script_java_major_version};
+    use super::{
+        apply_java_process_env, build_windows_bat_command,
+        ensure_supported_script_java_major_version,
+    };
     use sea_lantern_server_local_setup_core::prepend_path_entry;
     #[cfg(target_os = "windows")]
     use sea_lantern_server_local_setup_core::{
         build_windows_java_env_prefix, ManagedConsoleEncoding,
     };
     use std::process::Command;
-
-    #[cfg(target_os = "windows")]
-    use super::build_windows_bat_command;
 
     fn collect_envs(command: &Command) -> Vec<(String, Option<String>)> {
         command
@@ -152,8 +173,8 @@ mod tests {
         let cmd = build_windows_bat_command(
             "start &(1)%2.bat",
             ManagedConsoleEncoding::Utf8,
-            "C:/Java/JDK 21",
-            "C:/Java/JDK 21/bin",
+            Some("C:/Java/JDK 21"),
+            Some("C:/Java/JDK 21/bin"),
         );
 
         let args = cmd
@@ -178,8 +199,8 @@ mod tests {
         let cmd = build_windows_bat_command(
             "launch.bat",
             ManagedConsoleEncoding::Gbk,
-            java_home,
-            java_bin,
+            Some(java_home),
+            Some(java_bin),
         );
 
         let args = cmd
@@ -206,8 +227,8 @@ mod tests {
         let cmd = build_windows_bat_command(
             "launch.bat",
             ManagedConsoleEncoding::Gbk,
-            java_home,
-            java_bin,
+            Some(java_home),
+            Some(java_bin),
         );
 
         let args = cmd
@@ -220,5 +241,27 @@ mod tests {
         );
 
         assert_eq!(args, vec!["/d".to_string(), "/c".to_string(), expected]);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_bat_command_can_skip_java_env_injection() {
+        let cmd = build_windows_bat_command("launch.bat", ManagedConsoleEncoding::Utf8, None, None);
+
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        let envs = collect_envs(&cmd);
+
+        assert!(envs.is_empty());
+        assert_eq!(
+            args,
+            vec![
+                "/d".to_string(),
+                "/c".to_string(),
+                "chcp 65001>nul & call \"launch.bat\" nogui".to_string(),
+            ]
+        );
     }
 }

--- a/backend/tauri-host/src/services/server/manager/runtime_start/local_launch_detail.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/local_launch_detail.rs
@@ -2,9 +2,8 @@ use crate::models::server::ServerInstance;
 use crate::services::server::manager::i18n::manager_t1;
 use crate::services::server::manager::startup_support::resolve_effective_startup_config_checked;
 use sea_lantern_server_local_setup_core::{
-    preview_command as preview_shared_command, resolve_java_paths, resolve_local_launch_target,
+    preview_command as preview_shared_command, resolve_local_launch_target,
     resolve_managed_console_encoding, startup_filename, startup_mode_is_starter,
-    startup_mode_requires_java,
 };
 
 use super::super::common::StartupMode;
@@ -14,6 +13,7 @@ use super::launch::command_builder::{
     find_preferred_jar_path,
 };
 use super::launch::context::{resolve_starter_core_key, LaunchContext};
+use super::resolve_launch_java_dirs;
 use super::LocalLaunchDetail;
 
 pub(crate) fn build_local_launch_detail(
@@ -29,12 +29,8 @@ pub(crate) fn build_local_launch_detail(
     let startup_path_obj = std::path::Path::new(startup_path);
     let managed_console_encoding =
         resolve_managed_console_encoding(startup_mode.as_str(), startup_path_obj);
-    let (java_bin_dir_str, java_home_dir_str) = if startup_mode_requires_java(startup_mode.as_str())
-    {
-        resolve_java_paths(runtime.java_path.as_str())?
-    } else {
-        (String::new(), String::new())
-    };
+    let (java_bin_dir_str, java_home_dir_str) =
+        resolve_launch_java_dirs(startup_mode, runtime.java_path.as_str())?;
     let starter_core_key = resolve_starter_core_key(server)?;
 
     let context = LaunchContext {

--- a/backend/tauri-host/src/services/server/manager/runtime_start/local_launch_detail.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_start/local_launch_detail.rs
@@ -4,6 +4,7 @@ use crate::services::server::manager::startup_support::resolve_effective_startup
 use sea_lantern_server_local_setup_core::{
     preview_command as preview_shared_command, resolve_java_paths, resolve_local_launch_target,
     resolve_managed_console_encoding, startup_filename, startup_mode_is_starter,
+    startup_mode_requires_java,
 };
 
 use super::super::common::StartupMode;
@@ -28,7 +29,12 @@ pub(crate) fn build_local_launch_detail(
     let startup_path_obj = std::path::Path::new(startup_path);
     let managed_console_encoding =
         resolve_managed_console_encoding(startup_mode.as_str(), startup_path_obj);
-    let (java_bin_dir_str, java_home_dir_str) = resolve_java_paths(runtime.java_path.as_str())?;
+    let (java_bin_dir_str, java_home_dir_str) = if startup_mode_requires_java(startup_mode.as_str())
+    {
+        resolve_java_paths(runtime.java_path.as_str())?
+    } else {
+        (String::new(), String::new())
+    };
     let starter_core_key = resolve_starter_core_key(server)?;
 
     let context = LaunchContext {
@@ -264,6 +270,25 @@ mod tests {
         assert_eq!(detail.launch_target, "java -jar custom.jar nogui");
         assert!(detail.effective_jvm_args.is_empty());
         assert!(detail.command_preview.contains("custom.jar"));
+    }
+
+    #[test]
+    fn build_local_launch_detail_allows_script_mode_without_java_path() {
+        let temp_dir = tempdir().expect("temp dir should exist");
+        let mut server = test_server(temp_dir.path().to_string_lossy().to_string(), "sh");
+        let script_path = temp_dir.path().join("start.sh");
+        std::fs::write(&script_path, b"#!/bin/sh\nexit 0\n").expect("script fixture should exist");
+        if let ServerRuntimeConfig::Local(runtime) = &mut server.runtime {
+            runtime.jar_path = script_path.to_string_lossy().to_string();
+            runtime.java_path.clear();
+        }
+
+        let detail = build_local_launch_detail(&server, &test_settings())
+            .expect("script launch detail should build without java path");
+
+        assert_eq!(detail.startup_mode, "sh");
+        assert_eq!(detail.java_path, "");
+        assert!(detail.command_preview.contains("start.sh"));
     }
 
     #[test]

--- a/frontend/src/components/views/create/startupUtils.ts
+++ b/frontend/src/components/views/create/startupUtils.ts
@@ -1,6 +1,10 @@
 import type { StartupCandidate, StartupMode } from "@components/views/create/startupTypes";
+import startupModeMetadataRaw from "@shared/startup-modes.json";
 
 const STARTER_MAIN_CLASS_PREFIX = "net.neoforged.serverstarterjar";
+type StartupModeMetadata = Record<StartupMode, { requiresJava: boolean }>;
+
+const startupModeMetadata = startupModeMetadataRaw as StartupModeMetadata;
 
 export function isStarterMainClass(mainClass: string | null): boolean {
   return !!mainClass?.startsWith(STARTER_MAIN_CLASS_PREFIX);
@@ -107,7 +111,7 @@ export function mapStartupModeForModpack(
 }
 
 export function startupModeRequiresJava(mode: StartupMode | null | undefined): boolean {
-  return mode === "jar" || mode === "starter";
+  return mode ? startupModeMetadata[mode].requiresJava : false;
 }
 
 export function resolveExecutablePathForTarget(

--- a/frontend/src/components/views/create/startupUtils.ts
+++ b/frontend/src/components/views/create/startupUtils.ts
@@ -106,6 +106,10 @@ export function mapStartupModeForModpack(
   return mapStartupModeForApi(mode);
 }
 
+export function startupModeRequiresJava(mode: StartupMode | null | undefined): boolean {
+  return mode === "jar" || mode === "starter";
+}
+
 export function resolveExecutablePathForTarget(
   executablePath: string,
   sourceDir: string,

--- a/frontend/src/components/views/create/useCreateServerSubmit.ts
+++ b/frontend/src/components/views/create/useCreateServerSubmit.ts
@@ -7,6 +7,7 @@ import {
   containsIoRedirection,
   isStrictChildPath,
   mapStartupModeForModpack,
+  startupModeRequiresJava,
 } from "@components/views/create/startupUtils";
 import { i18n } from "@language";
 import { useServerStore } from "@stores/serverStore";
@@ -105,7 +106,7 @@ export function useCreateServerSubmit(options: UseCreateServerSubmitOptions) {
       options.selectedMcVersion.value.trim().length === 0
     );
   });
-  const requiresJava = computed(() => selectedStartup.value?.mode !== "custom");
+  const requiresJava = computed(() => startupModeRequiresJava(selectedStartup.value?.mode));
   const hasJava = computed(
     () => !requiresJava.value || options.selectedJava.value.trim().length > 0,
   );

--- a/frontend/src/views/AddExistingServerView.vue
+++ b/frontend/src/views/AddExistingServerView.vue
@@ -19,6 +19,7 @@ import { javaApi, type JavaInfo } from "@api/java";
 import { serverApi } from "@api/server";
 import { systemApi } from "@api/system";
 import type { StartupCandidate, StartupMode } from "@components/views/create/startupTypes";
+import { startupModeRequiresJava } from "@components/views/create/startupUtils";
 import type { CpuPolicyConfig, JvmPresetConfig } from "@type/server";
 import { useLoading } from "@composables/useAsync";
 import { useMessage } from "@composables/useMessage";
@@ -132,6 +133,8 @@ const selectedStartupTarget = computed(() => {
   return startup.path;
 });
 
+const requiresJava = computed(() => startupModeRequiresJava(selectedStartup.value?.mode));
+
 const stepItems = computed(() => [
   {
     step: 1,
@@ -149,7 +152,9 @@ const stepItems = computed(() => [
     step: 3,
     title: i18n.t("add_existing.step_config_title"),
     description: i18n.t("add_existing.step_config_desc"),
-    completed: selectedJava.value.trim().length > 0 && serverName.value.trim().length > 0,
+    completed:
+      (!requiresJava.value || selectedJava.value.trim().length > 0) &&
+      serverName.value.trim().length > 0,
   },
   {
     step: 4,
@@ -166,7 +171,10 @@ const activeStep = computed(() => {
   if (!selectedStartup.value) {
     return 2;
   }
-  if (selectedJava.value.trim().length === 0 || serverName.value.trim().length === 0) {
+  if (
+    (requiresJava.value && selectedJava.value.trim().length === 0) ||
+    serverName.value.trim().length === 0
+  ) {
     return 3;
   }
   return 4;
@@ -176,7 +184,7 @@ const canSubmit = computed(
   () =>
     serverPath.value.trim().length > 0 &&
     selectedStartup.value !== null &&
-    selectedJava.value.trim().length > 0 &&
+    (!requiresJava.value || selectedJava.value.trim().length > 0) &&
     serverName.value.trim().length > 0 &&
     !startupDetecting.value,
 );
@@ -245,7 +253,7 @@ function validateBeforeSubmit(): boolean {
     showError(i18n.t("create.startup_required"));
     return false;
   }
-  if (!selectedJava.value.trim()) {
+  if (requiresJava.value && !selectedJava.value.trim()) {
     showError(i18n.t("common.select_java_path"));
     return false;
   }
@@ -282,7 +290,7 @@ async function handleSubmit() {
     const addedServer = await serverApi.addExistingServer({
       name: serverName.value.trim(),
       serverPath: serverPath.value.trim(),
-      javaPath: selectedJava.value.trim(),
+      javaPath: requiresJava.value ? selectedJava.value.trim() : "",
       maxMemory: parseNumber(maxMemory.value, 2048),
       minMemory: parseNumber(minMemory.value, 512),
       port: parseNumber(port.value, 25565),
@@ -395,7 +403,7 @@ watch(
                 <JavaEnvironmentStep
                   :java-list="javaList"
                   :loading="javaLoading"
-                  :required="true"
+                  :required="requiresJava"
                   :selected-java="selectedJava"
                   @detect="detectJava"
                   @update:selected-java="selectedJava = $event"

--- a/frontend/src/views/CreateServerView.vue
+++ b/frontend/src/views/CreateServerView.vue
@@ -18,6 +18,7 @@ import ServerStartupConfigStep from "@components/views/create/ServerStartupConfi
 import SourceIntakeField from "@components/views/create/SourceIntakeField.vue";
 import StartupSelectionStep from "@components/views/create/StartupSelectionStep.vue";
 import { useCreateServerWindowDrop } from "@components/views/create/useCreateServerWindowDrop";
+import { startupModeRequiresJava } from "@components/views/create/startupUtils";
 import { i18n } from "@language";
 import { useCreateServerPage } from "@components/views/create/useCreateServerPage";
 
@@ -158,7 +159,7 @@ const { isDragging } = useCreateServerWindowDrop();
                 <JavaEnvironmentStep
                   :java-list="javaList"
                   :loading="javaLoading"
-                  :required="selectedStartup?.mode !== 'custom'"
+                  :required="startupModeRequiresJava(selectedStartup?.mode)"
                   :selected-java="selectedJava"
                   @detect="detectJava"
                   @update:selected-java="selectedJava = $event"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -31,6 +31,7 @@
       "@router/*": ["./src/router/*"],
       "@stores/*": ["./src/stores/*"],
       "@styles/*": ["./src/styles/*"],
+      "@shared/*": ["../shared/*"],
       "@themes": ["./src/themes"],
       "@themes/*": ["./src/themes/*"],
       "@tauri-host": ["../backend/tauri-host"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       "@data": path.resolve(frontendDir, "src/data"),
       "@language": path.resolve(frontendDir, "src/language"),
       "@router": path.resolve(frontendDir, "src/router"),
+      "@shared": path.resolve(rootDir, "shared"),
       "@stores": path.resolve(frontendDir, "src/stores"),
       "@styles": path.resolve(frontendDir, "src/styles"),
       "@themes": path.resolve(frontendDir, "src/themes"),

--- a/shared/startup-modes.json
+++ b/shared/startup-modes.json
@@ -1,0 +1,20 @@
+{
+  "starter": {
+    "requiresJava": true
+  },
+  "jar": {
+    "requiresJava": true
+  },
+  "bat": {
+    "requiresJava": false
+  },
+  "sh": {
+    "requiresJava": false
+  },
+  "ps1": {
+    "requiresJava": false
+  },
+  "custom": {
+    "requiresJava": false
+  }
+}


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

<!-- 一句话概括本次变更 -->

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #`填写 Issue 编号`

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

放宽对使用脚本的服务器启动模式的 Java 要求，同时在后端和前端流程中保留对 JAR/启动器（starter）模式的 Java 使用约束。

Bug Fixes:
- 允许在未配置 Java 路径的情况下，创建并启动基于脚本的服务器启动模式。

Enhancements:
- 引入共享逻辑，用于判断某个启动模式是否需要 Java，并在后端的启动准备流程和前端向导中一致地应用该逻辑。
- 增加对构建 Windows BAT 启动命令的支持：当不需要 Java 或未配置 Java 时，可省略 Java 环境注入。

Tests:
- 扩展后端测试，以覆盖在无 Java 情况下的脚本模式启动，以及在跳过 Java 环境注入时 Windows BAT 命令的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax Java requirement for server startup modes that use scripts while preserving Java usage for JAR/starter modes across backend and frontend flows.

Bug Fixes:
- Allow creating and launching servers with script-based startup modes without requiring a configured Java path.

Enhancements:
- Introduce shared logic to determine whether a startup mode requires Java and apply it consistently in backend launch preparation and frontend wizards.
- Add support for building Windows BAT launch commands that omit Java environment injection when Java is not required or not configured.

Tests:
- Extend backend tests to cover script-mode launches without Java and Windows BAT command behavior when Java env injection is skipped.

</details>