### PR TITLE
feat: add core provisioning parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5891,6 +5891,7 @@ name = "sealantern-core"
 version = "0.1.0"
 dependencies = [
  "tracing",
+ "zip",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,3 +9,4 @@ path = "src/lib.rs"
 
 [dependencies]
 tracing = "0.1"
+zip = { version = "2.0", default-features = false, features = ["deflate"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,5 +6,8 @@ pub mod process;
 #[path = "instance/lib.rs"]
 pub mod instance;
 
+#[path = "provisioning/lib.rs"]
+pub mod provisioning;
+
 #[path = "server/lib.rs"]
 pub mod server;

--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -1,0 +1,462 @@
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use zip::result::ZipError;
+
+/// A recognized server core family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoreKind {
+    ArclightForge,
+    ArclightNeoForge,
+    Youer,
+    Mohist,
+    CatServer,
+    SpongeForge,
+    ArclightFabric,
+    Banner,
+    NeoForge,
+    Forge,
+    Quilt,
+    Fabric,
+    PufferfishPurpur,
+    Pufferfish,
+    SpongeVanilla,
+    Purpur,
+    Paper,
+    Folia,
+    Leaves,
+    Leaf,
+    Spigot,
+    Bukkit,
+    VanillaSnapshot,
+    Vanilla,
+    NukkitX,
+    Bedrock,
+    Velocity,
+    BungeeCord,
+    Lightfall,
+    Travertine,
+    Pumpkin,
+    Unknown,
+}
+
+impl CoreKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ArclightForge => "arclight-forge",
+            Self::ArclightNeoForge => "arclight-neoforge",
+            Self::Youer => "youer",
+            Self::Mohist => "mohist",
+            Self::CatServer => "catserver",
+            Self::SpongeForge => "spongeforge",
+            Self::ArclightFabric => "arclight-fabric",
+            Self::Banner => "banner",
+            Self::NeoForge => "neoforge",
+            Self::Forge => "forge",
+            Self::Quilt => "quilt",
+            Self::Fabric => "fabric",
+            Self::PufferfishPurpur => "pufferfish_purpur",
+            Self::Pufferfish => "pufferfish",
+            Self::SpongeVanilla => "spongevanilla",
+            Self::Purpur => "purpur",
+            Self::Paper => "paper",
+            Self::Folia => "folia",
+            Self::Leaves => "leaves",
+            Self::Leaf => "leaf",
+            Self::Spigot => "spigot",
+            Self::Bukkit => "bukkit",
+            Self::VanillaSnapshot => "vanilla-snapshot",
+            Self::Vanilla => "vanilla",
+            Self::NukkitX => "nukkitx",
+            Self::Bedrock => "bedrock",
+            Self::Velocity => "velocity",
+            Self::BungeeCord => "bungeecord",
+            Self::Lightfall => "lightfall",
+            Self::Travertine => "travertine",
+            Self::Pumpkin => "pumpkin",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn from_filename(filename: &str) -> Self {
+        let filename = filename.to_ascii_lowercase();
+        for (kind, keywords) in CORE_KEYWORDS {
+            if keywords.iter().any(|keyword| filename.contains(keyword)) {
+                return *kind;
+            }
+        }
+        Self::Unknown
+    }
+}
+
+const CORE_KEYWORDS: &[(CoreKind, &[&str])] = &[
+    (CoreKind::ArclightForge, &["arclight-forge"]),
+    (CoreKind::ArclightNeoForge, &["arclight-neoforge"]),
+    (CoreKind::ArclightFabric, &["arclight-fabric"]),
+    (CoreKind::PufferfishPurpur, &["pufferfish_purpur", "pufferfish-purpur"]),
+    (CoreKind::VanillaSnapshot, &["vanilla-snapshot"]),
+    (CoreKind::Youer, &["youer"]),
+    (CoreKind::Mohist, &["mohist"]),
+    (CoreKind::CatServer, &["catserver"]),
+    (CoreKind::SpongeForge, &["spongeforge"]),
+    (CoreKind::Banner, &["banner"]),
+    (CoreKind::NeoForge, &["neoforge"]),
+    (CoreKind::Forge, &["forge"]),
+    (CoreKind::Quilt, &["quilt"]),
+    (CoreKind::Fabric, &["fabric"]),
+    (CoreKind::Pufferfish, &["pufferfish"]),
+    (CoreKind::SpongeVanilla, &["spongevanilla"]),
+    (CoreKind::Purpur, &["purpur"]),
+    (CoreKind::Paper, &["paper"]),
+    (CoreKind::Folia, &["folia"]),
+    (CoreKind::Leaves, &["leaves"]),
+    (CoreKind::Leaf, &["leaf"]),
+    (CoreKind::Spigot, &["spigot"]),
+    (CoreKind::Bukkit, &["bukkit"]),
+    (CoreKind::NukkitX, &["nukkitx", "nukkit"]),
+    (CoreKind::Bedrock, &["bedrock"]),
+    (CoreKind::Velocity, &["velocity"]),
+    (CoreKind::BungeeCord, &["bungeecord"]),
+    (CoreKind::Lightfall, &["lightfall"]),
+    (CoreKind::Travertine, &["travertine"]),
+    (CoreKind::Pumpkin, &["pumpkin"]),
+    (CoreKind::Vanilla, &["vanilla"]),
+];
+
+/// Parsed server-core metadata from a file name or JAR manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreFileInfo {
+    pub kind: CoreKind,
+    pub core_version: Option<String>,
+    pub minecraft_version: Option<String>,
+    pub main_class: Option<String>,
+}
+
+impl CoreFileInfo {
+    fn from_filename(filename: &str) -> Self {
+        let kind = CoreKind::from_filename(filename);
+        let minecraft_version = extract_minecraft_version(filename);
+        let core_version = extract_version_tokens(filename)
+            .into_iter()
+            .rev()
+            .find(|version| Some(version) != minecraft_version.as_ref());
+
+        Self {
+            kind,
+            core_version,
+            minecraft_version,
+            main_class: None,
+        }
+    }
+}
+
+/// Inspects a server-core filename without reading from disk.
+pub fn inspect_core_filename(filename: &str) -> CoreFileInfo {
+    let filename = Path::new(filename)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(filename);
+    CoreFileInfo::from_filename(filename)
+}
+
+/// Reads a JAR manifest and reconciles it with filename-based server-core detection.
+pub fn inspect_core_file(path: &Path) -> Result<CoreFileInfo, CoreParseError> {
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| CoreParseError::InvalidPath { path: path.to_path_buf() })?;
+    let mut info = CoreFileInfo::from_filename(filename);
+
+    if !path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("jar"))
+    {
+        return Ok(info);
+    }
+
+    let manifest = read_manifest(path)?;
+    let Some(manifest) = manifest else {
+        return Ok(info);
+    };
+
+    info.main_class = manifest.main_class;
+    if let Some(manifest_version) = manifest.implementation_version {
+        info.core_version = Some(manifest_version);
+    }
+    if let Some(main_class) = info.main_class.as_deref() {
+        if let Some(main_class_kind) = core_kind_from_main_class(main_class) {
+            info.kind = reconcile_core_kind(info.kind, main_class_kind);
+        }
+    }
+
+    Ok(info)
+}
+
+/// Extracts the first Minecraft-style version hint (for example `1.20.1`) from text.
+pub fn extract_minecraft_version(input: &str) -> Option<String> {
+    extract_version_tokens(input)
+        .into_iter()
+        .find(|version| version.starts_with("1."))
+}
+
+fn reconcile_core_kind(filename_kind: CoreKind, main_class_kind: CoreKind) -> CoreKind {
+    match (filename_kind, main_class_kind) {
+        // NeoForge installers retain a legacy Forge installer main class.
+        (CoreKind::NeoForge | CoreKind::ArclightNeoForge, CoreKind::Forge) => filename_kind,
+        (_, main_class_kind) => main_class_kind,
+    }
+}
+
+fn core_kind_from_main_class(main_class: &str) -> Option<CoreKind> {
+    match main_class {
+        value if value.starts_with("net.neoforged.serverstarterjar") => Some(CoreKind::NeoForge),
+        "net.minecraft.server.MinecraftServer" | "net.minecraft.bundler.Main" => {
+            Some(CoreKind::Vanilla)
+        }
+        "net.minecraft.client.Main" => Some(CoreKind::Unknown),
+        "net.minecraftforge.installer.SimpleInstaller" => Some(CoreKind::Forge),
+        "net.fabricmc.installer.Main" | "net.fabricmc.installer.ServerLauncher" => {
+            Some(CoreKind::Fabric)
+        }
+        "io.izzel.arclight.server.Launcher" => Some(CoreKind::ArclightForge),
+        "catserver.server.CatServerLaunch" | "foxlaunch.FoxServerLauncher" => {
+            Some(CoreKind::CatServer)
+        }
+        "org.bukkit.craftbukkit.Main" | "org.bukkit.craftbukkit.bootstrap.Main" => {
+            Some(CoreKind::Bukkit)
+        }
+        "io.papermc.paperclip.Main" | "com.destroystokyo.paperclip.Paperclip" => {
+            Some(CoreKind::Paper)
+        }
+        "org.leavesmc.leavesclip.Main" => Some(CoreKind::Leaves),
+        "net.md_5.bungee.Bootstrap" => Some(CoreKind::Lightfall),
+        "com.mohistmc.MohistMCStart" | "com.mohistmc.MohistMC" => Some(CoreKind::Mohist),
+        "com.velocitypowered.proxy.Velocity" => Some(CoreKind::Velocity),
+        _ => None,
+    }
+}
+
+struct JarManifest {
+    main_class: Option<String>,
+    implementation_version: Option<String>,
+}
+
+fn read_manifest(path: &Path) -> Result<Option<JarManifest>, CoreParseError> {
+    let file = File::open(path)
+        .map_err(|source| CoreParseError::Open { path: path.to_path_buf(), source })?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|source| CoreParseError::Archive { path: path.to_path_buf(), source })?;
+    let mut manifest = match archive.by_name("META-INF/MANIFEST.MF") {
+        Ok(manifest) => manifest,
+        Err(ZipError::FileNotFound) => return Ok(None),
+        Err(source) => {
+            return Err(CoreParseError::Manifest { path: path.to_path_buf(), source });
+        }
+    };
+
+    let mut bytes = Vec::new();
+    manifest
+        .read_to_end(&mut bytes)
+        .map_err(|source| CoreParseError::ManifestRead { path: path.to_path_buf(), source })?;
+    Ok(Some(parse_manifest(&String::from_utf8_lossy(&bytes))))
+}
+
+fn parse_manifest(content: &str) -> JarManifest {
+    let mut entries = Vec::new();
+    let mut current_key = String::new();
+    let mut current_value = String::new();
+
+    for line in content.lines() {
+        if line.is_empty() {
+            flush_manifest_entry(&mut entries, &mut current_key, &mut current_value);
+            continue;
+        }
+        if line.starts_with(' ') {
+            current_value.push_str(line.trim_start());
+            continue;
+        }
+
+        flush_manifest_entry(&mut entries, &mut current_key, &mut current_value);
+        if let Some((key, value)) = line.split_once(':') {
+            current_key.push_str(key.trim());
+            current_value.push_str(value.trim());
+        }
+    }
+    flush_manifest_entry(&mut entries, &mut current_key, &mut current_value);
+
+    JarManifest {
+        main_class: manifest_value(&entries, "Main-Class"),
+        implementation_version: manifest_value(&entries, "Implementation-Version"),
+    }
+}
+
+fn flush_manifest_entry(
+    entries: &mut Vec<(String, String)>,
+    current_key: &mut String,
+    current_value: &mut String,
+) {
+    if !current_key.is_empty() {
+        entries.push((std::mem::take(current_key), std::mem::take(current_value)));
+    }
+}
+
+fn manifest_value(entries: &[(String, String)], key: &str) -> Option<String> {
+    entries
+        .iter()
+        .find(|(entry_key, _)| entry_key.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn extract_version_tokens(input: &str) -> Vec<String> {
+    let bytes = input.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if !bytes[index].is_ascii_digit() || (index > 0 && bytes[index - 1].is_ascii_digit()) {
+            index += 1;
+            continue;
+        }
+
+        let started_at = index;
+        index += 1;
+        while index < bytes.len() && (bytes[index].is_ascii_digit() || bytes[index] == b'.') {
+            index += 1;
+        }
+        let token = input[started_at..index].trim_end_matches('.');
+        if !token.is_empty() {
+            tokens.push(token.to_string());
+        }
+    }
+
+    tokens
+}
+
+/// Describes a failure while opening or parsing a server-core file.
+#[derive(Debug)]
+pub enum CoreParseError {
+    InvalidPath { path: PathBuf },
+    Open { path: PathBuf, source: io::Error },
+    Archive { path: PathBuf, source: ZipError },
+    Manifest { path: PathBuf, source: ZipError },
+    ManifestRead { path: PathBuf, source: io::Error },
+}
+
+impl fmt::Display for CoreParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPath { path } => {
+                write!(formatter, "core file path has no filename: {}", path.display())
+            }
+            Self::Open { path, source } => {
+                write!(formatter, "could not open core file {}: {source}", path.display())
+            }
+            Self::Archive { path, source } => {
+                write!(formatter, "could not parse JAR archive {}: {source}", path.display())
+            }
+            Self::Manifest { path, source } => {
+                write!(formatter, "could not read JAR manifest from {}: {source}", path.display())
+            }
+            Self::ManifestRead { path, source } => write!(
+                formatter,
+                "could not read JAR manifest content from {}: {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CoreParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidPath { .. } => None,
+            Self::Open { source, .. } | Self::ManifestRead { source, .. } => Some(source),
+            Self::Archive { source, .. } | Self::Manifest { source, .. } => Some(source),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use zip::write::FileOptions;
+
+    use super::{
+        extract_minecraft_version, inspect_core_file, inspect_core_filename, parse_manifest,
+        CoreKind,
+    };
+
+    fn write_test_jar(filename: &str, manifest: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "sealantern-core-provisioning-{}-{}-{}.jar",
+            std::process::id(),
+            timestamp,
+            filename
+        ));
+        let file = File::create(&path).expect("create test JAR");
+        let mut archive = zip::ZipWriter::new(file);
+        archive
+            .start_file("META-INF/MANIFEST.MF", FileOptions::<()>::default())
+            .expect("create manifest entry");
+        archive
+            .write_all(manifest.as_bytes())
+            .expect("write manifest content");
+        archive.finish().expect("finish test JAR");
+        path
+    }
+
+    #[test]
+    fn filename_detection_prefers_neoforge_before_forge() {
+        let parsed = inspect_core_filename("neoforge-1.20.6-20.6.119.jar");
+
+        assert_eq!(parsed.kind, CoreKind::NeoForge);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("1.20.6"));
+        assert_eq!(parsed.core_version.as_deref(), Some("20.6.119"));
+    }
+
+    #[test]
+    fn manifest_parser_handles_continuation_lines() {
+        let manifest = parse_manifest(
+            "Manifest-Version: 1.0\r\nMain-Class: net.neoforged.server\r\n starterjar.Main\r\nImplementation-Version: 20.6.119\r\n\r\n",
+        );
+
+        assert_eq!(manifest.main_class.as_deref(), Some("net.neoforged.serverstarterjar.Main"));
+        assert_eq!(manifest.implementation_version.as_deref(), Some("20.6.119"));
+    }
+
+    #[test]
+    fn minecraft_version_extraction_ignores_non_minecraft_versions() {
+        assert_eq!(extract_minecraft_version("forge-47.2.0.jar"), None);
+        assert_eq!(extract_minecraft_version("paper-1.21.4-123.jar"), Some("1.21.4".to_string()));
+    }
+
+    #[test]
+    fn jar_manifest_keeps_neoforge_filename_over_legacy_forge_installer_class() {
+        let path = write_test_jar(
+            "neoforge-1.20.6-20.6.119-installer.jar",
+            "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.installer.SimpleInstaller\r\nImplementation-Version: 20.6.119\r\n\r\n",
+        );
+
+        let parsed = inspect_core_file(&path).expect("inspect test JAR");
+        std::fs::remove_file(&path).expect("remove test JAR");
+
+        assert_eq!(parsed.kind, CoreKind::NeoForge);
+        assert_eq!(
+            parsed.main_class.as_deref(),
+            Some("net.minecraftforge.installer.SimpleInstaller")
+        );
+        assert_eq!(parsed.core_version.as_deref(), Some("20.6.119"));
+    }
+}

