### PR TITLE
feat: add core instance modules

### DIFF
--- a/crates/core/src/instance/import.rs
+++ b/crates/core/src/instance/import.rs
@@ -1,0 +1,207 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use super::instance::{Instance, InstanceError, InstanceSpec, StartupMode};
+
+/// Input for planning a host-managed local-instance import.
+///
+/// The source directory and startup target are not read here. The host validates and copies them
+/// after this plan has established the destination-relative startup target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceImportRequest {
+    pub source_directory: PathBuf,
+    pub instance: InstanceSpec,
+}
+
+/// A validated import plan with a copied instance model for host adapters to persist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceImportPlan {
+    pub source_directory: PathBuf,
+    pub destination_directory: PathBuf,
+    pub startup_target_relative: Option<PathBuf>,
+    pub instance: Instance,
+}
+
+/// Builds an import plan without performing filesystem operations.
+pub fn plan_import(
+    mut request: InstanceImportRequest,
+) -> Result<InstanceImportPlan, InstanceImportError> {
+    if request.source_directory.as_os_str().is_empty() {
+        return Err(InstanceImportError::EmptySourceDirectory);
+    }
+
+    let destination_directory = request.instance.directory.clone();
+    if destination_directory.as_os_str().is_empty() {
+        return Err(InstanceImportError::EmptyDestinationDirectory);
+    }
+
+    let startup_target_relative = if request.instance.launch.startup_mode == StartupMode::Custom {
+        None
+    } else {
+        let source_target = request
+            .instance
+            .launch
+            .startup_target
+            .as_ref()
+            .ok_or(InstanceImportError::MissingSourceStartupTarget)?;
+        let relative = source_target
+            .strip_prefix(&request.source_directory)
+            .map_err(|_| InstanceImportError::StartupTargetOutsideSource {
+                source_directory: request.source_directory.clone(),
+                startup_target: source_target.clone(),
+            })?;
+        if relative.as_os_str().is_empty() {
+            return Err(InstanceImportError::SourceStartupTargetIsDirectory {
+                source_directory: request.source_directory.clone(),
+            });
+        }
+
+        let relative = relative.to_path_buf();
+        request.instance.launch.startup_target = Some(destination_directory.join(&relative));
+        Some(relative)
+    };
+
+    let instance = Instance::new(request.instance).map_err(InstanceImportError::Instance)?;
+
+    Ok(InstanceImportPlan {
+        source_directory: request.source_directory,
+        destination_directory,
+        startup_target_relative,
+        instance,
+    })
+}
+
+/// Describes why an instance import plan could not be created.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstanceImportError {
+    EmptySourceDirectory,
+    EmptyDestinationDirectory,
+    MissingSourceStartupTarget,
+    SourceStartupTargetIsDirectory {
+        source_directory: PathBuf,
+    },
+    StartupTargetOutsideSource {
+        source_directory: PathBuf,
+        startup_target: PathBuf,
+    },
+    Instance(InstanceError),
+}
+
+impl fmt::Display for InstanceImportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptySourceDirectory => {
+                write!(formatter, "import source directory cannot be empty")
+            }
+            Self::EmptyDestinationDirectory => {
+                write!(formatter, "import destination directory cannot be empty")
+            }
+            Self::MissingSourceStartupTarget => {
+                write!(formatter, "import requires a source startup target")
+            }
+            Self::SourceStartupTargetIsDirectory { source_directory } => write!(
+                formatter,
+                "import startup target must be a file below source directory {}",
+                source_directory.display()
+            ),
+            Self::StartupTargetOutsideSource { source_directory, startup_target } => write!(
+                formatter,
+                "startup target {} is outside import source directory {}",
+                startup_target.display(),
+                source_directory.display()
+            ),
+            Self::Instance(error) => write!(formatter, "invalid imported instance: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for InstanceImportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Instance(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::{plan_import, InstanceImportError, InstanceImportRequest};
+    use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+
+    fn import_spec(startup_target: Option<PathBuf>, startup_mode: StartupMode) -> InstanceSpec {
+        InstanceSpec {
+            id: InstanceId::new("imported-a").expect("instance ID should be valid"),
+            name: "Imported".to_string(),
+            aliases: Vec::new(),
+            core_type: "paper".to_string(),
+            core_version: String::new(),
+            game_version: "unknown".to_string(),
+            directory: PathBuf::from("managed/imported-a"),
+            port: 25565,
+            max_memory_mib: 4096,
+            min_memory_mib: 1024,
+            created_at_unix_secs: 100,
+            last_started_at_unix_secs: None,
+            launch: LocalLaunch {
+                startup_mode,
+                startup_target,
+                custom_command: None,
+                java_executable: Some(PathBuf::from("java")),
+                jvm_arguments: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn import_plan_rewrites_a_nested_startup_target_under_the_destination() {
+        let source_directory = PathBuf::from("imports/paper");
+        let startup_target = source_directory.join("libraries/server.jar");
+        let request = InstanceImportRequest {
+            source_directory: source_directory.clone(),
+            instance: import_spec(Some(startup_target), StartupMode::Jar),
+        };
+
+        let plan = plan_import(request).expect("import should plan");
+
+        assert_eq!(plan.startup_target_relative, Some(PathBuf::from("libraries/server.jar")));
+        assert_eq!(plan.instance.directory, Path::new("managed/imported-a"));
+        assert_eq!(
+            plan.instance.launch.startup_target,
+            Some(PathBuf::from("managed/imported-a/libraries/server.jar"))
+        );
+    }
+
+    #[test]
+    fn import_plan_rejects_a_startup_target_outside_the_source() {
+        let request = InstanceImportRequest {
+            source_directory: PathBuf::from("imports/paper"),
+            instance: import_spec(
+                Some(PathBuf::from("imports/shared/server.jar")),
+                StartupMode::Jar,
+            ),
+        };
+
+        let error = plan_import(request).expect_err("outside target must fail");
+
+        assert!(matches!(error, InstanceImportError::StartupTargetOutsideSource { .. }));
+    }
+
+    #[test]
+    fn custom_import_needs_no_startup_target() {
+        let mut spec = import_spec(None, StartupMode::Custom);
+        spec.launch.custom_command = Some("launch-custom".to_string());
+        let request = InstanceImportRequest {
+            source_directory: PathBuf::from("imports/custom"),
+            instance: spec,
+        };
+
+        let plan = plan_import(request).expect("custom import should plan");
+
+        assert!(plan.startup_target_relative.is_none());
+        assert!(plan.instance.launch.startup_target.is_none());
+        assert_eq!(plan.instance.launch.custom_command.as_deref(), Some("launch-custom"));
+    }
+}

--- a/crates/core/src/instance/import.rs
+++ b/crates/core/src/instance/import.rs
@@ -1,7 +1,7 @@
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use super::instance::{Instance, InstanceError, InstanceSpec, StartupMode};
+use super::instance::{Instance, InstanceError, InstanceSpec};
 
 /// Input for planning a host-managed local-instance import.
 ///
@@ -24,48 +24,77 @@ pub struct InstanceImportPlan {
 
 /// Builds an import plan without performing filesystem operations.
 pub fn plan_import(
-    mut request: InstanceImportRequest,
+    request: InstanceImportRequest,
 ) -> Result<InstanceImportPlan, InstanceImportError> {
-    if request.source_directory.as_os_str().is_empty() {
+    let InstanceImportRequest { source_directory, instance } = request;
+    let InstanceSpec {
+        id,
+        name,
+        aliases,
+        core_type,
+        core_version,
+        game_version,
+        directory,
+        port,
+        max_memory_mib,
+        min_memory_mib,
+        created_at_unix_secs,
+        last_started_at_unix_secs,
+        mut launch,
+    } = instance;
+
+    if source_directory.as_os_str().is_empty() {
         return Err(InstanceImportError::EmptySourceDirectory);
     }
-
-    let destination_directory = request.instance.directory.clone();
-    if destination_directory.as_os_str().is_empty() {
+    if directory.as_os_str().is_empty() {
         return Err(InstanceImportError::EmptyDestinationDirectory);
     }
 
-    let startup_target_relative = if request.instance.launch.startup_mode == StartupMode::Custom {
-        None
-    } else {
-        let source_target = request
-            .instance
-            .launch
-            .startup_target
-            .as_ref()
-            .ok_or(InstanceImportError::MissingSourceStartupTarget)?;
-        let relative = source_target
-            .strip_prefix(&request.source_directory)
-            .map_err(|_| InstanceImportError::StartupTargetOutsideSource {
-                source_directory: request.source_directory.clone(),
-                startup_target: source_target.clone(),
+    let source_startup_target = launch
+        .normalize_and_validate()
+        .map_err(InstanceImportError::Instance)?
+        .map(Path::to_path_buf);
+    let startup_target_relative = match source_startup_target {
+        Some(source_target) => {
+            let relative = source_target.strip_prefix(&source_directory).map_err(|_| {
+                InstanceImportError::StartupTargetOutsideSource {
+                    source_directory: source_directory.clone(),
+                    startup_target: source_target.clone(),
+                }
             })?;
-        if relative.as_os_str().is_empty() {
-            return Err(InstanceImportError::SourceStartupTargetIsDirectory {
-                source_directory: request.source_directory.clone(),
-            });
-        }
+            if relative.as_os_str().is_empty() {
+                return Err(InstanceImportError::StartupTargetMustBeBelowSource {
+                    source_directory: source_directory.clone(),
+                });
+            }
 
-        let relative = relative.to_path_buf();
-        request.instance.launch.startup_target = Some(destination_directory.join(&relative));
-        Some(relative)
+            let relative = relative.to_path_buf();
+            launch.startup_target = Some(directory.join(&relative));
+            Some(relative)
+        }
+        None => None,
     };
 
-    let instance = Instance::new(request.instance).map_err(InstanceImportError::Instance)?;
+    let instance = Instance::new(InstanceSpec {
+        id,
+        name,
+        aliases,
+        core_type,
+        core_version,
+        game_version,
+        directory,
+        port,
+        max_memory_mib,
+        min_memory_mib,
+        created_at_unix_secs,
+        last_started_at_unix_secs,
+        launch,
+    })
+    .map_err(InstanceImportError::Instance)?;
 
     Ok(InstanceImportPlan {
-        source_directory: request.source_directory,
-        destination_directory,
+        source_directory,
+        destination_directory: instance.directory.clone(),
         startup_target_relative,
         instance,
     })
@@ -76,8 +105,7 @@ pub fn plan_import(
 pub enum InstanceImportError {
     EmptySourceDirectory,
     EmptyDestinationDirectory,
-    MissingSourceStartupTarget,
-    SourceStartupTargetIsDirectory {
+    StartupTargetMustBeBelowSource {
         source_directory: PathBuf,
     },
     StartupTargetOutsideSource {
@@ -96,12 +124,9 @@ impl fmt::Display for InstanceImportError {
             Self::EmptyDestinationDirectory => {
                 write!(formatter, "import destination directory cannot be empty")
             }
-            Self::MissingSourceStartupTarget => {
-                write!(formatter, "import requires a source startup target")
-            }
-            Self::SourceStartupTargetIsDirectory { source_directory } => write!(
+            Self::StartupTargetMustBeBelowSource { source_directory } => write!(
                 formatter,
-                "import startup target must be a file below source directory {}",
+                "import startup target must be a path below source directory {}; the host verifies file type",
                 source_directory.display()
             ),
             Self::StartupTargetOutsideSource { source_directory, startup_target } => write!(
@@ -129,7 +154,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use super::{plan_import, InstanceImportError, InstanceImportRequest};
-    use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+    use crate::instance::{InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
 
     fn import_spec(startup_target: Option<PathBuf>, startup_mode: StartupMode) -> InstanceSpec {
         InstanceSpec {
@@ -203,5 +228,22 @@ mod tests {
         assert!(plan.startup_target_relative.is_none());
         assert!(plan.instance.launch.startup_target.is_none());
         assert_eq!(plan.instance.launch.custom_command.as_deref(), Some("launch-custom"));
+    }
+
+    #[test]
+    fn import_uses_the_shared_launch_validation_for_missing_targets() {
+        let request = InstanceImportRequest {
+            source_directory: PathBuf::from("imports/paper"),
+            instance: import_spec(None, StartupMode::Jar),
+        };
+
+        let error = plan_import(request).expect_err("non-custom imports require a startup target");
+
+        assert!(matches!(
+            error,
+            InstanceImportError::Instance(InstanceError::MissingStartupTarget {
+                mode: StartupMode::Jar
+            })
+        ));
     }
 }

--- a/crates/core/src/instance/import.rs
+++ b/crates/core/src/instance/import.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use super::instance::{Instance, InstanceError, InstanceSpec};
 
@@ -26,34 +26,19 @@ pub struct InstanceImportPlan {
 pub fn plan_import(
     request: InstanceImportRequest,
 ) -> Result<InstanceImportPlan, InstanceImportError> {
-    let InstanceImportRequest { source_directory, instance } = request;
-    let InstanceSpec {
-        id,
-        name,
-        aliases,
-        core_type,
-        core_version,
-        game_version,
-        directory,
-        port,
-        max_memory_mib,
-        min_memory_mib,
-        created_at_unix_secs,
-        last_started_at_unix_secs,
-        mut launch,
-    } = instance;
+    let InstanceImportRequest { source_directory, mut instance } = request;
 
     if source_directory.as_os_str().is_empty() {
         return Err(InstanceImportError::EmptySourceDirectory);
     }
-    if directory.as_os_str().is_empty() {
+    if instance.directory.as_os_str().is_empty() {
         return Err(InstanceImportError::EmptyDestinationDirectory);
     }
 
-    let source_startup_target = launch
+    let source_startup_target = instance
+        .launch
         .normalize_and_validate()
-        .map_err(InstanceImportError::Instance)?
-        .map(Path::to_path_buf);
+        .map_err(InstanceImportError::Instance)?;
     let startup_target_relative = match source_startup_target {
         Some(source_target) => {
             let relative = source_target.strip_prefix(&source_directory).map_err(|_| {
@@ -69,28 +54,13 @@ pub fn plan_import(
             }
 
             let relative = relative.to_path_buf();
-            launch.startup_target = Some(directory.join(&relative));
+            instance.launch.startup_target = Some(instance.directory.join(&relative));
             Some(relative)
         }
         None => None,
     };
 
-    let instance = Instance::new(InstanceSpec {
-        id,
-        name,
-        aliases,
-        core_type,
-        core_version,
-        game_version,
-        directory,
-        port,
-        max_memory_mib,
-        min_memory_mib,
-        created_at_unix_secs,
-        last_started_at_unix_secs,
-        launch,
-    })
-    .map_err(InstanceImportError::Instance)?;
+    let instance = Instance::new(instance).map_err(InstanceImportError::Instance)?;
 
     Ok(InstanceImportPlan {
         source_directory,

--- a/crates/core/src/instance/instance.rs
+++ b/crates/core/src/instance/instance.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// A stable identifier allocated by the host for a managed instance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -67,7 +67,7 @@ pub struct LocalLaunch {
 }
 
 impl LocalLaunch {
-    fn normalize_and_validate(&mut self) -> Result<(), InstanceError> {
+    pub(crate) fn normalize_and_validate(&mut self) -> Result<Option<&Path>, InstanceError> {
         self.custom_command = self
             .custom_command
             .as_deref()
@@ -83,18 +83,19 @@ impl LocalLaunch {
                 if self.startup_target.is_some() {
                     return Err(InstanceError::UnexpectedStartupTarget { mode: self.startup_mode });
                 }
+                Ok(None)
             }
             mode => {
-                if self.startup_target.is_none() {
-                    return Err(InstanceError::MissingStartupTarget { mode });
-                }
                 if self.custom_command.is_some() {
                     return Err(InstanceError::UnexpectedCustomCommand { mode });
                 }
+                let startup_target = self
+                    .startup_target
+                    .as_deref()
+                    .ok_or(InstanceError::MissingStartupTarget { mode })?;
+                Ok(Some(startup_target))
             }
         }
-
-        Ok(())
     }
 }
 
@@ -144,7 +145,7 @@ impl Instance {
             return Err(InstanceError::EmptyDirectory);
         }
         if spec.port == 0 {
-            return Err(InstanceError::InvalidPort);
+            return Err(InstanceError::UnsupportedPortZero);
         }
         if spec.max_memory_mib != 0
             && spec.min_memory_mib != 0
@@ -183,7 +184,7 @@ pub enum InstanceError {
     EmptyId,
     EmptyName,
     EmptyDirectory,
-    InvalidPort,
+    UnsupportedPortZero,
     InvalidMemoryRange {
         min_memory_mib: u32,
         max_memory_mib: u32,
@@ -209,7 +210,10 @@ impl fmt::Display for InstanceError {
             Self::EmptyId => write!(formatter, "instance ID cannot be empty"),
             Self::EmptyName => write!(formatter, "instance name cannot be empty"),
             Self::EmptyDirectory => write!(formatter, "instance directory cannot be empty"),
-            Self::InvalidPort => write!(formatter, "instance port must be greater than zero"),
+            Self::UnsupportedPortZero => write!(
+                formatter,
+                "port 0 is not supported; managed instances require an explicit port"
+            ),
             Self::InvalidMemoryRange { min_memory_mib, max_memory_mib } => write!(
                 formatter,
                 "minimum memory {min_memory_mib} MiB exceeds maximum memory {max_memory_mib} MiB"
@@ -314,6 +318,16 @@ mod tests {
                 max_memory_mib: 2048,
             }
         );
+    }
+
+    #[test]
+    fn instance_rejects_port_zero_instead_of_requesting_an_ephemeral_port() {
+        let mut spec = base_spec();
+        spec.port = 0;
+
+        let error = Instance::new(spec).expect_err("managed instances require a fixed port");
+
+        assert_eq!(error, InstanceError::UnsupportedPortZero);
     }
 
     #[test]

--- a/crates/core/src/instance/instance.rs
+++ b/crates/core/src/instance/instance.rs
@@ -1,0 +1,337 @@
+use std::ffi::OsString;
+use std::fmt;
+use std::path::PathBuf;
+
+/// A stable identifier allocated by the host for a managed instance.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InstanceId(String);
+
+impl InstanceId {
+    pub fn new(value: impl Into<String>) -> Result<Self, InstanceError> {
+        let value = value.into().trim().to_string();
+        if value.is_empty() {
+            return Err(InstanceError::EmptyId);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The configured mechanism used to start a local instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupMode {
+    Jar,
+    Batch,
+    Shell,
+    PowerShell,
+    Starter,
+    Custom,
+}
+
+impl StartupMode {
+    pub fn parse(value: &str) -> Result<Self, InstanceError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "jar" => Ok(Self::Jar),
+            "bat" | "batch" => Ok(Self::Batch),
+            "sh" | "shell" => Ok(Self::Shell),
+            "ps1" | "powershell" => Ok(Self::PowerShell),
+            "starter" => Ok(Self::Starter),
+            "custom" => Ok(Self::Custom),
+            _ => Err(InstanceError::UnsupportedStartupMode { value: value.to_string() }),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Jar => "jar",
+            Self::Batch => "bat",
+            Self::Shell => "sh",
+            Self::PowerShell => "ps1",
+            Self::Starter => "starter",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+/// Local runtime data owned by an instance, independent of process construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalLaunch {
+    pub startup_mode: StartupMode,
+    pub startup_target: Option<PathBuf>,
+    pub custom_command: Option<String>,
+    pub java_executable: Option<PathBuf>,
+    pub jvm_arguments: Vec<OsString>,
+}
+
+impl LocalLaunch {
+    fn normalize_and_validate(&mut self) -> Result<(), InstanceError> {
+        self.custom_command = self
+            .custom_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .map(str::to_string);
+
+        match self.startup_mode {
+            StartupMode::Custom => {
+                if self.custom_command.is_none() {
+                    return Err(InstanceError::MissingCustomCommand);
+                }
+                if self.startup_target.is_some() {
+                    return Err(InstanceError::UnexpectedStartupTarget { mode: self.startup_mode });
+                }
+            }
+            mode => {
+                if self.startup_target.is_none() {
+                    return Err(InstanceError::MissingStartupTarget { mode });
+                }
+                if self.custom_command.is_some() {
+                    return Err(InstanceError::UnexpectedCustomCommand { mode });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Input used to validate and construct an [`Instance`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceSpec {
+    pub id: InstanceId,
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub core_type: String,
+    pub core_version: String,
+    pub game_version: String,
+    pub directory: PathBuf,
+    pub port: u16,
+    pub max_memory_mib: u32,
+    pub min_memory_mib: u32,
+    pub created_at_unix_secs: u64,
+    pub last_started_at_unix_secs: Option<u64>,
+    pub launch: LocalLaunch,
+}
+
+/// A validated managed instance and its local runtime configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Instance {
+    pub id: InstanceId,
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub core_type: String,
+    pub core_version: String,
+    pub game_version: String,
+    pub directory: PathBuf,
+    pub port: u16,
+    pub max_memory_mib: u32,
+    pub min_memory_mib: u32,
+    pub created_at_unix_secs: u64,
+    pub last_started_at_unix_secs: Option<u64>,
+    pub launch: LocalLaunch,
+}
+
+impl Instance {
+    pub fn new(mut spec: InstanceSpec) -> Result<Self, InstanceError> {
+        spec.name = spec.name.trim().to_string();
+        if spec.name.is_empty() {
+            return Err(InstanceError::EmptyName);
+        }
+        if spec.directory.as_os_str().is_empty() {
+            return Err(InstanceError::EmptyDirectory);
+        }
+        if spec.port == 0 {
+            return Err(InstanceError::InvalidPort);
+        }
+        if spec.max_memory_mib != 0
+            && spec.min_memory_mib != 0
+            && spec.min_memory_mib > spec.max_memory_mib
+        {
+            return Err(InstanceError::InvalidMemoryRange {
+                min_memory_mib: spec.min_memory_mib,
+                max_memory_mib: spec.max_memory_mib,
+            });
+        }
+
+        spec.aliases = normalize_aliases(&spec.name, spec.aliases);
+        spec.launch.normalize_and_validate()?;
+
+        Ok(Self {
+            id: spec.id,
+            name: spec.name,
+            aliases: spec.aliases,
+            core_type: spec.core_type,
+            core_version: spec.core_version,
+            game_version: spec.game_version,
+            directory: spec.directory,
+            port: spec.port,
+            max_memory_mib: spec.max_memory_mib,
+            min_memory_mib: spec.min_memory_mib,
+            created_at_unix_secs: spec.created_at_unix_secs,
+            last_started_at_unix_secs: spec.last_started_at_unix_secs,
+            launch: spec.launch,
+        })
+    }
+}
+
+/// Identifies invalid or internally inconsistent instance data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstanceError {
+    EmptyId,
+    EmptyName,
+    EmptyDirectory,
+    InvalidPort,
+    InvalidMemoryRange {
+        min_memory_mib: u32,
+        max_memory_mib: u32,
+    },
+    UnsupportedStartupMode {
+        value: String,
+    },
+    MissingStartupTarget {
+        mode: StartupMode,
+    },
+    UnexpectedStartupTarget {
+        mode: StartupMode,
+    },
+    MissingCustomCommand,
+    UnexpectedCustomCommand {
+        mode: StartupMode,
+    },
+}
+
+impl fmt::Display for InstanceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyId => write!(formatter, "instance ID cannot be empty"),
+            Self::EmptyName => write!(formatter, "instance name cannot be empty"),
+            Self::EmptyDirectory => write!(formatter, "instance directory cannot be empty"),
+            Self::InvalidPort => write!(formatter, "instance port must be greater than zero"),
+            Self::InvalidMemoryRange { min_memory_mib, max_memory_mib } => write!(
+                formatter,
+                "minimum memory {min_memory_mib} MiB exceeds maximum memory {max_memory_mib} MiB"
+            ),
+            Self::UnsupportedStartupMode { value } => {
+                write!(formatter, "unsupported startup mode: {value}")
+            }
+            Self::MissingStartupTarget { mode } => {
+                write!(formatter, "{} mode requires a startup target", mode.as_str())
+            }
+            Self::UnexpectedStartupTarget { mode } => {
+                write!(formatter, "{} mode must not define a startup target", mode.as_str())
+            }
+            Self::MissingCustomCommand => write!(formatter, "custom mode requires a command"),
+            Self::UnexpectedCustomCommand { mode } => {
+                write!(formatter, "{} mode must not define a custom command", mode.as_str())
+            }
+        }
+    }
+}
+
+impl std::error::Error for InstanceError {}
+
+fn normalize_aliases(instance_name: &str, aliases: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::with_capacity(aliases.len());
+    for alias in aliases {
+        let alias = alias.trim();
+        if alias.is_empty()
+            || alias.eq_ignore_ascii_case(instance_name)
+            || normalized
+                .iter()
+                .any(|existing: &String| existing.eq_ignore_ascii_case(alias))
+        {
+            continue;
+        }
+        normalized.push(alias.to_string());
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    use super::{Instance, InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+
+    fn base_spec() -> InstanceSpec {
+        InstanceSpec {
+            id: InstanceId::new("instance-a").expect("instance ID should be valid"),
+            name: "Primary".to_string(),
+            aliases: Vec::new(),
+            core_type: "paper".to_string(),
+            core_version: String::new(),
+            game_version: "1.21.1".to_string(),
+            directory: PathBuf::from("servers/instance-a"),
+            port: 25565,
+            max_memory_mib: 4096,
+            min_memory_mib: 1024,
+            created_at_unix_secs: 100,
+            last_started_at_unix_secs: None,
+            launch: LocalLaunch {
+                startup_mode: StartupMode::Jar,
+                startup_target: Some(Path::new("servers/instance-a/server.jar").to_path_buf()),
+                custom_command: None,
+                java_executable: Some(Path::new("java").to_path_buf()),
+                jvm_arguments: vec![OsString::from("-Xmx4G")],
+            },
+        }
+    }
+
+    #[test]
+    fn instance_normalizes_aliases_and_trims_the_name() {
+        let mut spec = base_spec();
+        spec.name = " Primary ".to_string();
+        spec.aliases = vec![
+            " Alpha ".to_string(),
+            "alpha".to_string(),
+            "PRIMARY".to_string(),
+            "".to_string(),
+            "Beta".to_string(),
+        ];
+
+        let instance = Instance::new(spec).expect("instance should be valid");
+
+        assert_eq!(instance.name, "Primary");
+        assert_eq!(instance.aliases, vec!["Alpha", "Beta"]);
+    }
+
+    #[test]
+    fn instance_rejects_an_invalid_memory_range() {
+        let mut spec = base_spec();
+        spec.min_memory_mib = 4096;
+        spec.max_memory_mib = 2048;
+
+        let error = Instance::new(spec).expect_err("memory range must be ordered");
+
+        assert_eq!(
+            error,
+            InstanceError::InvalidMemoryRange {
+                min_memory_mib: 4096,
+                max_memory_mib: 2048,
+            }
+        );
+    }
+
+    #[test]
+    fn custom_launch_requires_a_command_and_no_startup_target() {
+        let mut spec = base_spec();
+        spec.launch.startup_mode = StartupMode::Custom;
+        spec.launch.startup_target = None;
+        spec.launch.custom_command = Some("  launch-server  ".to_string());
+
+        let instance = Instance::new(spec).expect("custom launch should be valid");
+
+        assert_eq!(instance.launch.custom_command.as_deref(), Some("launch-server"));
+    }
+
+    #[test]
+    fn startup_mode_parsing_rejects_unknown_modes() {
+        let error = StartupMode::parse("docker").expect_err("unknown mode should fail");
+
+        assert_eq!(error, InstanceError::UnsupportedStartupMode { value: "docker".to_string() });
+    }
+}

--- a/crates/core/src/instance/instance.rs
+++ b/crates/core/src/instance/instance.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// A stable identifier allocated by the host for a managed instance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -67,7 +67,7 @@ pub struct LocalLaunch {
 }
 
 impl LocalLaunch {
-    pub(crate) fn normalize_and_validate(&mut self) -> Result<Option<&Path>, InstanceError> {
+    pub(crate) fn normalize_and_validate(&mut self) -> Result<Option<PathBuf>, InstanceError> {
         self.custom_command = self
             .custom_command
             .as_deref()
@@ -91,7 +91,7 @@ impl LocalLaunch {
                 }
                 let startup_target = self
                     .startup_target
-                    .as_deref()
+                    .clone()
                     .ok_or(InstanceError::MissingStartupTarget { mode })?;
                 Ok(Some(startup_target))
             }

--- a/crates/core/src/instance/lib.rs
+++ b/crates/core/src/instance/lib.rs
@@ -1,0 +1,5 @@
+pub mod import;
+pub mod instance;
+
+pub use import::{plan_import, InstanceImportError, InstanceImportPlan, InstanceImportRequest};
+pub use instance::{Instance, InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,5 +3,8 @@
 pub mod observability;
 pub mod process;
 
+#[path = "instance/lib.rs"]
+pub mod instance;
+
 #[path = "server/lib.rs"]
 pub mod server;


### PR DESCRIPTION
## Summary
- add validated core instance metadata and local launch configuration
- add filesystem-free import planning with safe destination-relative startup targets
- keep host file copy, persistence, and runtime integration outside the core contract

## Verification
- cargo fmt --package sealantern-core -- --check
- cargo test --package sealantern-core instance::
- cargo check --package sealantern-core --target x86_64-unknown-linux-gnu
- cargo check --package sealantern-core --target x86_64-apple-darwin

## Summary by Sourcery

在 core crate 中新增核心实例模型和导入规划功能。

新功能：
- 在 core crate 中引入经过验证的实例身份、元数据以及本地启动配置类型。
- 提供与文件系统无关的实例导入规划功能，可生成相对于目标位置的启动目标。

增强内容：
- 通过 core crate 的公共实例模块暴露新的实例和导入规划 API。

测试：
- 添加单元测试，覆盖实例验证规则、别名规范化、启动模式解析以及导入规划的边界情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a core instance model and import planning to the core crate.

New Features:
- Introduce validated instance identity, metadata, and local launch configuration types in the core crate.
- Provide filesystem-agnostic instance import planning that produces destination-relative startup targets.

Enhancements:
- Expose the new instance and import planning APIs through the core crate's public instance module.

Tests:
- Add unit tests covering instance validation rules, alias normalization, startup mode parsing, and import planning edge cases.

</details>

新功能：
- 引入核心实例模型类型，包括标识符、元数据和本地启动配置
- 添加不依赖文件系统的实例导入规划，支持相对于目标位置的启动目标

改进：
- 从 core crate 中暴露新的实例与导入规划 API，并将实例模块接入核心库

测试：
- 添加单元测试，覆盖实例校验、别名规范化、启动模式解析以及导入规划的边界情况

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 core crate 中新增核心实例模型和导入规划功能。

新功能：
- 在 core crate 中引入经过验证的实例身份、元数据以及本地启动配置类型。
- 提供与文件系统无关的实例导入规划功能，可生成相对于目标位置的启动目标。

增强内容：
- 通过 core crate 的公共实例模块暴露新的实例和导入规划 API。

测试：
- 添加单元测试，覆盖实例验证规则、别名规范化、启动模式解析以及导入规划的边界情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a core instance model and import planning to the core crate.

New Features:
- Introduce validated instance identity, metadata, and local launch configuration types in the core crate.
- Provide filesystem-agnostic instance import planning that produces destination-relative startup targets.

Enhancements:
- Expose the new instance and import planning APIs through the core crate's public instance module.

Tests:
- Add unit tests covering instance validation rules, alias normalization, startup mode parsing, and import planning edge cases.

</details>

</details>