### PR TITLE
feat:添加服务器重启功能

### DIFF
--- a/backend/tauri-host/src/adapters/http/command_registry/server.rs
+++ b/backend/tauri-host/src/adapters/http/command_registry/server.rs
@@ -15,6 +15,7 @@ pub(super) fn register_handlers(builder: &mut RegistryBuilder) {
     builder.register("import_modpack", handle_import_modpack as CommandHandler);
     builder.register("start_server", handle_start_server as CommandHandler);
     builder.register("stop_server", handle_stop_server as CommandHandler);
+    builder.register("restart_server", handle_restart_server as CommandHandler);
     builder.register("send_command", handle_send_command as CommandHandler);
     builder.register("get_server_list", handle_get_server_list as CommandHandler);
     builder.register("get_server_status", handle_get_server_status as CommandHandler);
@@ -128,6 +129,16 @@ fn handle_stop_server(params: Value) -> futures::future::BoxFuture<'static, Resu
     Box::pin(async move {
         let req: ServerIdRequest = parse_params(params)?;
         server_commands::stop_server(req.id)?;
+        Ok(Value::Null)
+    })
+}
+
+fn handle_restart_server(
+    params: Value,
+) -> futures::future::BoxFuture<'static, Result<Value, String>> {
+    Box::pin(async move {
+        let req: ServerIdRequest = parse_params(params)?;
+        server_commands::restart_server(req.id)?;
         Ok(Value::Null)
     })
 }

--- a/backend/tauri-host/src/commands/server/manage.rs
+++ b/backend/tauri-host/src/commands/server/manage.rs
@@ -32,6 +32,12 @@ pub fn force_stop_server(id: String, confirmation_token: String) -> Result<(), S
 }
 
 #[tauri::command]
+/// 重启服务器
+pub fn restart_server(id: String) -> Result<(), String> {
+    runtime::restart_server(id)
+}
+
+#[tauri::command]
 #[allow(clippy::too_many_arguments)]
 /// 新建服务器实例
 pub fn create_server(

--- a/backend/tauri-host/src/commands/server/manage/runtime.rs
+++ b/backend/tauri-host/src/commands/server/manage/runtime.rs
@@ -47,6 +47,11 @@ pub(super) fn force_stop_server(id: String, confirmation_token: String) -> Resul
     manager().force_stop_server(&id, &confirmation_token)
 }
 
