### PR TITLE
fix(server): 修复下载链接并发初始化时的竞态条件

### DIFF
--- a/src-tauri/src/services/server/downloader.rs
+++ b/src-tauri/src/services/server/downloader.rs
@@ -4,20 +4,23 @@ pub(crate) use crate::models::download::{
 };
 use crate::utils::downloader::SingleThreadDownloader;
 use serde_json::Value;
-use tokio::sync::OnceCell;
+use tokio::sync::{Mutex, OnceCell};
 
 ///此处常量见 utils/constants.rs
 use crate::utils::constants::DOWNLOAD_LINK_LIST_URL;
 
 static DOWNLOAD_LINKS: OnceCell<BaseDownloadLinks> = OnceCell::const_new();
+static INIT_LOCK: Mutex<()> = Mutex::const_new(());
 
 impl LinkManager {
     pub async fn get() -> Result<&'static BaseDownloadLinks, String> {
         if DOWNLOAD_LINKS.get().is_none() {
-            let links = Self::init().await?;
-            DOWNLOAD_LINKS
-                .set(links)
-                .map_err(|_| "download links already initialized".to_string())?;
+            let _guard = INIT_LOCK.lock().await;
+            // 双重检查：在锁内再次确认，防止等待锁期间别人已经初始化了
+            if DOWNLOAD_LINKS.get().is_none() {
+                let links = Self::init().await?;
+                DOWNLOAD_LINKS.set(links).ok();
+            }
         }
 
         DOWNLOAD_LINKS


### PR DESCRIPTION
使用双重检查锁定模式替代原有的 check-then-set 模式，
防止多个 Tauri 命令同时初始化 OnceCell 时 set() 失败。


## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

Bug Fixes:
- 防止在多个 Tauri 命令并发访问并初始化下载链接时，`OnceCell` 初始化失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent OnceCell initialization failures when multiple Tauri commands concurrently access and initialize the download links.

</details>