### PR TITLE
refactor(infra): 新增 persistence 配置模块

### DIFF
--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -4,3 +4,4 @@ pub mod download;
 pub mod fs;
 pub mod net;
 pub mod observability;
+pub mod persistence;

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -21,9 +21,7 @@ pub enum ConfigError {
         message: String,
     },
     /// File extension does not match any supported format.
-    UnsupportedFormat {
-        path: PathBuf,
-    },
+    UnsupportedFormat { path: PathBuf },
 }
 
 impl std::fmt::Display for ConfigError {
@@ -125,17 +123,17 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
 
         let data = if path.exists() {
             let content = read_limited(&path, CONFIG_READ_LIMIT).await?;
-            let text = String::from_utf8(content)
-                .map_err(|e| FsError::serialization("config", "decode UTF-8", &path, e.to_string()))?;
-            format.deserialize(&text).map_err(|e| {
-                FsError::serialization("config", "decode", &path, e.to_string())
-            })?
+            let text = String::from_utf8(content).map_err(|e| {
+                FsError::serialization("config", "decode UTF-8", &path, e.to_string())
+            })?;
+            format
+                .deserialize(&text)
+                .map_err(|e| FsError::serialization("config", "decode", &path, e.to_string()))?
         } else {
             ensure_parent(&path).await?;
-            let content =
-                format.serialize(&default).map_err(|e| {
-                    FsError::serialization("config", "encode", &path, e.to_string())
-                })?;
+            let content = format
+                .serialize(&default)
+                .map_err(|e| FsError::serialization("config", "encode", &path, e.to_string()))?;
             write_atomic(&path, content.as_bytes()).await?;
             default
         };
@@ -149,9 +147,9 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         let content = read_limited(&path, CONFIG_READ_LIMIT).await?;
         let text = String::from_utf8(content)
             .map_err(|e| FsError::serialization("config", "decode UTF-8", &path, e.to_string()))?;
-        let data = format.deserialize(&text).map_err(|e| {
-            FsError::serialization("config", "decode", &path, e.to_string())
-        })?;
+        let data = format
+            .deserialize(&text)
+            .map_err(|e| FsError::serialization("config", "decode", &path, e.to_string()))?;
         Ok(Self { path, data, format })
     }
 
@@ -163,19 +161,22 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         if auto_backup && self.path.exists() {
             self.backup().await?;
         }
