### PR TITLE
feat: add core process terminal module

### DIFF
--- a/crates/core/src/process/command_build.rs
+++ b/crates/core/src/process/command_build.rs
@@ -36,6 +36,7 @@ pub enum WindowsConsoleEncoding {
     Gbk,
 }
 
+#[cfg(target_os = "windows")]
 impl WindowsConsoleEncoding {
     fn code_page(self) -> &'static str {
         match self {

--- a/crates/core/src/process/mod.rs
+++ b/crates/core/src/process/mod.rs
@@ -1,8 +1,10 @@
 pub mod command_build;
 pub mod daemon;
+pub mod terminal;
 
 pub use command_build::{
     apply_java_environment, build_command, CommandBuildError, CommandBuildMode,
     CommandBuildRequest, JavaEnvironment, WindowsConsoleEncoding,
 };
 pub use daemon::{Daemon, DaemonTerminationError, DaemonTerminationSign};
+pub use terminal::{Terminal, TerminalOutput, TerminalStream, TerminalWriteError};

--- a/crates/core/src/process/terminal.rs
+++ b/crates/core/src/process/terminal.rs
@@ -1,0 +1,269 @@
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::process::{ChildStderr, ChildStdin, ChildStdout};
+
+use super::Daemon;
+
+/// Identifies one of a daemon's output streams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalStream {
+    Stdout,
+    Stderr,
+}
+
+/// An owned daemon output stream that retains its source identity.
+pub enum TerminalOutput {
+    Stdout(ChildStdout),
+    Stderr(ChildStderr),
+}
+
+impl TerminalOutput {
+    pub fn stream(&self) -> TerminalStream {
+        match self {
+            Self::Stdout(_) => TerminalStream::Stdout,
+            Self::Stderr(_) => TerminalStream::Stderr,
+        }
+    }
+}
+
+impl Read for TerminalOutput {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Stdout(stdout) => stdout.read(buffer),
+            Self::Stderr(stderr) => stderr.read(buffer),
+        }
+    }
+}
+
+/// A daemon's standard streams after their ownership has moved out of the process handle.
+pub struct Terminal {
+    stdin: Option<ChildStdin>,
+    stdout: Option<ChildStdout>,
+    stderr: Option<ChildStderr>,
+}
+
+impl Terminal {
+    /// Transfers all configured standard streams from a daemon into a terminal handle.
+    pub fn from_daemon(daemon: &mut Daemon) -> Self {
+        Self {
+            stdin: daemon.take_stdin(),
+            stdout: daemon.take_stdout(),
+            stderr: daemon.take_stderr(),
+        }
+    }
+
+    /// Returns whether the daemon was configured with a writable standard input stream.
+    pub fn accepts_input(&self) -> bool {
+        self.stdin.is_some()
+    }
+
+    /// Writes bytes to standard input and flushes them to the daemon.
+    pub fn write(&mut self, input: &[u8]) -> Result<(), TerminalWriteError> {
+        let stdin = self.stdin()?;
+        stdin.write_all(input).map_err(TerminalWriteError::Write)?;
+        stdin.flush().map_err(TerminalWriteError::Flush)
+    }
+
+    /// Writes one command line to standard input and flushes it to the daemon.
+    pub fn write_line(&mut self, line: &str) -> Result<(), TerminalWriteError> {
+        let stdin = self.stdin()?;
+        stdin
+            .write_all(line.as_bytes())
+            .map_err(TerminalWriteError::Write)?;
+        stdin.write_all(b"\n").map_err(TerminalWriteError::Write)?;
+        stdin.flush().map_err(TerminalWriteError::Flush)
+    }
+
+    /// Transfers ownership of an output stream to the host reader.
+    pub fn take_output(&mut self, stream: TerminalStream) -> Option<TerminalOutput> {
+        match stream {
+            TerminalStream::Stdout => self.stdout.take().map(TerminalOutput::Stdout),
+            TerminalStream::Stderr => self.stderr.take().map(TerminalOutput::Stderr),
+        }
+    }
+
+    fn stdin(&mut self) -> Result<&mut ChildStdin, TerminalWriteError> {
+        self.stdin
+            .as_mut()
+            .ok_or(TerminalWriteError::InputUnavailable)
+    }
+}
+
+/// Describes why writing to a daemon terminal failed.
+#[derive(Debug)]
+pub enum TerminalWriteError {
+    InputUnavailable,
+    Write(io::Error),
+    Flush(io::Error),
+}
+
+impl TerminalWriteError {
+    /// Returns the underlying operating-system error, when a write was attempted.
+    pub fn io_error(&self) -> Option<&io::Error> {
+        match self {
+            Self::InputUnavailable => None,
+            Self::Write(error) | Self::Flush(error) => Some(error),
+        }
+    }
+}
+
+impl fmt::Display for TerminalWriteError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InputUnavailable => write!(formatter, "daemon standard input is not configured"),
+            Self::Write(error) => {
+                write!(formatter, "could not write to daemon standard input: {error}")
+            }
+            Self::Flush(error) => {
+                write!(formatter, "could not flush daemon standard input: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TerminalWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.io_error()
+            .map(|error| error as &(dyn std::error::Error + 'static))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+
+    use super::{Terminal, TerminalOutput, TerminalStream, TerminalWriteError};
+    use crate::process::Daemon;
+
+    #[cfg(unix)]
+    fn output_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "printf stdout; printf stderr >&2"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn output_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "echo stdout & echo stderr 1>&2"]);
+        command
+    }
+
+    #[cfg(unix)]
+    fn command_reader_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "read line; printf '%s' \"$line\""]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn command_reader_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/V:ON", "/C", "set /p line=& echo !line!"]);
+        command
+    }
+
+    #[cfg(unix)]
+    fn exit_successfully_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 0"]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn exit_successfully_command() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/C", "exit 0"]);
+        command
+    }
+
+    #[test]
+    fn transfers_output_streams_without_losing_their_identity() {
+        let mut command = output_command();
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
+        let mut terminal = Terminal::from_daemon(&mut daemon);
+
+        let mut stdout = terminal
+            .take_output(TerminalStream::Stdout)
+            .expect("stdout should be available");
+        let mut stderr = terminal
+            .take_output(TerminalStream::Stderr)
+            .expect("stderr should be available");
+        let mut stdout_text = String::new();
+        let mut stderr_text = String::new();
+
+        stdout
+            .read_to_string(&mut stdout_text)
+            .expect("read stdout");
+        stderr
+            .read_to_string(&mut stderr_text)
+            .expect("read stderr");
+
+        assert_eq!(stdout.stream(), TerminalStream::Stdout);
+        assert_eq!(stderr.stream(), TerminalStream::Stderr);
+        assert_eq!(stdout_text.trim(), "stdout");
+        assert_eq!(stderr_text.trim(), "stderr");
+        assert!(daemon.wait().expect("wait for test process").success());
+        assert!(terminal.take_output(TerminalStream::Stdout).is_none());
+    }
+
+    #[test]
+    fn writes_and_flushes_a_command_line_to_daemon_input() {
+        let mut command = command_reader_command();
+        command.stdin(Stdio::piped()).stdout(Stdio::piped());
+        let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
+        let mut terminal = Terminal::from_daemon(&mut daemon);
+
+        terminal
+            .write_line("say hello")
+            .expect("write command line");
+        let mut stdout = terminal
+            .take_output(TerminalStream::Stdout)
+            .expect("stdout should be available");
+        let mut output = String::new();
+        stdout
+            .read_to_string(&mut output)
+            .expect("read command output");
+
+        assert!(daemon.wait().expect("wait for test process").success());
+        assert!(output.contains("say hello"));
+    }
+
+    #[test]
+    fn reports_unavailable_standard_input_without_discarding_state() {
+        let mut command = exit_successfully_command();
+        command.stdin(Stdio::null());
+        let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
+        let mut terminal = Terminal::from_daemon(&mut daemon);
+
+        let error = terminal
+            .write_line("stop")
+            .expect_err("stdin was not configured as piped");
+
+        assert!(matches!(error, TerminalWriteError::InputUnavailable));
+        assert!(!terminal.accepts_input());
+        let _ = daemon.wait().expect("wait for test process");
+    }
+
+    #[test]
+    fn terminal_output_implements_read_for_host_owned_readers() {
+        let mut command = output_command();
+        command.stdout(Stdio::piped()).stderr(Stdio::null());
+        let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
+        let mut terminal = Terminal::from_daemon(&mut daemon);
+        let mut output = terminal
+            .take_output(TerminalStream::Stdout)
+            .expect("stdout should be available");
+
+        assert!(matches!(output, TerminalOutput::Stdout(_)));
+
+        let mut text = String::new();
+        output
+            .read_to_string(&mut text)
+            .expect("read terminal output");
+        assert!(text.contains("stdout"));
+        let _ = daemon.wait().expect("wait for test process");
+    }
+}


