### PR TITLE
Chore/fix ci and update tauri version

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -91,27 +91,6 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: 创建或复用 Nightly GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.meta.outputs.tag }}
-          RELEASE_NAME: ${{ steps.meta.outputs.release_name }}
-          RELEASE_BODY: ${{ steps.meta.outputs.release_body }}
-          SOURCE_SHA: ${{ steps.meta.outputs.source_sha }}
-        run: |
-          set -euo pipefail
-
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "✅ 已存在 Nightly Release，复用标签 $TAG"
-            exit 0
-          fi
-
-          gh release create "$TAG" \
-            --target "$SOURCE_SHA" \
-            --title "$RELEASE_NAME" \
-            --notes "$RELEASE_BODY" \
-            --prerelease
-
   publish-tauri-nightly:
     name: 构建并发布 Nightly 桌面端
     needs: validate-nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,7 +2940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -7363,9 +7363,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -7381,13 +7381,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.5"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -7397,7 +7399,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "url",
 ]
 

--- a/backend/tauri-host/Cargo.toml
+++ b/backend/tauri-host/Cargo.toml
@@ -35,8 +35,8 @@ sl-server-info = "0.1.0"
 sl-server-flavor-core = "0.2.1"
 tauri = { version = "2", features = ["protocol-asset", "tray-icon", "macos-private-api"] }
 tauri-plugin-opener = "2"
-tauri-plugin-dialog = "2"
-tauri-plugin-fs = "2.0.0"
+tauri-plugin-dialog = "2.7.1"
+tauri-plugin-fs = "2.5.1"
 tokio-util = "0.7.18"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## 提交前检查清单

- [ ] 本地/CI 测试通过(可选)
- [ ] 自我代码审查完成(建议)

## 变更详情

### 摘要

 更新 tauri 版本并优化ci

## 自动化审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

更新 Tauri 主机依赖，并简化 nightly 发布 CI 工作流程。

增强功能：
- 在 Tauri 主机后端中提升 `tauri-plugin-dialog` 和 `tauri-plugin-fs` 的版本。
- 刷新 `Cargo.lock` 以与更新后的依赖版本保持一致。

CI：
- 从 nightly-release 工作流程中移除创建或重用 Nightly GitHub Release 的步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Tauri host dependencies and simplify nightly release CI workflow.

Enhancements:
- Bump tauri-plugin-dialog and tauri-plugin-fs versions in the Tauri host backend.
- Refresh Cargo.lock to align with updated dependency versions.

CI:
- Remove the step that creates or reuses the Nightly GitHub Release from the nightly-release workflow.

</details>