-        let content = self.format.serialize(&self.data).map_err(|e| {
-            FsError::serialization("config", "encode", &self.path, e.to_string())
-        })?;
+        let content = self
+            .format
+            .serialize(&self.data)
+            .map_err(|e| FsError::serialization("config", "encode", &self.path, e.to_string()))?;
         write_atomic(&self.path, content.as_bytes()).await
     }
 
     pub async fn reload(&mut self) -> Result<(), FsError> {
         let content = read_limited(&self.path, CONFIG_READ_LIMIT).await?;
-        let text = String::from_utf8(content)
-            .map_err(|e| FsError::serialization("config", "decode UTF-8", &self.path, e.to_string()))?;
-        let data: T = self.format.deserialize(&text).map_err(|e| {
-            FsError::serialization("config", "decode", &self.path, e.to_string())
+        let text = String::from_utf8(content).map_err(|e| {
+            FsError::serialization("config", "decode UTF-8", &self.path, e.to_string())
         })?;
+        let data: T = self
+            .format
+            .deserialize(&text)
+            .map_err(|e| FsError::serialization("config", "decode", &self.path, e.to_string()))?;
         self.data = data;
         Ok(())
     }
@@ -197,7 +198,11 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis();
-        let file_name = self.path.file_name().and_then(|n| n.to_str()).unwrap_or("config");
+        let file_name = self
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("config");
         let backup_name = format!("{}.bak-{}", file_name, timestamp);
         let backup_path = self.path.with_file_name(&backup_name);
         tokio::fs::copy(&self.path, &backup_path)
@@ -228,7 +233,11 @@ mod tests {
 
     impl Default for TestConfig {
         fn default() -> Self {
-            Self { name: "default".into(), port: 25565, enabled: true }
+            Self {
+                name: "default".into(),
+                port: 25565,
+                enabled: true,
+            }
         }
     }
 
@@ -238,7 +247,11 @@ mod tests {
 
     #[test]
     fn config_format_round_trip_json() {
-        let cfg = TestConfig { name: "test".into(), port: 8080, enabled: false };
+        let cfg = TestConfig {
+            name: "test".into(),
+            port: 8080,
+            enabled: false,
+        };
         let json = ConfigFormat::Json.serialize(&cfg).unwrap();
         let restored: TestConfig = ConfigFormat::Json.deserialize(&json).unwrap();
         assert_eq!(cfg, restored);
@@ -246,7 +259,11 @@ mod tests {
 
     #[test]
     fn config_format_round_trip_toml() {
-        let cfg = TestConfig { name: "test".into(), port: 8080, enabled: false };
+        let cfg = TestConfig {
+            name: "test".into(),
+            port: 8080,
+            enabled: false,
+        };
         let toml = ConfigFormat::Toml.serialize(&cfg).unwrap();
         let restored: TestConfig = ConfigFormat::Toml.deserialize(&toml).unwrap();
         assert_eq!(cfg, restored);
@@ -254,7 +271,11 @@ mod tests {
 
     #[test]
     fn config_format_round_trip_yaml() {
-        let cfg = TestConfig { name: "test".into(), port: 8080, enabled: false };
+        let cfg = TestConfig {
+            name: "test".into(),
+            port: 8080,
+            enabled: false,
+        };
         let yaml = ConfigFormat::Yaml.serialize(&cfg).unwrap();
         let restored: TestConfig = ConfigFormat::Yaml.deserialize(&yaml).unwrap();
         assert_eq!(cfg, restored);
@@ -278,7 +299,9 @@ mod tests {
     async fn config_file_load_creates_default() {
         let dir = test_dir("load_default");
         let path = dir.join("settings.json");
-        let cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+        let cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
         assert_eq!(cfg.get().name, "default");
         assert!(path.exists());
         let _ = std::fs::remove_dir_all(&dir);
@@ -288,9 +311,15 @@ mod tests {
     async fn config_file_save_atomic() {
         let dir = test_dir("save_atomic");
         let path = dir.join("settings.json");
-        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
 
-        cfg.set(TestConfig { name: "modified".into(), port: 9999, enabled: false });
+        cfg.set(TestConfig {
+            name: "modified".into(),
+            port: 9999,
+            enabled: false,
+        });
         cfg.save(false).await.unwrap();
 
         let loaded = ConfigFile::<TestConfig>::load(&path).await.unwrap();
@@ -303,9 +332,15 @@ mod tests {
     async fn config_file_reload() {
         let dir = test_dir("reload");
         let path = dir.join("settings.json");
-        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
 
-        let modified = TestConfig { name: "external".into(), port: 1234, enabled: true };
+        let modified = TestConfig {
+            name: "external".into(),
+            port: 1234,
+            enabled: true,
+        };
         let json = ConfigFormat::Json.serialize(&modified).unwrap();
         std::fs::write(&path, &json).unwrap();
 
@@ -318,15 +353,25 @@ mod tests {
     async fn config_file_backup() {
         let dir = test_dir("backup");
         let path = dir.join("settings.json");
-        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
 
-        cfg.set(TestConfig { name: "before".into(), port: 1111, enabled: true });
+        cfg.set(TestConfig {
+            name: "before".into(),
+            port: 1111,
+            enabled: true,
+        });
         cfg.save(false).await.unwrap();
 
         let backup_path = cfg.backup().await.unwrap();
         assert!(backup_path.exists());
 
-        cfg.set(TestConfig { name: "after".into(), port: 2222, enabled: false });
+        cfg.set(TestConfig {
+            name: "after".into(),
+            port: 2222,
+            enabled: false,
+        });
         cfg.save(false).await.unwrap();
 
         std::fs::copy(&backup_path, &path).unwrap();
@@ -339,7 +384,9 @@ mod tests {
     async fn config_file_update_closure() {
         let dir = test_dir("update");
         let path = dir.join("settings.json");
-        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
 
         cfg.update(|c| c.port = 8888);
         assert_eq!(cfg.get().port, 8888);

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -1,0 +1,348 @@
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::fs::{ensure_parent, read_limited, write_atomic, DataLimit, FsError};
+
+const CONFIG_READ_LIMIT: DataLimit = DataLimit::new(10 * 1024 * 1024);
+
+/// Errors returned by configuration operations.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// Serialization failed.
+    Serialize {
+        format: &'static str,
+        message: String,
+    },
+    /// Deserialization failed.
+    Deserialize {
+        format: &'static str,
+        message: String,
+    },
+    /// File extension does not match any supported format.
+    UnsupportedFormat {
+        path: PathBuf,
+    },
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::Serialize { format, message } => {
+                write!(f, "failed to serialize {format}: {message}")
+            }
+            ConfigError::Deserialize { format, message } => {
+                write!(f, "failed to deserialize {format}: {message}")
+            }
+            ConfigError::UnsupportedFormat { path } => {
+                write!(f, "unsupported config format: {}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Supported configuration file format.
+///
+/// Can be used directly for string-level serialization and deserialization
+/// without touching the file system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigFormat {
+    Json,
+    Toml,
+    Yaml,
+}
+
+impl ConfigFormat {
+    fn from_extension(path: &Path) -> Result<Self, ConfigError> {
+        match path.extension().and_then(|e| e.to_str()) {
+            Some("json") => Ok(ConfigFormat::Json),
+            Some("toml") => Ok(ConfigFormat::Toml),
+            Some("yaml") | Some("yml") => Ok(ConfigFormat::Yaml),
+            _ => Err(ConfigError::UnsupportedFormat { path: path.to_path_buf() }),
+        }
+    }
+
+    pub fn serialize<T: Serialize>(&self, value: &T) -> Result<String, ConfigError> {
+        match self {
+            ConfigFormat::Json => serde_json::to_string_pretty(value)
+                .map_err(|e| ConfigError::Serialize { format: "JSON", message: e.to_string() }),
+            ConfigFormat::Toml => toml::to_string_pretty(value)
+                .map_err(|e| ConfigError::Serialize { format: "TOML", message: e.to_string() }),
+            ConfigFormat::Yaml => serde_yaml::to_string(value)
+                .map_err(|e| ConfigError::Serialize { format: "YAML", message: e.to_string() }),
+        }
+    }
+
+    pub fn deserialize<T: DeserializeOwned>(&self, data: &str) -> Result<T, ConfigError> {
+        match self {
+            ConfigFormat::Json => serde_json::from_str(data)
+                .map_err(|e| ConfigError::Deserialize { format: "JSON", message: e.to_string() }),
+            ConfigFormat::Toml => toml::from_str(data)
+                .map_err(|e| ConfigError::Deserialize { format: "TOML", message: e.to_string() }),
+            ConfigFormat::Yaml => serde_yaml::from_str(data)
+                .map_err(|e| ConfigError::Deserialize { format: "YAML", message: e.to_string() }),
+        }
+    }
+}
+
+impl From<ConfigError> for FsError {
+    fn from(err: ConfigError) -> Self {
+        match err {
+            ConfigError::Serialize { format, message } => {
+                FsError::serialization(format, "encode", "", message)
+            }
+            ConfigError::Deserialize { format, message } => {
+                FsError::serialization(format, "decode", "", message)
+            }
+            ConfigError::UnsupportedFormat { path } => FsError::InvalidPath {
+                path,
+                reason: "unsupported config format (expected .json, .toml, .yaml, or .yml)",
+            },
+        }
+    }
+}
+
+/// Generic configuration file manager.
+///
+/// Provides load, save, backup and restore operations for any serializable type.
+/// The config format is inferred from the file extension.
+///
+/// File I/O methods are asynchronous and reuse `fs` primitives
+/// (`write_atomic`, `read_limited`, `ensure_parent`).
+pub struct ConfigFile<T> {
+    path: PathBuf,
+    data: T,
+    format: ConfigFormat,
+}
+
+impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
+    pub async fn load_or_create(path: impl Into<PathBuf>, default: T) -> Result<Self, FsError> {
+        let path = path.into();
+        let format = ConfigFormat::from_extension(&path)?;
+
+        let data = if path.exists() {
+            let content = read_limited(&path, CONFIG_READ_LIMIT).await?;
+            let text = String::from_utf8(content)
+                .map_err(|e| FsError::serialization("config", "decode UTF-8", &path, e.to_string()))?;
+            format.deserialize(&text).map_err(|e| {
+                FsError::serialization("config", "decode", &path, e.to_string())
+            })?
+        } else {
+            ensure_parent(&path).await?;
+            let content =
+                format.serialize(&default).map_err(|e| {
+                    FsError::serialization("config", "encode", &path, e.to_string())
+                })?;
+            write_atomic(&path, content.as_bytes()).await?;
+            default
+        };
+
+        Ok(Self { path, data, format })
+    }
+
+    pub async fn load(path: impl Into<PathBuf>) -> Result<Self, FsError> {
+        let path = path.into();
+        let format = ConfigFormat::from_extension(&path)?;
+        let content = read_limited(&path, CONFIG_READ_LIMIT).await?;
+        let text = String::from_utf8(content)
+            .map_err(|e| FsError::serialization("config", "decode UTF-8", &path, e.to_string()))?;
+        let data = format.deserialize(&text).map_err(|e| {
+            FsError::serialization("config", "decode", &path, e.to_string())
+        })?;
+        Ok(Self { path, data, format })
+    }
+
+    /// Save current configuration to file using atomic write.
+    ///
+    /// When `auto_backup` is true, the previous version is backed up before
+    /// the new content is written, enabling recovery if the new file is corrupt.
+    pub async fn save(&self, auto_backup: bool) -> Result<(), FsError> {
+        if auto_backup && self.path.exists() {
+            self.backup().await?;
+        }
+        let content = self.format.serialize(&self.data).map_err(|e| {
+            FsError::serialization("config", "encode", &self.path, e.to_string())
+        })?;
+        write_atomic(&self.path, content.as_bytes()).await
+    }
+
+    pub async fn reload(&mut self) -> Result<(), FsError> {
+        let content = read_limited(&self.path, CONFIG_READ_LIMIT).await?;
+        let text = String::from_utf8(content)
+            .map_err(|e| FsError::serialization("config", "decode UTF-8", &self.path, e.to_string()))?;
+        let data: T = self.format.deserialize(&text).map_err(|e| {
+            FsError::serialization("config", "decode", &self.path, e.to_string())
+        })?;
+        self.data = data;
+        Ok(())
+    }
+
+    pub fn get(&self) -> &T {
+        &self.data
+    }
+
+    pub fn set(&mut self, data: T) {
+        self.data = data;
+    }
+
+    pub fn update(&mut self, f: impl FnOnce(&mut T)) {
+        f(&mut self.data);
+    }
+
+    pub async fn backup(&self) -> Result<PathBuf, FsError> {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let file_name = self.path.file_name().and_then(|n| n.to_str()).unwrap_or("config");
+        let backup_name = format!("{}.bak-{}", file_name, timestamp);
+        let backup_path = self.path.with_file_name(&backup_name);
+        tokio::fs::copy(&self.path, &backup_path)
+            .await
+            .map_err(|e| FsError::io("backup config", &self.path, e))?;
+        Ok(backup_path)
+    }
+}
+
+impl<T: Serialize + DeserializeOwned + Default> ConfigFile<T> {
+    pub async fn load_or_default(path: impl Into<PathBuf>) -> Result<Self, FsError> {
+        Self::load_or_create(path, T::default()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct TestConfig {
+        name: String,
+        port: u16,
+        enabled: bool,
+    }
+
+    impl Default for TestConfig {
+        fn default() -> Self {
+            Self { name: "default".into(), port: 25565, enabled: true }
+        }
+    }
+
+    fn test_dir(label: &str) -> PathBuf {
+        crate::fs::test_dir(label)
+    }
+
+    #[test]
+    fn config_format_round_trip_json() {
+        let cfg = TestConfig { name: "test".into(), port: 8080, enabled: false };
+        let json = ConfigFormat::Json.serialize(&cfg).unwrap();
+        let restored: TestConfig = ConfigFormat::Json.deserialize(&json).unwrap();
+        assert_eq!(cfg, restored);
+    }
+
+    #[test]
+    fn config_format_round_trip_toml() {
+        let cfg = TestConfig { name: "test".into(), port: 8080, enabled: false };
+        let toml = ConfigFormat::Toml.serialize(&cfg).unwrap();
+        let restored: TestConfig = ConfigFormat::Toml.deserialize(&toml).unwrap();
+        assert_eq!(cfg, restored);
+    }
+
+    #[test]
+    fn config_format_round_trip_yaml() {
+        let cfg = TestConfig { name: "test".into(), port: 8080, enabled: false };
+        let yaml = ConfigFormat::Yaml.serialize(&cfg).unwrap();
+        let restored: TestConfig = ConfigFormat::Yaml.deserialize(&yaml).unwrap();
+        assert_eq!(cfg, restored);
+    }
+
+    #[test]
+    fn config_format_unsupported_extension() {
+        let result = ConfigFormat::from_extension(Path::new("config.ini"));
+        assert!(matches!(result, Err(ConfigError::UnsupportedFormat { .. })));
+    }
+
+    #[test]
+    fn config_format_serialize_error() {
+        let mut value = std::collections::HashMap::new();
+        value.insert(vec![1u8], "value");
+        let result = ConfigFormat::Json.serialize(&value);
+        assert!(matches!(result, Err(ConfigError::Serialize { .. })));
+    }
+
+    #[tokio::test]
+    async fn config_file_load_creates_default() {
+        let dir = test_dir("load_default");
+        let path = dir.join("settings.json");
+        let cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+        assert_eq!(cfg.get().name, "default");
+        assert!(path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn config_file_save_atomic() {
+        let dir = test_dir("save_atomic");
+        let path = dir.join("settings.json");
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+
+        cfg.set(TestConfig { name: "modified".into(), port: 9999, enabled: false });
+        cfg.save(false).await.unwrap();
+
+        let loaded = ConfigFile::<TestConfig>::load(&path).await.unwrap();
+        assert_eq!(loaded.get().name, "modified");
+        assert_eq!(loaded.get().port, 9999);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn config_file_reload() {
+        let dir = test_dir("reload");
+        let path = dir.join("settings.json");
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+
+        let modified = TestConfig { name: "external".into(), port: 1234, enabled: true };
+        let json = ConfigFormat::Json.serialize(&modified).unwrap();
+        std::fs::write(&path, &json).unwrap();
+
+        cfg.reload().await.unwrap();
+        assert_eq!(cfg.get().name, "external");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn config_file_backup() {
+        let dir = test_dir("backup");
+        let path = dir.join("settings.json");
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+
+        cfg.set(TestConfig { name: "before".into(), port: 1111, enabled: true });
+        cfg.save(false).await.unwrap();
+
+        let backup_path = cfg.backup().await.unwrap();
+        assert!(backup_path.exists());
+
+        cfg.set(TestConfig { name: "after".into(), port: 2222, enabled: false });
+        cfg.save(false).await.unwrap();
+
+        std::fs::copy(&backup_path, &path).unwrap();
+        let restored = ConfigFile::<TestConfig>::load(&path).await.unwrap();
+        assert_eq!(restored.get().name, "before");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn config_file_update_closure() {
+        let dir = test_dir("update");
+        let path = dir.join("settings.json");
+        let mut cfg = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await.unwrap();
+
+        cfg.update(|c| c.port = 8888);
+        assert_eq!(cfg.get().port, 8888);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/infra/src/persistence/mod.rs
+++ b/crates/infra/src/persistence/mod.rs
@@ -1,0 +1,3 @@
+pub mod config;
+
+pub use config::{ConfigError, ConfigFile, ConfigFormat};


### PR DESCRIPTION
- ConfigFile<T> 泛型配置文件管理器（load/load_or_create/save/reload）
- ConfigFormat 枚举（JSON/TOML/YAML）支持纯字符串序列化与反序列化
- ConfigError 自定义错误类型，与 FsError 可互转
- save() 支持 auto_backup 参数，写入前自动备份
- 复用 fs 模块的 write_atomic、read_limited、ensure_parent
- 10 个测试覆盖序列化、加载、保存、重载、备份全流程


## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

引入一个新的持久化模块，提供带备份支持的通用配置文件管理功能。

New Features:
- 添加通用的 `ConfigFile` 管理器，用于加载、保存、重新加载和备份类型化配置文件，配置类型根据文件扩展名推断。
- 添加 `ConfigFormat` 工具，用于在不直接访问文件系统的情况下，以 JSON、TOML 和 YAML 格式序列化和反序列化配置数据。
- 暴露 `ConfigError`，用于结构化的配置相关错误处理，并可转换为现有的 `FsError` 类型。

Enhancements:
- 将配置持久化与现有的基础设施文件系统工具集成，实现原子写入、限定大小读取和父目录自动创建。

Tests:
- 添加单元测试和异步测试，覆盖格式往返转换、错误处理、加载/创建流程、原子保存、重新加载、备份以及对配置数据的就地更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new persistence module providing generic configuration file management with backup support.

New Features:
- Add a generic ConfigFile manager for loading, saving, reloading, and backing up typed configuration files inferred from file extension.
- Add ConfigFormat utilities to serialize and deserialize configuration data in JSON, TOML, and YAML without direct filesystem interaction.
- Expose ConfigError for structured configuration-related error handling and conversion into existing FsError types.

Enhancements:
- Integrate configuration persistence with existing infra fs utilities for atomic writes, bounded reads, and parent directory creation.

Tests:
- Add unit and async tests covering format round-trips, error handling, load/create flows, atomic saving, reloading, backups, and in-place updates of configuration data.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个新的持久化模块，提供带备份支持的通用配置文件管理功能。

New Features:
- 添加通用的 `ConfigFile` 管理器，用于加载、保存、重新加载和备份类型化配置文件，配置类型根据文件扩展名推断。
- 添加 `ConfigFormat` 工具，用于在不直接访问文件系统的情况下，以 JSON、TOML 和 YAML 格式序列化和反序列化配置数据。
- 暴露 `ConfigError`，用于结构化的配置相关错误处理，并可转换为现有的 `FsError` 类型。

Enhancements:
- 将配置持久化与现有的基础设施文件系统工具集成，实现原子写入、限定大小读取和父目录自动创建。

Tests:
- 添加单元测试和异步测试，覆盖格式往返转换、错误处理、加载/创建流程、原子保存、重新加载、备份以及对配置数据的就地更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new persistence module providing generic configuration file management with backup support.

New Features:
- Add a generic ConfigFile manager for loading, saving, reloading, and backing up typed configuration files inferred from file extension.
- Add ConfigFormat utilities to serialize and deserialize configuration data in JSON, TOML, and YAML without direct filesystem interaction.
- Expose ConfigError for structured configuration-related error handling and conversion into existing FsError types.

Enhancements:
- Integrate configuration persistence with existing infra fs utilities for atomic writes, bounded reads, and parent directory creation.

Tests:
- Add unit and async tests covering format round-trips, error handling, load/create flows, atomic saving, reloading, backups, and in-place updates of configuration data.

</details>

</details>