### PR DESCRIPTION
## Summary
- add a core terminal owner for daemon stdin, stdout, and stderr
- preserve output stream identity and retain underlying input I/O errors
- gate the Windows-only console encoding helper for clean non-Windows builds

## Verification
- cargo fmt --package sealantern-core -- --check
- cargo test --package sealantern-core process::
- cargo check --package sealantern-core --target x86_64-unknown-linux-gnu
- cargo check --package sealantern-core --target x86_64-apple-darwin

## Summary by Sourcery

为守护进程引入一个终端抽象，用于管理 stdin/stdout/stderr 的所有权和交互。

新功能：
- 新增一个 `Terminal` 类型，用于拥有守护进程的标准流，并提供写入输入和转移输出句柄的方法，同时保持各个流的身份一致性。

增强：
- 从 `process` 模块中导出与终端相关的类型，方便在整个核心 crate 中使用。
- 将 `WindowsConsoleEncoding` 辅助工具的实现限制在 Windows 目标上，以避免在非 Windows 平台上的构建问题。

测试：
- 新增类似集成测试的用例，用于验证终端 I/O 行为，包括流身份的保持、输入处理，以及对 `TerminalOutput` 读取的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a terminal abstraction for daemon processes to manage stdin/stdout/stderr ownership and interaction.

New Features:
- Add a Terminal type that owns a daemon process's standard streams and provides methods for writing input and transferring output handles while preserving stream identity.

Enhancements:
- Expose terminal-related types from the process module for easier consumption across the core crate.
- Restrict WindowsConsoleEncoding helper implementation to Windows targets to avoid non-Windows build issues.

Tests:
- Add integration-style tests validating terminal I/O behavior, including stream identity preservation, input handling, and TerminalOutput read support.

</details>