--- a/crates/core/src/provisioning/lib.rs
+++ b/crates/core/src/provisioning/lib.rs
@@ -1,0 +1,10 @@
+pub mod core_parsing;
+pub mod startup_parsing;
+
+pub use core_parsing::{
+    inspect_core_file, inspect_core_filename, CoreFileInfo, CoreKind, CoreParseError,
+};
+pub use startup_parsing::{
+    parse_startup_script_content, parse_startup_script_file, JavaLaunch, StartupParseError,
+    StartupScriptInfo, StartupScriptKind,
+};

--- a/crates/core/src/provisioning/startup_parsing.rs
+++ b/crates/core/src/provisioning/startup_parsing.rs
@@ -1,0 +1,348 @@
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::core_parsing::{extract_minecraft_version, CoreKind};
+
+/// The script format selected from a startup-file extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupScriptKind {
+    Batch,
+    Shell,
+    PowerShell,
+}
+
+impl StartupScriptKind {
+    pub fn from_path(path: &Path) -> Option<Self> {
+        match path.extension().and_then(|extension| extension.to_str())? {
+            extension
+                if extension.eq_ignore_ascii_case("bat")
+                    || extension.eq_ignore_ascii_case("cmd") =>
+            {
+                Some(Self::Batch)
+            }
+            extension if extension.eq_ignore_ascii_case("sh") => Some(Self::Shell),
+            extension if extension.eq_ignore_ascii_case("ps1") => Some(Self::PowerShell),
+            _ => None,
+        }
+    }
+}
+
+/// One Java process invocation discovered in a startup script.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JavaLaunch {
+    pub java_command: String,
+    pub jvm_arguments: Vec<String>,
+    pub jar_path: Option<PathBuf>,
+    pub main_class: Option<String>,
+    pub argument_files: Vec<PathBuf>,
+    pub application_arguments: Vec<String>,
+}
+
+/// Parsed startup-script metadata without executing shell content or expanding variables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartupScriptInfo {
+    pub kind: StartupScriptKind,
+    pub launches: Vec<JavaLaunch>,
+    pub inferred_core: CoreKind,
+    pub minecraft_version: Option<String>,
+}
+
+/// Parses a startup script from a file without executing it.
+pub fn parse_startup_script_file(path: &Path) -> Result<StartupScriptInfo, StartupParseError> {
+    let kind = StartupScriptKind::from_path(path)
+        .ok_or_else(|| StartupParseError::UnsupportedScript { path: path.to_path_buf() })?;
+    let content = fs::read_to_string(path)
+        .map_err(|source| StartupParseError::Read { path: path.to_path_buf(), source })?;
+    Ok(parse_startup_script_content(kind, &content))
+}
+
+/// Parses startup-script content without executing commands or expanding variables.
+pub fn parse_startup_script_content(kind: StartupScriptKind, content: &str) -> StartupScriptInfo {
+    let launches = content
+        .lines()
+        .flat_map(|line| split_command_segments(kind, line))
+        .filter_map(|segment| parse_java_launch(&segment))
+        .collect::<Vec<_>>();
+    let inferred_core = infer_core_kind(&launches);
+    let minecraft_version = infer_minecraft_version(&launches);
+
+    StartupScriptInfo {
+        kind,
+        launches,
+        inferred_core,
+        minecraft_version,
+    }
+}
+
+fn split_command_segments(kind: StartupScriptKind, line: &str) -> Vec<String> {
+    let line = line.trim_start_matches('@').trim();
+    if is_comment_or_control_line(kind, line) {
+        return Vec::new();
+    }
+
+    let separators = match kind {
+        StartupScriptKind::Batch => "&",
+        StartupScriptKind::Shell | StartupScriptKind::PowerShell => ";",
+    };
+    split_outside_quotes(line, separators)
+}
+
+fn is_comment_or_control_line(kind: StartupScriptKind, line: &str) -> bool {
+    let lowercase = line.to_ascii_lowercase();
+    if line.is_empty() || lowercase == "pause" || lowercase.starts_with("echo ") {
+        return true;
+    }
+
+    match kind {
+        StartupScriptKind::Batch => lowercase.starts_with("rem ") || line.starts_with("::"),
+        StartupScriptKind::Shell | StartupScriptKind::PowerShell => line.starts_with('#'),
+    }
+}
+
+fn split_outside_quotes(line: &str, separators: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut segment = String::new();
+    let mut quote = None;
+    let mut characters = line.chars().peekable();
+
+    while let Some(character) = characters.next() {
+        if matches!(character, '\'' | '"') {
+            if quote == Some(character) {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some(character);
+            }
+            segment.push(character);
+            continue;
+        }
+        if quote.is_none() && separators.contains(character) {
+            if character == '&' && characters.peek() == Some(&'&') {
+                let _ = characters.next();
+            }
+            if !segment.trim().is_empty() {
+                segments.push(segment.trim().to_string());
+            }
+            segment.clear();
+            continue;
+        }
+        segment.push(character);
+    }
+
+    if !segment.trim().is_empty() {
+        segments.push(segment.trim().to_string());
+    }
+    segments
+}
+
+fn parse_java_launch(segment: &str) -> Option<JavaLaunch> {
+    let tokens = tokenize(segment);
+    let java_index = tokens.iter().position(|token| is_java_command(token))?;
+    let java_command = tokens[java_index].clone();
+    let mut launch = JavaLaunch {
+        java_command,
+        jvm_arguments: Vec::new(),
+        jar_path: None,
+        main_class: None,
+        argument_files: Vec::new(),
+        application_arguments: Vec::new(),
+    };
+    let mut index = java_index + 1;
+    let mut parse_application_arguments = false;
+
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if parse_application_arguments {
+            launch.application_arguments.push(token.clone());
+            index += 1;
+            continue;
+        }
+        if token == "-jar" {
+            if let Some(jar_path) = tokens.get(index + 1) {
+                launch.jar_path = Some(PathBuf::from(jar_path));
+                index += 2;
+                parse_application_arguments = true;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        if let Some(argument_file) = token.strip_prefix('@') {
+            if !argument_file.is_empty() {
+                launch.argument_files.push(PathBuf::from(argument_file));
+            }
+            index += 1;
+            continue;
+        }
+        if token == "-cp" || token == "-classpath" {
+            launch.jvm_arguments.push(token.clone());
+            if let Some(class_path) = tokens.get(index + 1) {
+                launch.jvm_arguments.push(class_path.clone());
+                index += 2;
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+        if token.starts_with('-') {
+            launch.jvm_arguments.push(token.clone());
+            index += 1;
+            continue;
+        }
+        launch.main_class = Some(token.clone());
+        parse_application_arguments = true;
+        index += 1;
+    }
+
+    Some(launch)
+}
+
+fn tokenize(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quote = None;
+
+    for character in input.chars() {
+        if matches!(character, '\'' | '"') {
+            if quote == Some(character) {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some(character);
+            } else {
+                token.push(character);
+            }
+            continue;
+        }
+        if quote.is_none() && character.is_whitespace() {
+            if !token.is_empty() {
+                tokens.push(std::mem::take(&mut token));
+            }
+            continue;
+        }
+        token.push(character);
+    }
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+    tokens
+}
+
+fn is_java_command(token: &str) -> bool {
+    let executable = Path::new(token)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(token)
+        .to_ascii_lowercase();
+    matches!(executable.as_str(), "java" | "java.exe" | "javaw" | "javaw.exe")
+}
+
+fn infer_core_kind(launches: &[JavaLaunch]) -> CoreKind {
+    launches
+        .iter()
+        .flat_map(|launch| launch.jar_path.iter().chain(launch.argument_files.iter()))
+        .map(|path| CoreKind::from_filename(&path.to_string_lossy()))
+        .find(|kind| *kind != CoreKind::Unknown)
+        .unwrap_or(CoreKind::Unknown)
+}
+
+fn infer_minecraft_version(launches: &[JavaLaunch]) -> Option<String> {
+    launches.iter().find_map(|launch| {
+        launch
+            .jar_path
+            .iter()
+            .chain(launch.argument_files.iter())
+            .find_map(|path| extract_minecraft_version(&path.to_string_lossy()))
+    })
+}
+
+/// Describes an error while loading a startup script for static parsing.
+#[derive(Debug)]
+pub enum StartupParseError {
+    UnsupportedScript { path: PathBuf },
+    Read { path: PathBuf, source: io::Error },
+}
+
+impl fmt::Display for StartupParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedScript { path } => {
+                write!(formatter, "unsupported startup script extension for {}", path.display())
+            }
+            Self::Read { path, source } => {
+                write!(formatter, "could not read startup script {}: {source}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for StartupParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::UnsupportedScript { .. } => None,
+            Self::Read { source, .. } => Some(source),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{parse_startup_script_content, CoreKind, StartupScriptKind};
+
+    #[test]
+    fn parses_a_direct_jar_launch_with_velocity_jvm_flags() {
+        let content = "@echo off\n\njava -Xms4096M -Xmx4096M -XX:+AlwaysPreTouch -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:MaxInlineLevel=15 -jar server.jar\n\npause";
+
+        let parsed = parse_startup_script_content(StartupScriptKind::Batch, content);
+
+        assert_eq!(parsed.launches.len(), 1);
+        let launch = &parsed.launches[0];
+        assert_eq!(launch.java_command, "java");
+        assert_eq!(launch.jar_path, Some(PathBuf::from("server.jar")));
+        assert_eq!(launch.jvm_arguments.len(), 8);
+        assert!(launch.jvm_arguments.contains(&"-XX:+UseG1GC".to_string()));
+    }
+
+    #[test]
+    fn parses_modern_forge_argument_file_launches() {
+        let content = "@echo off\njava @user_jvm_args.txt @libraries/net/minecraftforge/forge/1.20.1-47.2.0/win_args.txt %*\npause";
+
+        let parsed = parse_startup_script_content(StartupScriptKind::Batch, content);
+
+        assert_eq!(parsed.launches.len(), 1);
+        assert_eq!(parsed.inferred_core, CoreKind::Forge);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("1.20.1"));
+        assert_eq!(
+            parsed.launches[0].argument_files,
+            vec![
+                PathBuf::from("user_jvm_args.txt"),
+                PathBuf::from("libraries/net/minecraftforge/forge/1.20.1-47.2.0/win_args.txt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_neoforge_argument_file_launches_before_forge() {
+        let content = "java @libraries/net/neoforged/neoforge/1.21.1-21.1.96/win_args.txt";
+
+        let parsed = parse_startup_script_content(StartupScriptKind::Batch, content);
+
+        assert_eq!(parsed.inferred_core, CoreKind::NeoForge);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("1.21.1"));
+    }
+
+    #[test]
+    fn shell_parser_keeps_quoted_jar_paths_together() {
+        let content = "java -Xmx2G -jar \"server files/paper-1.21.1.jar\" nogui";
+
+        let parsed = parse_startup_script_content(StartupScriptKind::Shell, content);
+
+        assert_eq!(
+            parsed.launches[0].jar_path,
+            Some(PathBuf::from("server files/paper-1.21.1.jar"))
+        );
+        assert_eq!(parsed.inferred_core, CoreKind::Paper);
+    }
+}


### PR DESCRIPTION
## Summary
- add JAR core detection from filenames and manifests
- add non-executing startup-script parsing for batch, shell, and PowerShell
- recognize direct JAR and modern Forge/NeoForge argument-file launches

## Verification
- cargo fmt --package sealantern-core -- --check
- cargo test --package sealantern-core provisioning::
- cargo check --package sealantern-core --target x86_64-unknown-linux-gnu
- cargo check --package sealantern-core --target x86_64-apple-darwin

## 由 Sourcery 提供的摘要

引入用于从 JAR 和启动脚本中检测服务器核心的核心配置（provisioning）工具。

新功能：
- 添加 provisioning 模块，提供用于检查服务器核心 JAR 并从文件名和 manifest 中推断元数据的实用工具。
- 支持对 batch、shell 和 PowerShell 启动脚本进行静态解析，以提取 Java 启动配置，包括直接启动 JAR 和基于参数文件（argument-file）的启动方式。

增强内容：
- 将新的 provisioning 模块接入核心 crate 的公共 API，并添加基于 zip 的 JAR manifest 读取依赖。

测试：
- 添加单元测试，用于覆盖核心类型/版本检测、manifest 解析，以及针对常见服务器启动模式的启动脚本解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce core provisioning utilities for detecting server cores from JARs and startup scripts.

New Features:
- Add provisioning module exposing utilities to inspect server core JARs and infer metadata from filenames and manifests.
- Support static parsing of batch, shell, and PowerShell startup scripts to extract Java launch configurations, including direct JAR and argument-file based launches.

Enhancements:
- Wire the new provisioning module into the core crate’s public API and add a zip-based JAR manifest reader dependency.

Tests:
- Add unit tests covering core kind/version detection, manifest parsing, and startup script parsing for common server launch patterns.

</details>