### PR TITLE
fix: parse multiline startup commands

### DIFF
--- a/crates/core/src/provisioning/startup_parsing.rs
+++ b/crates/core/src/provisioning/startup_parsing.rs
@@ -60,8 +60,8 @@ pub fn parse_startup_script_file(path: &Path) -> Result<StartupScriptInfo, Start
 
 /// Parses startup-script content without executing commands or expanding variables.
 pub fn parse_startup_script_content(kind: StartupScriptKind, content: &str) -> StartupScriptInfo {
-    let launches = content
-        .lines()
+    let launches = logical_script_lines(kind, content)
+        .iter()
         .flat_map(|line| split_command_segments(kind, line))
         .filter_map(|segment| parse_java_launch(&segment))
         .collect::<Vec<_>>();
@@ -73,6 +73,47 @@ pub fn parse_startup_script_content(kind: StartupScriptKind, content: &str) -> S
         launches,
         inferred_core,
         minecraft_version,
+    }
+}
+
+fn logical_script_lines(kind: StartupScriptKind, content: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for line in content.lines() {
+        let line = line.trim_end();
+        if let Some(line) = remove_continuation_marker(kind, line) {
+            current.push_str(line);
+            current.push(' ');
+            continue;
+        }
+
+        current.push_str(line);
+        lines.push(std::mem::take(&mut current));
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+fn remove_continuation_marker(kind: StartupScriptKind, line: &str) -> Option<&str> {
+    let marker = match kind {
+        StartupScriptKind::Batch => '^',
+        StartupScriptKind::Shell => '\\',
+        StartupScriptKind::PowerShell => '`',
+    };
+    let marker_count = line
+        .chars()
+        .rev()
+        .take_while(|character| *character == marker)
+        .count();
+
+    if marker_count % 2 == 1 {
+        Some(&line[..line.len() - marker.len_utf8()])
+    } else {
+        None
     }
 }
 
@@ -324,6 +365,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_a_multiline_batch_forge_launch() {
+        let content = "java -Xmx4G ^\n  @user_jvm_args.txt ^\n  @libraries/net/minecraftforge/forge/1.20.1-47.2.0/win_args.txt %*";
+
+        let parsed = parse_startup_script_content(StartupScriptKind::Batch, content);
+
+        assert_eq!(parsed.launches.len(), 1);
+        assert_eq!(parsed.inferred_core, CoreKind::Forge);
+        assert_eq!(parsed.launches[0].jvm_arguments, vec!["-Xmx4G"]);
+        assert_eq!(parsed.launches[0].argument_files.len(), 2);
+    }
+
+    #[test]
     fn parses_neoforge_argument_file_launches_before_forge() {
         let content = "java @libraries/net/neoforged/neoforge/1.21.1-21.1.96/win_args.txt";
 
@@ -344,5 +397,23 @@ mod tests {
             Some(PathBuf::from("server files/paper-1.21.1.jar"))
         );
         assert_eq!(parsed.inferred_core, CoreKind::Paper);
+    }
+
+    #[test]
+    fn parses_shell_and_powershell_line_continuations() {
+        let shell = parse_startup_script_content(
+            StartupScriptKind::Shell,
+            concat!("java -Xmx2G ", "\\", "\n", "             -jar paper-1.21.1.jar nogui"),
+        );
+        let powershell = parse_startup_script_content(
+            StartupScriptKind::PowerShell,
+            "java -Xmx2G `\n             -jar paper-1.21.1.jar nogui",
+        );
+
+        for parsed in [shell, powershell] {
+            assert_eq!(parsed.launches.len(), 1);
+            assert_eq!(parsed.launches[0].jvm_arguments, vec!["-Xmx2G"]);
+            assert_eq!(parsed.launches[0].jar_path, Some(PathBuf::from("paper-1.21.1.jar")));
+        }
     }
 }

--- a/crates/core/src/provisioning/startup_parsing.rs
+++ b/crates/core/src/provisioning/startup_parsing.rs
@@ -84,12 +84,18 @@ fn logical_script_lines(kind: StartupScriptKind, content: &str) -> Vec<String> {
         let line = line.trim_end();
         if let Some(line) = remove_continuation_marker(kind, line) {
             current.push_str(line);
-            current.push(' ');
+            if !current.is_empty() && !current.chars().last().is_some_and(char::is_whitespace) {
+                current.push(' ');
+            }
             continue;
         }
 
         current.push_str(line);
-        lines.push(std::mem::take(&mut current));
+        if !current.trim().is_empty() {
+            lines.push(std::mem::take(&mut current));
+        } else {
+            current.clear();
+        }
     }
 
     if !current.is_empty() {
@@ -330,7 +336,23 @@ impl std::error::Error for StartupParseError {
 mod tests {
     use std::path::PathBuf;
 
-    use super::{parse_startup_script_content, CoreKind, StartupScriptKind};
+    use super::{logical_script_lines, parse_startup_script_content, CoreKind, StartupScriptKind};
+
+    #[test]
+    fn logical_lines_preserve_existing_continuation_whitespace() {
+        let lines =
+            logical_script_lines(StartupScriptKind::Batch, "java -Xmx2G ^\n-jar paper-1.21.1.jar");
+
+        assert_eq!(lines, vec!["java -Xmx2G -jar paper-1.21.1.jar"]);
+    }
+
+    #[test]
+    fn logical_lines_skip_blank_lines() {
+        let lines =
+            logical_script_lines(StartupScriptKind::Batch, "\n  \njava -jar paper-1.21.1.jar\n\t");
+
+        assert_eq!(lines, vec!["java -jar paper-1.21.1.jar"]);
+    }
 
     #[test]
     fn parses_a_direct_jar_launch_with_velocity_jvm_flags() {


### PR DESCRIPTION
## Summary
- join Batch, Shell, and PowerShell continuation lines before startup command parsing
- retain JVM arguments, JAR targets, and Forge argument-file paths across multiline launches
- add regression coverage for Batch Forge, Shell, and PowerShell scripts

## Verification
- cargo fmt --package sealantern-core -- --check
- cargo test --package sealantern-core

## Summary by Sourcery

在所有受支持的脚本类型中，在解析 Java 启动命令之前处理多行启动脚本命令。

Bug Fixes:
- 正确解析在 Batch、Shell 和 PowerShell 脚本中被拆分为多行的 Java 启动命令。

Tests:
- 添加回归测试，以覆盖多行 Batch Forge 启动以及 Shell/PowerShell 的行续写情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle multiline startup script commands before parsing Java launches across supported script types.

Bug Fixes:
- Correctly parse Java startup commands that are split across multiple lines in Batch, Shell, and PowerShell scripts.

Tests:
- Add regression tests covering multiline Batch Forge launches and Shell/PowerShell line continuations.

</details>