### PR TITLE
feat: add core server status module

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,3 +2,6 @@
 
 pub mod observability;
 pub mod process;
+
+#[path = "server/lib.rs"]
+pub mod server;

--- a/crates/core/src/server/lib.rs
+++ b/crates/core/src/server/lib.rs
@@ -1,0 +1,3 @@
+pub mod status;
+
+pub use status::{ServerProcessState, ServerStatus};

--- a/crates/core/src/server/status.rs
+++ b/crates/core/src/server/status.rs
@@ -1,0 +1,101 @@
+use std::io;
+use std::process::ExitStatus;
+
+use crate::process::Daemon;
+
+/// A point-in-time observation of a server daemon.
+#[derive(Debug)]
+pub struct ServerStatus {
+    pub process_id: u32,
+    pub state: ServerProcessState,
+}
+
+/// The process state reported by a server daemon.
+#[derive(Debug)]
+pub enum ServerProcessState {
+    Running,
+    Exited(ExitStatus),
+}
+
+impl ServerStatus {
+    /// Wraps the current state collected by a daemon.
+    pub fn from_daemon(daemon: &mut Daemon) -> io::Result<Self> {
+        let process_id = daemon.id();
+        let state = match daemon.poll().map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("could not observe daemon process {process_id}: {error}"),
+            )
+        })? {
+            Some(exit_status) => ServerProcessState::Exited(exit_status),
+            None => ServerProcessState::Running,
+        };
+
+        Ok(Self { state, process_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::{ServerProcessState, ServerStatus};
+    use crate::process::Daemon;
+
+    #[cfg(unix)]
+    fn exit_successfully_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 0"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn exit_successfully_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "exit 0"]);
+        command
+    }
+
+    #[cfg(unix)]
+    fn long_running_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 30"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn long_running_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
+        command
+    }
+
+    #[test]
+    fn wraps_a_running_daemon() {
+        let mut command = long_running_command();
+        let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
+        let process_id = daemon.id();
+
+        let status = ServerStatus::from_daemon(&mut daemon).expect("observe running daemon");
+
+        assert_eq!(status.process_id, process_id);
+        assert!(matches!(status.state, ServerProcessState::Running));
+        daemon
+            .terminate_tree()
+            .expect("terminate test process tree");
+    }
+
+    #[test]
+    fn wraps_a_finished_daemon_exit_status() {
+        let mut command = exit_successfully_command();
+        let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
+        let _ = daemon.wait().expect("wait for test process");
+
+        let status = ServerStatus::from_daemon(&mut daemon).expect("observe finished daemon");
+
+        assert!(matches!(
+            status.state,
+            ServerProcessState::Exited(exit_status) if exit_status.success()
+        ));
+    }
+}

--- a/crates/core/src/server/status.rs
+++ b/crates/core/src/server/status.rs
@@ -21,12 +21,7 @@ impl ServerStatus {
     /// Wraps the current state collected by a daemon.
     pub fn from_daemon(daemon: &mut Daemon) -> io::Result<Self> {
         let process_id = daemon.id();
-        let state = match daemon.poll().map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!("could not observe daemon process {process_id}: {error}"),
-            )
-        })? {
+        let state = match daemon.poll()? {
             Some(exit_status) => ServerProcessState::Exited(exit_status),
             None => ServerProcessState::Running,
         };


### PR DESCRIPTION
## Summary
- add the core server status module
- wrap daemon process observations without duplicating status collection
- cover running and exited daemon snapshots

## Verification
- cargo fmt --package sealantern-core -- --check
- cargo test --package sealantern-core server::status

## 由 Sourcery 提供的总结

引入一个核心服务器状态模块，用于封装守护进程在特定时间点的观测信息。

新功能：
- 添加一个核心服务器模块，通过 `ServerStatus` 和 `ServerProcessState` 抽象来公开服务器守护进程状态。

测试：
- 添加跨平台测试，用于覆盖运行中和已退出守护进程的服务器状态快照。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a core server status module that encapsulates point-in-time observations of daemon processes.

New Features:
- Add a core server module exposing server daemon status via ServerStatus and ServerProcessState abstractions.

Tests:
- Add cross-platform tests covering server status snapshots for both running and exited daemon processes.

</details>