+/// 重启服务器：停服后等待 2 秒再启动
+pub(super) fn restart_server(id: String) -> Result<(), String> {
+    manager().restart_server(&id)
+}
+
 /// 启动服务器，并在需要时向前端发送启动回退事件
 pub(super) fn start_server(app: tauri::AppHandle, id: String) -> Result<(), String> {
     let _ = app;

--- a/backend/tauri-host/src/runtime/command_catalog.rs
+++ b/backend/tauri-host/src/runtime/command_catalog.rs
@@ -40,6 +40,7 @@ pub(crate) fn desktop_handler(
         server_commands::copy_directory_contents,
         server_commands::start_server,
         server_commands::stop_server,
+        server_commands::restart_server,
         server_commands::prepare_force_stop_server,
         server_commands::force_stop_server,
         server_commands::send_command,

--- a/backend/tauri-host/src/services/server/manager.rs
+++ b/backend/tauri-host/src/services/server/manager.rs
@@ -267,6 +267,31 @@ impl ServerManager {
         )
     }
 
+    pub fn restart_server(&self, id: &str) -> Result<(), String> {
+        let detail = format!("server_id={}", id);
+        logger::log_user_action("server.manager", "restart", &detail);
+        let _ = publish_server_lifecycle(
+            id,
+            ServerEventKind::LifecycleStopRequested,
+            Some("restart_requested".to_string()),
+            None,
+            None,
+            None,
+        );
+        let result = runtime_control::restart_server(self, id);
+        if let Err(error) = &result {
+            let _ = publish_server_lifecycle(
+                id,
+                ServerEventKind::LifecycleRuntimeError,
+                Some("restart_failed".to_string()),
+                Some(error.clone()),
+                None,
+                None,
+            );
+        }
+        log_manager_result("restart", &detail, result)
+    }
+
     pub(crate) fn save(&self) -> Result<(), String> {
         let servers = self.lock_servers()?;
         let data_dir = self.data_dir_value()?;

--- a/backend/tauri-host/src/services/server/manager/runtime_control.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_control.rs
@@ -2,6 +2,7 @@
 
 mod force_stop;
 mod request;
+mod restart;
 mod status;
 mod stop;
 
@@ -31,6 +32,11 @@ pub(super) fn force_stop_server(
     confirmation_token: &str,
 ) -> Result<(), String> {
     force_stop::force_stop_server(manager, id, confirmation_token)
+}
+
+/// 停服后等待 2 秒，再重新启动服务器
+pub(super) fn restart_server(manager: &ServerManager, id: &str) -> Result<(), String> {
+    restart::restart_server(manager, id)
 }
 
 /// 发送 `stop` 命令并等待服务器退出

--- a/backend/tauri-host/src/services/server/manager/runtime_control/restart.rs
+++ b/backend/tauri-host/src/services/server/manager/runtime_control/restart.rs
@@ -1,0 +1,67 @@
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    models::server::{ServerStatus, ServerStatusInfo},
+    utils::server_status::status_detail_indicates_running,
+};
+
+use super::ServerManager;
+
+const RESTART_STOP_POLL_INTERVAL_MS: u64 = 500;
+const RESTART_STOP_TIMEOUT_SECS: u64 = 30;
+const RESTART_AFTER_STOP_DELAY_SECS: u64 = 2;
+
+pub(super) fn restart_server(manager: &ServerManager, id: &str) -> Result<(), String> {
+    let status = manager.get_server_status(id);
+
+    if status_requires_running_wait(&status) {
+        manager.stop_server(id)?;
+        wait_for_server_stop(manager, id, RESTART_STOP_TIMEOUT_SECS)?;
+        thread::sleep(Duration::from_secs(RESTART_AFTER_STOP_DELAY_SECS));
+    }
+
+    manager.start_server(id)?;
+    Ok(())
+}
+
+fn wait_for_server_stop(
+    manager: &ServerManager,
+    server_id: &str,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    let started = Instant::now();
+    loop {
+        let status = manager.get_server_status(server_id);
+        if !status_requires_running_wait(&status) {
+            return Ok(());
+        }
+
+        if started.elapsed().as_secs() >= timeout_secs {
+            return Err(format!(
+                "等待服务器停止超时: server_id={} timeout={}s last_status={} detail={} error={}",
+                server_id,
+                timeout_secs,
+                status.status.as_str(),
+                status.detail_message.as_deref().unwrap_or(""),
+                status.error_message.as_deref().unwrap_or("")
+            ));
+        }
+
+        thread::sleep(Duration::from_millis(RESTART_STOP_POLL_INTERVAL_MS));
+    }
+}
+
+fn status_requires_running_wait(status: &ServerStatusInfo) -> bool {
+    if matches!(
+        status.status,
+        ServerStatus::Running | ServerStatus::Starting | ServerStatus::Stopping
+    ) {
+        return true;
+    }
+
+    matches!(status.status, ServerStatus::Error)
+        && status_detail_indicates_running(status.detail_message.as_deref())
+}

--- a/frontend/src/api/server.ts
+++ b/frontend/src/api/server.ts
@@ -457,6 +457,10 @@ export const serverApi = {
     return tauriInvoke("stop_server", { id });
   },
 
+  async restart(id: string): Promise<void> {
+    return tauriInvoke("restart_server", { id });
+  },
+
   async prepareForceStop(id: string): Promise<ForceStopPreparation> {
     const result = await tauriInvoke<ForceStopPreparationRaw>("prepare_force_stop_server", { id });
     return {

--- a/frontend/src/language/en-US/common.json
+++ b/frontend/src/language/en-US/common.json
@@ -33,6 +33,7 @@
   "server_status_error": "Error",
   "message_server_started": "Server started",
   "message_server_stopped": "Server stopped",
+  "message_server_restarted": "Server restarted",
   "message_command_sent": "Command sent",
   "message_whitelist_added": "Added to whitelist",
   "message_whitelist_removed": "Removed from whitelist",

--- a/frontend/src/language/en-US/console.json
+++ b/frontend/src/language/en-US/console.json
@@ -26,6 +26,7 @@
   "create_server_first": "Please create and select a server first",
   "suggestion_hint": "Tab to complete / Up Down for suggestions or history",
   "force_stop": "Force Stop",
+  "restart": "Restart",
   "force_stop_confirm": "Force stopping will kill the server process immediately and may cause data loss. Continue?",
   "force_stop_requested": "Force stop requested",
   "overview_title": "Unified Console",

--- a/frontend/src/language/zh-CN/common.json
+++ b/frontend/src/language/zh-CN/common.json
@@ -33,6 +33,7 @@
   "server_status_error": "错误",
   "message_server_started": "服务器已启动",
   "message_server_stopped": "服务器已停止",
+  "message_server_restarted": "服务器已重启",
   "message_command_sent": "命令已发送",
   "message_whitelist_added": "已添加到白名单",
   "message_whitelist_removed": "已从白名单移除",

--- a/frontend/src/language/zh-CN/console.json
+++ b/frontend/src/language/zh-CN/console.json
@@ -26,6 +26,7 @@
   "create_server_first": "请先创建并选择一个服务器",
   "suggestion_hint": "Tab 补全 / Up Down 选择建议或历史",
   "force_stop": "强制关停",
+  "restart": "重启",
   "force_stop_confirm": "强制关停会立即杀死服务器进程，可能导致数据丢失。确定继续吗？",
   "force_stop_requested": "已发送强制关停请求",
   "overview_title": "统一控制台",

--- a/frontend/src/pages/home/useNextHomeLayoutEditor.ts
+++ b/frontend/src/pages/home/useNextHomeLayoutEditor.ts
@@ -303,6 +303,10 @@ function resolveAutoHeightLayout(
   return result;
 }
 
+function serializeInstances(value: NextHomeCardInstance[]): string {
+  return JSON.stringify(value);
+}
+
 export function useNextHomeLayoutEditor(options: UseNextHomeLayoutEditorOptions) {
   const settingsStore = useSettingsStore();
   const instances = shallowRef<NextHomeCardInstance[]>([]);
@@ -589,10 +593,6 @@ export function useNextHomeLayoutEditor(options: UseNextHomeLayoutEditorOptions)
     ).filter((instance): instance is NextHomeCardInstance => instance !== null);
     replaceInstances(sanitizedDefaults);
     selectedInstanceId.value = sanitizedDefaults[0]?.instanceId ?? null;
-  }
-
-  function serializeInstances(value: NextHomeCardInstance[]): string {
-    return JSON.stringify(value);
   }
 
   function sanitizePersistedLayout(

--- a/frontend/src/pages/plugins/usePluginDetailPage.ts
+++ b/frontend/src/pages/plugins/usePluginDetailPage.ts
@@ -168,6 +168,7 @@ export function usePluginDetailPage() {
 
   void getHostCapabilities().then((capabilities) => {
     hostCapabilities.value = capabilities;
+    return capabilities;
   });
 
   const { showFeedback, clearFeedback } = usePluginMarketFeedback({

--- a/frontend/src/pages/plugins/usePluginsPage.ts
+++ b/frontend/src/pages/plugins/usePluginsPage.ts
@@ -130,6 +130,7 @@ export function usePluginsPage() {
 
   void getHostCapabilities().then((capabilities) => {
     hostCapabilities.value = capabilities;
+    return capabilities;
   });
 
   async function loadPage(manual = false): Promise<void> {

--- a/frontend/src/pages/server-instance/console/ServerInstanceConsolePage.vue
+++ b/frontend/src/pages/server-instance/console/ServerInstanceConsolePage.vue
@@ -53,6 +53,15 @@ onUnmounted(() => {
           {{ page.primaryActionLabel.value }}
         </SLButton>
         <SLButton
+          v-if="page.canRestart.value"
+          variant="secondary"
+          size="sm"
+          :loading="page.lifecycleSubmitting.value"
+          @click="page.runRestartAction"
+        >
+          {{ i18n.t("console.restart") }}
+        </SLButton>
+        <SLButton
           v-if="page.canForceStop.value"
           variant="danger"
           size="sm"

--- a/frontend/src/pages/server-instance/console/useServerInstanceConsolePage.ts
+++ b/frontend/src/pages/server-instance/console/useServerInstanceConsolePage.ts
@@ -48,6 +48,10 @@ function canForceStopServer(status: ServerStatus | undefined): boolean {
   return status === "Running" || status === "Starting" || status === "Stopping";
 }
 
+function canRestartServer(status: ServerStatus | undefined): boolean {
+  return status === "Running" || status === "Starting" || status === "Stopping";
+}
+
 export function useServerInstanceConsolePage() {
   const workspace = useNextInstanceWorkspaceContext();
   const message = useMessage();
@@ -80,6 +84,7 @@ export function useServerInstanceConsolePage() {
   const canStart = computed(() => canStartServer(runtimeStatus.value));
   const canStop = computed(() => canStopServer(runtimeStatus.value));
   const canForceStop = computed(() => canForceStopServer(runtimeStatus.value));
+  const canRestart = computed(() => canRestartServer(runtimeStatus.value));
   const primaryActionLabel = computed(() =>
     canStart.value ? i18n.t("home.start") : i18n.t("home.stop"),
   );
@@ -147,6 +152,25 @@ export function useServerInstanceConsolePage() {
         message.showSuccess(i18n.t("common.message_server_stopped"));
       }
 
+      await refresh(false);
+    } catch (error) {
+      message.showError(error instanceof Error ? error.message : String(error));
+    } finally {
+      lifecycleSubmitting.value = false;
+    }
+  }
+
+  async function runRestartAction(): Promise<void> {
+    if (!serverId.value || !canRestart.value || lifecycleSubmitting.value) {
+      return;
+    }
+
+    lifecycleSubmitting.value = true;
+    message.clearAll();
+
+    try {
+      await serverApi.restart(serverId.value);
+      message.showSuccess(i18n.t("common.message_server_restarted"));
       await refresh(false);
     } catch (error) {
       message.showError(error instanceof Error ? error.message : String(error));
@@ -238,6 +262,7 @@ export function useServerInstanceConsolePage() {
     lifecycleSubmitting,
     isActive,
     canForceStop,
+    canRestart,
     statusLabel,
     primaryActionLabel,
     primaryActionVariant,
@@ -246,6 +271,7 @@ export function useServerInstanceConsolePage() {
     forceStopSubmitting,
     refresh,
     runPrimaryAction,
+    runRestartAction,
     openForceStopDialog,
     closeForceStopDialog,
     confirmForceStop,


### PR DESCRIPTION
## 提交前检查清单

- [ ] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [ ] 本地/CI 测试通过
- [ ] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [ ] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

<!-- 一句话概括本次变更 -->

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #`填写 Issue 编号`

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

引入完整的服务器重启功能，使用户可以通过控制台 UI 重启实例；该功能由新的运行时控制、生命周期日志记录，以及 Tauri/HTTP 命令接线提供支持，同时整理相关的辅助函数和能力处理逻辑。

新功能：
- 在前端和后端添加服务器重启能力，包括控制台上的操作以及对应的 Tauri 命令/HTTP 处理器。

缺陷修复：
- 确保首页布局实例的序列化只在一个共享的辅助函数中定义，避免重复。
- 从插件页面的能力加载流程中返回解析后的主机能力值，以保持 Promise 链的一致性。

改进优化：
- 实现健壮的服务器重启流程：停止运行中或处于错误状态的服务器，等待其在超时时间内关闭，然后在带有生命周期日志和状态更新的情况下重新启动。
- 通过服务器 API 客户端暴露重启支持，使控制台页面能够触发重启并显示成功消息。
- 在控制台页面中添加用于重启服务器实例的 UI 支持，包括重启按钮的条件渲染和加载状态。
- 扩展 i18n 资源，在英文和中文语言环境中增加与服务器重启操作相关的消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a full server restart feature that allows users to restart instances from the console UI, backed by new runtime control, lifecycle logging, and Tauri/HTTP command wiring, while tidying related helpers and capability handling.

New Features:
- Add server restart capability across frontend and backend, including a console action and corresponding Tauri command/HTTP handler.

Bug Fixes:
- Ensure home layout instance serialization is defined once in a shared helper to avoid duplication.
- Return the resolved host capabilities value from plugin pages’ capability loading to keep promise chains consistent.

Enhancements:
- Implement robust server restart flow that stops running/error servers, waits for shutdown with timeout, then restarts with lifecycle logging and status updates.
- Expose restart support through the server API client, enabling the console page to trigger restart and display success messaging.
- Add UI support for restarting a server instance from the console page, including conditional rendering and loading state of the restart button.
- Extend i18n resources with messages for server restart actions in both English and Chinese locales.

</details>