### PR TITLE
feat: add core tracing events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5889,6 +5889,9 @@ dependencies = [
 [[package]]
 name = "sealantern-core"
 version = "0.1.0"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "security-framework"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,3 +6,6 @@ license = "GPL-3.0-only"
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+tracing = "0.1"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,4 @@
 #![forbid(unsafe_code)]
 
+pub mod observability;
 pub mod process;

--- a/crates/core/src/observability.rs
+++ b/crates/core/src/observability.rs
@@ -1,0 +1,18 @@
+use std::fmt::Display;
+
+/// Stable tracing target for process-daemon lifecycle events.
+pub const PROCESS_DAEMON_TARGET: &str = "sealantern.core.process.daemon";
+
+/// Stable event name that host adapters may map to a frontend-facing event.
+pub const EVENT_DAEMON_TERMINATION_FAILED: &str = "daemon_termination_failed";
+
+pub(crate) fn daemon_termination_failed(process_id: u32, sign: &str, error: &dyn Display) {
+    tracing::error!(
+        target: PROCESS_DAEMON_TARGET,
+        event_name = EVENT_DAEMON_TERMINATION_FAILED,
+        process_id,
+        sign,
+        error = %error,
+        "daemon process tree termination failed"
+    );
+}

--- a/crates/core/src/process/daemon.rs
+++ b/crates/core/src/process/daemon.rs
@@ -194,7 +194,7 @@ fn termination_error(
         message: message.into(),
         source,
     };
-    eprintln!("[sealantern-core][daemon] {error}");
+    crate::observability::daemon_termination_failed(process_id, sign.as_str(), &error);
     error
 }
 


### PR DESCRIPTION
## Summary
- add a core observability facade with stable daemon tracing target and event name
- emit structured daemon termination errors through tracing instead of stderr
- keep subscriber, sink, and frontend transport outside core

## Validation
- cargo test -p sealantern-core
- cargo check -p sealantern-core --target x86_64-pc-windows-msvc
- cargo check -p sealantern-core --target x86_64-unknown-linux-gnu

## Summary by Sourcery

引入一个核心可观测性门面，用于稳定地跟踪守护进程生命周期，并通过结构化追踪事件而不是 stderr 日志来传递守护进程终止失败信息。

New Features:
- 添加一个核心可观测性模块，为守护进程生命周期事件提供稳定的追踪目标和事件名称。

Bug Fixes:
- 将守护进程终止失败作为结构化追踪事件发出，而不是非结构化的 stderr 输出。

Enhancements:
- 将守护进程终止错误处理接入新的可观测性门面，以支持宿主适配器和前端。

Build:
- 为 core crate 添加 `tracing` crate 作为依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a core observability facade for stable daemon lifecycle tracing and route daemon termination failures through structured tracing events instead of stderr logging.

New Features:
- Add a core observability module exposing stable tracing targets and event names for daemon lifecycle events.

Bug Fixes:
- Emit daemon termination failures as structured tracing events rather than unstructured stderr output.

Enhancements:
- Wire daemon termination error handling to the new observability facade to support host adapters and frontends.

Build:
- Add the `tracing` crate as a dependency of the core crate.

</details>