### PR TITLE
feat: add hardened archive infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6030,6 +6030,7 @@ dependencies = [
  "toml 0.8.2",
  "tracing",
  "uuid",
+ "zip",
 ]
 
 [[package]]

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -25,3 +25,4 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 toml = "0.8"
 uuid = { version = "1", features = ["v4"] }
+zip = { version = "2.0", default-features = false, features = ["deflate"] }

--- a/crates/infra/src/archive/error.rs
+++ b/crates/infra/src/archive/error.rs
@@ -1,0 +1,97 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use zip::result::ZipError;
+
+/// Errors returned by ZIP archive operations.
+#[derive(Debug)]
+pub enum ArchiveError {
+    /// An operating system file operation failed.
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// The ZIP format could not be read or written.
+    Zip {
+        operation: &'static str,
+        path: PathBuf,
+        source: ZipError,
+    },
+    /// The requested ZIP source is not a regular directory.
+    InvalidSource { path: PathBuf, reason: &'static str },
+    /// A source entry cannot be represented safely in a portable ZIP archive.
+    UnsupportedSourceEntry { path: PathBuf, kind: &'static str },
+    /// An archive entry name would escape or otherwise violate the extraction root.
+    UnsafeEntry {
+        archive: PathBuf,
+        entry: String,
+        reason: String,
+    },
+    /// An archive entry uses a type intentionally unsupported by this API.
+    UnsupportedEntry {
+        archive: PathBuf,
+        entry: String,
+        kind: &'static str,
+    },
+    /// A symbolic-link payload is not a portable, safe relative path.
+    InvalidSymbolicLinkTarget { reason: &'static str },
+}
+
+impl ArchiveError {
+    pub(crate) fn io(
+        operation: &'static str,
+        path: impl Into<PathBuf>,
+        source: std::io::Error,
+    ) -> Self {
+        Self::Io { operation, path: path.into(), source }
+    }
+
+    pub(crate) fn zip(operation: &'static str, path: impl Into<PathBuf>, source: ZipError) -> Self {
+        Self::Zip { operation, path: path.into(), source }
+    }
+}
+
+impl fmt::Display for ArchiveError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { operation, path, source } => {
+                write!(formatter, "failed to {operation} '{}': {source}", path.display())
+            }
+            Self::Zip { operation, path, source } => write!(
+                formatter,
+                "failed to {operation} ZIP archive '{}': {source}",
+                path.display()
+            ),
+            Self::InvalidSource { path, reason } => {
+                write!(formatter, "invalid ZIP source '{}': {reason}", path.display())
+            }
+            Self::UnsupportedSourceEntry { path, kind } => write!(
+                formatter,
+                "cannot add {kind} source entry '{}' to a portable ZIP archive",
+                path.display()
+            ),
+            Self::UnsafeEntry { archive, entry, reason } => {
+                write!(formatter, "unsafe ZIP entry '{entry}' in '{}': {reason}", archive.display())
+            }
+            Self::UnsupportedEntry { archive, entry, kind } => write!(
+                formatter,
+                "unsupported {kind} ZIP entry '{entry}' in '{}'",
+                archive.display()
+            ),
+            Self::InvalidSymbolicLinkTarget { reason } => {
+                write!(formatter, "invalid ZIP symbolic-link target: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ArchiveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Zip { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/crates/infra/src/archive/error.rs
+++ b/crates/infra/src/archive/error.rs
@@ -20,6 +20,10 @@ pub enum ArchiveError {
     },
     /// The requested ZIP source is not a regular directory.
     InvalidSource { path: PathBuf, reason: &'static str },
+    /// The extraction destination is not a new, ordinary directory.
+    InvalidDestination { path: PathBuf, reason: &'static str },
+    /// An output archive or extraction destination already exists.
+    DestinationExists { path: PathBuf },
     /// A source entry cannot be represented safely in a portable ZIP archive.
     UnsupportedSourceEntry { path: PathBuf, kind: &'static str },
     /// An archive entry name would escape or otherwise violate the extraction root.
@@ -34,8 +38,27 @@ pub enum ArchiveError {
         entry: String,
         kind: &'static str,
     },
+    /// Archive metadata or streamed content exceeded a configured resource limit.
+    LimitExceeded {
+        archive: PathBuf,
+        limit: &'static str,
+        observed: u64,
+        maximum: u64,
+    },
     /// A symbolic-link payload is not a portable, safe relative path.
     InvalidSymbolicLinkTarget { reason: &'static str },
+    /// A symbolic-link payload is not safe for a specific archive entry.
+    InvalidSymbolicLinkTargetEntry {
+        archive: PathBuf,
+        entry: String,
+        reason: &'static str,
+    },
+    /// A symbolic-link payload could not be read from the archive.
+    SymbolicLinkTargetRead {
+        archive: PathBuf,
+        entry: String,
+        source: std::io::Error,
+    },
 }
 
 impl ArchiveError {
@@ -49,6 +72,16 @@ impl ArchiveError {
 
     pub(crate) fn zip(operation: &'static str, path: impl Into<PathBuf>, source: ZipError) -> Self {
         Self::Zip { operation, path: path.into(), source }
+    }
+
+    pub(crate) fn entry(&self) -> Option<&str> {
+        match self {
+            Self::UnsafeEntry { entry, .. }
+            | Self::UnsupportedEntry { entry, .. }
+            | Self::InvalidSymbolicLinkTargetEntry { entry, .. }
+            | Self::SymbolicLinkTargetRead { entry, .. } => Some(entry),
+            _ => None,
+        }
     }
 }
 
@@ -66,6 +99,12 @@ impl fmt::Display for ArchiveError {
             Self::InvalidSource { path, reason } => {
                 write!(formatter, "invalid ZIP source '{}': {reason}", path.display())
             }
+            Self::InvalidDestination { path, reason } => {
+                write!(formatter, "invalid ZIP destination '{}': {reason}", path.display())
+            }
+            Self::DestinationExists { path } => {
+                write!(formatter, "ZIP destination already exists: '{}'", path.display())
+            }
             Self::UnsupportedSourceEntry { path, kind } => write!(
                 formatter,
                 "cannot add {kind} source entry '{}' to a portable ZIP archive",
@@ -79,8 +118,27 @@ impl fmt::Display for ArchiveError {
                 "unsupported {kind} ZIP entry '{entry}' in '{}'",
                 archive.display()
             ),
+            Self::LimitExceeded { archive, limit, observed, maximum } => write!(
+                formatter,
+                "ZIP archive '{}' exceeds the {limit} limit: {observed} > {maximum}",
+                archive.display()
+            ),
             Self::InvalidSymbolicLinkTarget { reason } => {
                 write!(formatter, "invalid ZIP symbolic-link target: {reason}")
+            }
+            Self::InvalidSymbolicLinkTargetEntry { archive, entry, reason } => {
+                write!(
+                    formatter,
+                    "invalid symbolic-link target for ZIP entry '{entry}' in '{}': {reason}",
+                    archive.display()
+                )
+            }
+            Self::SymbolicLinkTargetRead { archive, entry, source } => {
+                write!(
+                    formatter,
+                    "failed to read symbolic-link target for ZIP entry '{entry}' in '{}': {source}",
+                    archive.display()
+                )
             }
         }
     }
@@ -91,6 +149,7 @@ impl std::error::Error for ArchiveError {
         match self {
             Self::Io { source, .. } => Some(source),
             Self::Zip { source, .. } => Some(source),
+            Self::SymbolicLinkTargetRead { source, .. } => Some(source),
             _ => None,
         }
     }

--- a/crates/infra/src/archive/mod.rs
+++ b/crates/infra/src/archive/mod.rs
@@ -1,0 +1,16 @@
+//! Portable ZIP archive infrastructure.
+//!
+//! Archives are written from directory contents and extracted through validated
+//! relative paths. Symbolic links are deliberately rejected during extraction:
+//! creating them has incompatible permissions and semantics across supported
+//! platforms, and callers must opt into a dedicated policy before doing so.
+
+mod error;
+mod symbol_link;
+mod unzip;
+mod zipper;
+
+pub use error::ArchiveError;
+pub use symbol_link::{is_symbolic_link, parse_symbolic_link_target};
+pub use unzip::{extract_zip, ExtractionSummary};
+pub use zipper::{create_zip, ArchiveSummary};

--- a/crates/infra/src/archive/mod.rs
+++ b/crates/infra/src/archive/mod.rs
@@ -10,7 +10,63 @@ mod symbol_link;
 mod unzip;
 mod zipper;
 
+use std::path::Path;
+
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
+
 pub use error::ArchiveError;
 pub use symbol_link::{is_symbolic_link, parse_symbolic_link_target};
-pub use unzip::{extract_zip, ExtractionSummary};
+pub use unzip::{extract_zip, extract_zip_with_limits, ExtractionLimits, ExtractionSummary};
 pub use zipper::{create_zip, ArchiveSummary};
+
+fn open_existing_directory(path: &Path, role: &'static str) -> Result<Dir, ArchiveError> {
+    let parent_path = parent_path(path);
+    let name = path
+        .file_name()
+        .ok_or_else(|| ArchiveError::InvalidSource {
+            path: path.to_path_buf(),
+            reason: "source directory must have a final path component",
+        })?;
+    let parent = Dir::open_ambient_dir(parent_path, ambient_authority())
+        .map_err(|error| ArchiveError::io("open ZIP source parent", parent_path, error))?;
+    let metadata = parent
+        .symlink_metadata(name)
+        .map_err(|error| ArchiveError::io("read ZIP source metadata", path, error))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(ArchiveError::InvalidSource { path: path.to_path_buf(), reason: role });
+    }
+    parent
+        .open_dir(name)
+        .map_err(|error| ArchiveError::io("open ZIP source directory", path, error))
+}
+
+fn create_new_directory(path: &Path) -> Result<Dir, ArchiveError> {
+    let parent_path = parent_path(path);
+    std::fs::create_dir_all(parent_path)
+        .map_err(|error| ArchiveError::io("create ZIP destination parent", parent_path, error))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| ArchiveError::InvalidDestination {
+            path: path.to_path_buf(),
+            reason: "destination directory must have a final path component",
+        })?;
+    let parent = Dir::open_ambient_dir(parent_path, ambient_authority())
+        .map_err(|error| ArchiveError::io("open ZIP destination parent", parent_path, error))?;
+    match parent.create_dir(name) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(ArchiveError::DestinationExists { path: path.to_path_buf() });
+        }
+        Err(error) => return Err(ArchiveError::io("create ZIP extraction directory", path, error)),
+    }
+    parent
+        .open_dir(name)
+        .map_err(|error| ArchiveError::io("open ZIP extraction directory", path, error))
+}
+
+fn parent_path(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}

--- a/crates/infra/src/archive/symbol_link.rs
+++ b/crates/infra/src/archive/symbol_link.rs
@@ -1,0 +1,50 @@
+use crate::fs::SafeRelativePath;
+
+use super::ArchiveError;
+
+const UNIX_FILE_TYPE_MASK: u32 = 0o170000;
+const UNIX_SYMBOLIC_LINK: u32 = 0o120000;
+
+/// Returns whether ZIP Unix attributes identify an entry as a symbolic link.
+pub fn is_symbolic_link(unix_mode: Option<u32>) -> bool {
+    unix_mode.is_some_and(|mode| mode & UNIX_FILE_TYPE_MASK == UNIX_SYMBOLIC_LINK)
+}
+
+/// Parses a ZIP symbolic-link payload as a portable, root-relative target.
+///
+/// ZIP symlink payloads are raw bytes. They must be UTF-8 and use only normal,
+/// forward-slash-separated components before a caller can safely apply a
+/// platform-specific link creation policy.
+pub fn parse_symbolic_link_target(target: &[u8]) -> Result<SafeRelativePath, ArchiveError> {
+    let target = std::str::from_utf8(target).map_err(|_| {
+        ArchiveError::InvalidSymbolicLinkTarget { reason: "target is not valid UTF-8" }
+    })?;
+    SafeRelativePath::parse(target).map_err(|_| ArchiveError::InvalidSymbolicLinkTarget {
+        reason: "target must be portable and relative",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_unix_symbolic_link_mode() {
+        assert!(is_symbolic_link(Some(0o120777)));
+        assert!(!is_symbolic_link(Some(0o100644)));
+        assert!(!is_symbolic_link(None));
+    }
+
+    #[test]
+    fn accepts_only_safe_portable_targets() {
+        assert_eq!(
+            parse_symbolic_link_target(b"assets/server.jar")
+                .unwrap()
+                .as_path(),
+            std::path::Path::new("assets/server.jar")
+        );
+        assert!(parse_symbolic_link_target(b"../outside").is_err());
+        assert!(parse_symbolic_link_target(b"C:\\outside").is_err());
+        assert!(parse_symbolic_link_target(&[0xff]).is_err());
+    }
+}

--- a/crates/infra/src/archive/unzip.rs
+++ b/crates/infra/src/archive/unzip.rs
@@ -127,8 +127,8 @@ fn extract_zip_inner(
         let copied = copy_entry_with_limits(
             &mut entry,
             &mut output,
+            &output_path,
             archive_path,
-            &entry_name,
             &mut summary.bytes,
             limits,
         )?;
@@ -272,8 +272,8 @@ fn ensure_directory(root: &Dir, path: &Path, destination: &Path) -> Result<(), A
 fn copy_entry_with_limits(
     entry: &mut zip::read::ZipFile<'_>,
     output: &mut cap_std::fs::File,
+    output_path: &Path,
     archive_path: &Path,
-    entry_name: &str,
     total_bytes: &mut u64,
     limits: ExtractionLimits,
 ) -> Result<u64, ArchiveError> {
@@ -322,7 +322,7 @@ fn copy_entry_with_limits(
             .write_all(&buffer[..count])
             .map_err(|error| ArchiveError::Io {
                 operation: "write ZIP entry file",
-                path: PathBuf::from(entry_name),
+                path: output_path.to_path_buf(),
                 source: error,
             })?;
     }

--- a/crates/infra/src/archive/unzip.rs
+++ b/crates/infra/src/archive/unzip.rs
@@ -1,0 +1,158 @@
+use std::fs::{self, File};
+use std::io::{self, Read};
+use std::path::Path;
+
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
+use zip::ZipArchive;
+
+use crate::fs::SafeRelativePath;
+
+use super::{is_symbolic_link, parse_symbolic_link_target, ArchiveError};
+
+const MAX_SYMBOLIC_LINK_TARGET_BYTES: u64 = 4 * 1024;
+
+/// Counts entries and uncompressed bytes processed during ZIP extraction.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ExtractionSummary {
+    /// Number of regular files extracted.
+    pub files: u64,
+    /// Number of directory entries extracted.
+    pub directories: u64,
+    /// Total uncompressed file bytes extracted.
+    pub bytes: u64,
+}
+
+/// Extracts a ZIP archive into destination.
+///
+/// Every entry is parsed as a portable SafeRelativePath. ZIP entries that
+/// represent symbolic links are rejected after their targets are validated,
+/// because creating links requires an explicit platform-specific policy.
+pub fn extract_zip(
+    archive: impl AsRef<Path>,
+    destination: impl AsRef<Path>,
+) -> Result<ExtractionSummary, ArchiveError> {
+    let archive = archive.as_ref();
+    let destination = destination.as_ref();
+    let result = extract_zip_inner(archive, destination);
+    if let Err(error) = &result {
+        crate::observability::archive_operation_failed("extract ZIP", archive, error);
+    }
+    result
+}
+
+fn extract_zip_inner(
+    archive_path: &Path,
+    destination: &Path,
+) -> Result<ExtractionSummary, ArchiveError> {
+    fs::create_dir_all(destination)
+        .map_err(|error| ArchiveError::io("create ZIP extraction directory", destination, error))?;
+    let root = Dir::open_ambient_dir(destination, ambient_authority())
+        .map_err(|error| ArchiveError::io("open ZIP extraction directory", destination, error))?;
+    let file = File::open(archive_path)
+        .map_err(|error| ArchiveError::io("open ZIP archive", archive_path, error))?;
+    let mut archive =
+        ZipArchive::new(file).map_err(|error| ArchiveError::zip("read", archive_path, error))?;
+    let mut summary = ExtractionSummary::default();
+
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| ArchiveError::zip("read entry from", archive_path, error))?;
+        let entry_name = entry.name().to_owned();
+        let relative =
+            SafeRelativePath::parse(&entry_name).map_err(|error| ArchiveError::UnsafeEntry {
+                archive: archive_path.to_path_buf(),
+                entry: entry_name.clone(),
+                reason: error.to_string(),
+            })?;
+
+        if is_symbolic_link(entry.unix_mode()) {
+            validate_symbolic_link_target(&mut entry)?;
+            return Err(ArchiveError::UnsupportedEntry {
+                archive: archive_path.to_path_buf(),
+                entry: entry_name,
+                kind: "symbolic link",
+            });
+        }
+        if entry.is_dir() {
+            root.create_dir_all(relative.as_path()).map_err(|error| {
+                ArchiveError::io(
+                    "create ZIP entry directory",
+                    destination.join(relative.as_path()),
+                    error,
+                )
+            })?;
+            summary.directories += 1;
+            continue;
+        }
+
+        if let Some(parent) = relative.as_path().parent() {
+            root.create_dir_all(parent).map_err(|error| {
+                ArchiveError::io("create ZIP entry parent", destination.join(parent), error)
+            })?;
+        }
+        let output_path = destination.join(relative.as_path());
+        let mut output = root
+            .create(relative.as_path())
+            .map_err(|error| ArchiveError::io("create ZIP entry file", &output_path, error))?;
+        let copied = io::copy(&mut entry, &mut output)
+            .map_err(|error| ArchiveError::io("extract ZIP entry file", &output_path, error))?;
+        summary.files += 1;
+        summary.bytes += copied;
+    }
+
+    Ok(summary)
+}
+
+fn validate_symbolic_link_target(entry: &mut zip::read::ZipFile<'_>) -> Result<(), ArchiveError> {
+    let mut target = Vec::new();
+    entry
+        .take(MAX_SYMBOLIC_LINK_TARGET_BYTES + 1)
+        .read_to_end(&mut target)
+        .map_err(|error| ArchiveError::InvalidSymbolicLinkTarget {
+            reason: if error.kind() == io::ErrorKind::InvalidData {
+                "target could not be decoded from ZIP"
+            } else {
+                "target could not be read from ZIP"
+            },
+        })?;
+    if target.len() as u64 > MAX_SYMBOLIC_LINK_TARGET_BYTES {
+        return Err(ArchiveError::InvalidSymbolicLinkTarget {
+            reason: "target exceeds the 4096-byte limit",
+        });
+    }
+    parse_symbolic_link_target(&target).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    use super::*;
+
+    #[test]
+    fn rejects_path_traversal_before_writing() {
+        let root = crate::fs::test_dir("unzip");
+        let archive_path = root.join("unsafe.zip");
+        let destination = root.join("destination");
+        let file = File::create(&archive_path).unwrap();
+        let mut writer = ZipWriter::new(file);
+        writer
+            .start_file("../outside.txt", SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(b"unsafe").unwrap();
+        writer.finish().unwrap();
+
+        assert!(matches!(
+            extract_zip(&archive_path, &destination),
+            Err(ArchiveError::UnsafeEntry { .. })
+        ));
+        assert!(!root.join("outside.txt").exists());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/infra/src/archive/unzip.rs
+++ b/crates/infra/src/archive/unzip.rs
@@ -1,16 +1,43 @@
-use std::fs::{self, File};
-use std::io::{self, Read};
-use std::path::Path;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
 
-use cap_std::ambient_authority;
-use cap_std::fs::Dir;
+use cap_std::fs::{Dir, OpenOptions};
 use zip::ZipArchive;
 
 use crate::fs::SafeRelativePath;
 
-use super::{is_symbolic_link, parse_symbolic_link_target, ArchiveError};
+use super::{create_new_directory, is_symbolic_link, parse_symbolic_link_target, ArchiveError};
 
 const MAX_SYMBOLIC_LINK_TARGET_BYTES: u64 = 4 * 1024;
+
+/// Resource limits applied before and during ZIP extraction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExtractionLimits {
+    /// Maximum compressed ZIP file size accepted from disk.
+    pub max_archive_bytes: u64,
+    /// Maximum number of entries in the ZIP central directory.
+    pub max_entries: usize,
+    /// Maximum uncompressed bytes for one regular file.
+    pub max_entry_bytes: u64,
+    /// Maximum total uncompressed bytes written across all entries.
+    pub max_total_bytes: u64,
+    /// Maximum accepted ratio of uncompressed to compressed bytes.
+    pub max_compression_ratio: u64,
+}
+
+impl Default for ExtractionLimits {
+    fn default() -> Self {
+        Self {
+            max_archive_bytes: 4 * 1024 * 1024 * 1024,
+            max_entries: 10_000,
+            max_entry_bytes: 4 * 1024 * 1024 * 1024,
+            max_total_bytes: 16 * 1024 * 1024 * 1024,
+            max_compression_ratio: 200,
+        }
+    }
+}
 
 /// Counts entries and uncompressed bytes processed during ZIP extraction.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -23,20 +50,39 @@ pub struct ExtractionSummary {
     pub bytes: u64,
 }
 
-/// Extracts a ZIP archive into destination.
+/// Extracts a ZIP archive into a new destination directory with default limits.
 ///
-/// Every entry is parsed as a portable SafeRelativePath. ZIP entries that
-/// represent symbolic links are rejected after their targets are validated,
-/// because creating links requires an explicit platform-specific policy.
+/// The destination must not already exist. This avoids overwriting a previous
+/// extraction if an archive is invalid or a later I/O operation fails.
 pub fn extract_zip(
     archive: impl AsRef<Path>,
     destination: impl AsRef<Path>,
 ) -> Result<ExtractionSummary, ArchiveError> {
+    extract_zip_with_limits(archive, destination, ExtractionLimits::default())
+}
+
+/// Extracts a ZIP archive into a new destination directory with explicit limits.
+///
+/// All entry names, duplicate paths, symbolic links, and metadata limits are
+/// validated before the destination directory is created. The destination is
+/// opened without following its final path component, and every output file is
+/// created exclusively.
+pub fn extract_zip_with_limits(
+    archive: impl AsRef<Path>,
+    destination: impl AsRef<Path>,
+    limits: ExtractionLimits,
+) -> Result<ExtractionSummary, ArchiveError> {
     let archive = archive.as_ref();
     let destination = destination.as_ref();
-    let result = extract_zip_inner(archive, destination);
+    let result = extract_zip_inner(archive, destination, limits);
     if let Err(error) = &result {
-        crate::observability::archive_operation_failed("extract ZIP", archive, error);
+        crate::observability::archive_operation_failed_with_context(
+            "extract ZIP",
+            archive,
+            Some(destination),
+            error.entry(),
+            error,
+        );
     }
     result
 }
@@ -44,15 +90,20 @@ pub fn extract_zip(
 fn extract_zip_inner(
     archive_path: &Path,
     destination: &Path,
+    limits: ExtractionLimits,
 ) -> Result<ExtractionSummary, ArchiveError> {
-    fs::create_dir_all(destination)
-        .map_err(|error| ArchiveError::io("create ZIP extraction directory", destination, error))?;
-    let root = Dir::open_ambient_dir(destination, ambient_authority())
-        .map_err(|error| ArchiveError::io("open ZIP extraction directory", destination, error))?;
+    let archive_size = std::fs::metadata(archive_path)
+        .map_err(|error| ArchiveError::io("read ZIP archive metadata", archive_path, error))?
+        .len();
+    check_limit(archive_path, "compressed archive bytes", archive_size, limits.max_archive_bytes)?;
+
     let file = File::open(archive_path)
         .map_err(|error| ArchiveError::io("open ZIP archive", archive_path, error))?;
     let mut archive =
         ZipArchive::new(file).map_err(|error| ArchiveError::zip("read", archive_path, error))?;
+    validate_archive(&mut archive, archive_path, limits)?;
+
+    let root = create_new_directory(destination)?;
     let mut summary = ExtractionSummary::default();
 
     for index in 0..archive.len() {
@@ -60,15 +111,58 @@ fn extract_zip_inner(
             .by_index(index)
             .map_err(|error| ArchiveError::zip("read entry from", archive_path, error))?;
         let entry_name = entry.name().to_owned();
-        let relative =
-            SafeRelativePath::parse(&entry_name).map_err(|error| ArchiveError::UnsafeEntry {
-                archive: archive_path.to_path_buf(),
-                entry: entry_name.clone(),
-                reason: error.to_string(),
-            })?;
+        let relative = safe_entry_path(archive_path, &entry_name)?;
 
+        if entry.is_dir() {
+            ensure_directory(&root, relative.as_path(), destination)?;
+            summary.directories += 1;
+            continue;
+        }
+
+        ensure_parent_dirs(&root, relative.as_path(), destination)?;
+        let output_path = destination.join(relative.as_path());
+        let mut output = root
+            .open_with(relative.as_path(), OpenOptions::new().write(true).create_new(true))
+            .map_err(|error| ArchiveError::io("create ZIP entry file", &output_path, error))?;
+        let copied = copy_entry_with_limits(
+            &mut entry,
+            &mut output,
+            archive_path,
+            &entry_name,
+            &mut summary.bytes,
+            limits,
+        )?;
+        summary.files += 1;
+        debug_assert_eq!(copied, entry.size());
+    }
+
+    Ok(summary)
+}
+
+fn validate_archive(
+    archive: &mut ZipArchive<File>,
+    archive_path: &Path,
+    limits: ExtractionLimits,
+) -> Result<(), ArchiveError> {
+    check_limit(archive_path, "entry count", archive.len() as u64, limits.max_entries as u64)?;
+
+    let mut paths = HashSet::with_capacity(archive.len());
+    let mut total_bytes = 0_u64;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|error| ArchiveError::zip("read entry from", archive_path, error))?;
+        let entry_name = entry.name().to_owned();
+        let relative = safe_entry_path(archive_path, &entry_name)?;
+        if !paths.insert(relative.clone()) {
+            return Err(ArchiveError::UnsafeEntry {
+                archive: archive_path.to_path_buf(),
+                entry: entry_name,
+                reason: "archive contains duplicate output paths".to_string(),
+            });
+        }
         if is_symbolic_link(entry.unix_mode()) {
-            validate_symbolic_link_target(&mut entry)?;
+            validate_symbolic_link_target(&mut entry, archive_path, &entry_name)?;
             return Err(ArchiveError::UnsupportedEntry {
                 archive: archive_path.to_path_buf(),
                 entry: entry_name,
@@ -76,53 +170,213 @@ fn extract_zip_inner(
             });
         }
         if entry.is_dir() {
-            root.create_dir_all(relative.as_path()).map_err(|error| {
-                ArchiveError::io(
-                    "create ZIP entry directory",
-                    destination.join(relative.as_path()),
-                    error,
-                )
-            })?;
-            summary.directories += 1;
             continue;
         }
 
-        if let Some(parent) = relative.as_path().parent() {
-            root.create_dir_all(parent).map_err(|error| {
-                ArchiveError::io("create ZIP entry parent", destination.join(parent), error)
-            })?;
+        let entry_size = entry.size();
+        check_limit(
+            archive_path,
+            "per-entry uncompressed bytes",
+            entry_size,
+            limits.max_entry_bytes,
+        )?;
+        total_bytes =
+            total_bytes
+                .checked_add(entry_size)
+                .ok_or_else(|| ArchiveError::LimitExceeded {
+                    archive: archive_path.to_path_buf(),
+                    limit: "total uncompressed bytes",
+                    observed: u64::MAX,
+                    maximum: limits.max_total_bytes,
+                })?;
+        check_limit(archive_path, "total uncompressed bytes", total_bytes, limits.max_total_bytes)?;
+        let compressed_size = entry.compressed_size();
+        if entry_size > 0
+            && (compressed_size == 0
+                || entry_size > compressed_size.saturating_mul(limits.max_compression_ratio))
+        {
+            return Err(ArchiveError::LimitExceeded {
+                archive: archive_path.to_path_buf(),
+                limit: "compression ratio",
+                observed: entry_size,
+                maximum: compressed_size.saturating_mul(limits.max_compression_ratio),
+            });
         }
-        let output_path = destination.join(relative.as_path());
-        let mut output = root
-            .create(relative.as_path())
-            .map_err(|error| ArchiveError::io("create ZIP entry file", &output_path, error))?;
-        let copied = io::copy(&mut entry, &mut output)
-            .map_err(|error| ArchiveError::io("extract ZIP entry file", &output_path, error))?;
-        summary.files += 1;
-        summary.bytes += copied;
     }
-
-    Ok(summary)
+    Ok(())
 }
 
-fn validate_symbolic_link_target(entry: &mut zip::read::ZipFile<'_>) -> Result<(), ArchiveError> {
+fn safe_entry_path(
+    archive_path: &Path,
+    entry_name: &str,
+) -> Result<SafeRelativePath, ArchiveError> {
+    SafeRelativePath::parse(entry_name).map_err(|error| ArchiveError::UnsafeEntry {
+        archive: archive_path.to_path_buf(),
+        entry: entry_name.to_string(),
+        reason: error.to_string(),
+    })
+}
+
+fn ensure_parent_dirs(root: &Dir, path: &Path, destination: &Path) -> Result<(), ArchiveError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        current.push(component);
+        match root.open_dir(&current) {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                root.create_dir(&current).map_err(|error| {
+                    ArchiveError::io(
+                        "create ZIP entry parent directory",
+                        destination.join(&current),
+                        error,
+                    )
+                })?;
+                root.open_dir(&current).map_err(|error| {
+                    ArchiveError::io(
+                        "open ZIP entry parent directory",
+                        destination.join(&current),
+                        error,
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(ArchiveError::io(
+                    "open ZIP entry parent directory",
+                    destination.join(&current),
+                    error,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ensure_directory(root: &Dir, path: &Path, destination: &Path) -> Result<(), ArchiveError> {
+    ensure_parent_dirs(root, path, destination)?;
+    match root.create_dir(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            root.open_dir(path).map(|_| ()).map_err(|error| {
+                ArchiveError::io("open ZIP entry directory", destination.join(path), error)
+            })
+        }
+        Err(error) => {
+            Err(ArchiveError::io("create ZIP entry directory", destination.join(path), error))
+        }
+    }
+}
+
+fn copy_entry_with_limits(
+    entry: &mut zip::read::ZipFile<'_>,
+    output: &mut cap_std::fs::File,
+    archive_path: &Path,
+    entry_name: &str,
+    total_bytes: &mut u64,
+    limits: ExtractionLimits,
+) -> Result<u64, ArchiveError> {
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut entry_bytes = 0_u64;
+    loop {
+        let count = entry.read(&mut buffer).map_err(|error| ArchiveError::Io {
+            operation: "read ZIP entry",
+            path: archive_path.to_path_buf(),
+            source: error,
+        })?;
+        if count == 0 {
+            return Ok(entry_bytes);
+        }
+        entry_bytes =
+            entry_bytes
+                .checked_add(count as u64)
+                .ok_or_else(|| ArchiveError::LimitExceeded {
+                    archive: archive_path.to_path_buf(),
+                    limit: "per-entry uncompressed bytes",
+                    observed: u64::MAX,
+                    maximum: limits.max_entry_bytes,
+                })?;
+        check_limit(
+            archive_path,
+            "per-entry uncompressed bytes",
+            entry_bytes,
+            limits.max_entry_bytes,
+        )?;
+        *total_bytes =
+            total_bytes
+                .checked_add(count as u64)
+                .ok_or_else(|| ArchiveError::LimitExceeded {
+                    archive: archive_path.to_path_buf(),
+                    limit: "total uncompressed bytes",
+                    observed: u64::MAX,
+                    maximum: limits.max_total_bytes,
+                })?;
+        check_limit(
+            archive_path,
+            "total uncompressed bytes",
+            *total_bytes,
+            limits.max_total_bytes,
+        )?;
+        output
+            .write_all(&buffer[..count])
+            .map_err(|error| ArchiveError::Io {
+                operation: "write ZIP entry file",
+                path: PathBuf::from(entry_name),
+                source: error,
+            })?;
+    }
+}
+
+fn validate_symbolic_link_target(
+    entry: &mut zip::read::ZipFile<'_>,
+    archive_path: &Path,
+    entry_name: &str,
+) -> Result<(), ArchiveError> {
     let mut target = Vec::new();
     entry
         .take(MAX_SYMBOLIC_LINK_TARGET_BYTES + 1)
         .read_to_end(&mut target)
-        .map_err(|error| ArchiveError::InvalidSymbolicLinkTarget {
-            reason: if error.kind() == io::ErrorKind::InvalidData {
-                "target could not be decoded from ZIP"
-            } else {
-                "target could not be read from ZIP"
-            },
+        .map_err(|source| ArchiveError::SymbolicLinkTargetRead {
+            archive: archive_path.to_path_buf(),
+            entry: entry_name.to_string(),
+            source,
         })?;
     if target.len() as u64 > MAX_SYMBOLIC_LINK_TARGET_BYTES {
-        return Err(ArchiveError::InvalidSymbolicLinkTarget {
+        return Err(ArchiveError::InvalidSymbolicLinkTargetEntry {
+            archive: archive_path.to_path_buf(),
+            entry: entry_name.to_string(),
             reason: "target exceeds the 4096-byte limit",
         });
     }
-    parse_symbolic_link_target(&target).map(|_| ())
+    match parse_symbolic_link_target(&target) {
+        Ok(_) => Ok(()),
+        Err(ArchiveError::InvalidSymbolicLinkTarget { reason }) => {
+            Err(ArchiveError::InvalidSymbolicLinkTargetEntry {
+                archive: archive_path.to_path_buf(),
+                entry: entry_name.to_string(),
+                reason,
+            })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn check_limit(
+    archive: &Path,
+    limit: &'static str,
+    observed: u64,
+    maximum: u64,
+) -> Result<(), ArchiveError> {
+    if observed > maximum {
+        return Err(ArchiveError::LimitExceeded {
+            archive: archive.to_path_buf(),
+            limit,
+            observed,
+            maximum,
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -135,7 +389,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rejects_path_traversal_before_writing() {
+    fn rejects_path_traversal_before_creating_destination() {
         let root = crate::fs::test_dir("unzip");
         let archive_path = root.join("unsafe.zip");
         let destination = root.join("destination");
@@ -152,7 +406,109 @@ mod tests {
             Err(ArchiveError::UnsafeEntry { .. })
         ));
         assert!(!root.join("outside.txt").exists());
+        assert!(!destination.exists());
 
-        fs::remove_dir_all(root).unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_overwrite_existing_destination() {
+        let root = crate::fs::test_dir("existing-destination");
+        let archive_path = root.join("archive.zip");
+        let destination = root.join("destination");
+        let file = File::create(&archive_path).unwrap();
+        let mut writer = ZipWriter::new(file);
+        writer
+            .start_file("server.properties", SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(b"from archive").unwrap();
+        writer.finish().unwrap();
+        std::fs::create_dir_all(&destination).unwrap();
+        std::fs::write(destination.join("server.properties"), b"existing").unwrap();
+
+        assert!(matches!(
+            extract_zip(&archive_path, &destination),
+            Err(ArchiveError::DestinationExists { .. })
+        ));
+        assert_eq!(std::fs::read(destination.join("server.properties")).unwrap(), b"existing");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn enforces_declared_entry_limit_before_writing() {
+        let root = crate::fs::test_dir("limits");
+        let archive_path = root.join("large.zip");
+        let destination = root.join("destination");
+        let file = File::create(&archive_path).unwrap();
+        let mut writer = ZipWriter::new(file);
+        writer
+            .start_file("payload.bin", SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(&[0; 32]).unwrap();
+        writer.finish().unwrap();
+
+        let limits = ExtractionLimits {
+            max_entry_bytes: 16,
+            ..ExtractionLimits::default()
+        };
+        assert!(matches!(
+            extract_zip_with_limits(&archive_path, &destination, limits),
+            Err(ArchiveError::LimitExceeded {
+                limit: "per-entry uncompressed bytes",
+                ..
+            })
+        ));
+        assert!(!destination.exists());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn accepts_explicit_directory_after_an_implicit_parent() {
+        let root = crate::fs::test_dir("directory-order");
+        let archive_path = root.join("ordered.zip");
+        let destination = root.join("destination");
+        let file = File::create(&archive_path).unwrap();
+        let mut writer = ZipWriter::new(file);
+        writer
+            .start_file("config/server.properties", SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(b"motd=Sea Lantern").unwrap();
+        writer
+            .add_directory("config", SimpleFileOptions::default())
+            .unwrap();
+        writer.finish().unwrap();
+
+        let summary = extract_zip(&archive_path, &destination).unwrap();
+        assert_eq!(summary.files, 1);
+        assert_eq!(summary.directories, 1);
+        assert_eq!(
+            std::fs::read(destination.join("config/server.properties")).unwrap(),
+            b"motd=Sea Lantern"
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_symbolic_link_entries_before_creating_destination() {
+        let root = crate::fs::test_dir("symbolic-link");
+        let archive_path = root.join("link.zip");
+        let destination = root.join("destination");
+        let file = File::create(&archive_path).unwrap();
+        let mut writer = ZipWriter::new(file);
+        writer
+            .add_symlink("config", "../outside", SimpleFileOptions::default())
+            .unwrap();
+        writer.finish().unwrap();
+
+        assert!(matches!(
+            extract_zip(&archive_path, &destination),
+            Err(ArchiveError::InvalidSymbolicLinkTargetEntry { .. })
+        ));
+        assert!(!destination.exists());
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/infra/src/archive/zipper.rs
+++ b/crates/infra/src/archive/zipper.rs
@@ -35,7 +35,7 @@ pub fn create_zip(
         crate::observability::archive_operation_failed_with_context(
             "create ZIP",
             destination,
-            Some(destination),
+            Some(source),
             error.entry(),
             error,
         );

--- a/crates/infra/src/archive/zipper.rs
+++ b/crates/infra/src/archive/zipper.rs
@@ -1,11 +1,12 @@
-use std::fs::{self, File};
+use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 
+use cap_std::fs::Dir;
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipWriter};
 
-use super::ArchiveError;
+use super::{open_existing_directory, parent_path, ArchiveError};
 
 /// Counts entries and uncompressed bytes processed during ZIP creation.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -20,9 +21,9 @@ pub struct ArchiveSummary {
 
 /// Creates a ZIP archive containing the contents of source.
 ///
-/// Empty directories are retained. Symbolic links and special file types are
-/// rejected so the output has consistent behavior when consumed on another
-/// supported platform.
+/// The destination must not already exist. A temporary archive is completed in
+/// the destination directory and then hard-linked into place, so source-read
+/// or write failures never replace a previous archive with a partial result.
 pub fn create_zip(
     source: impl AsRef<Path>,
     destination: impl AsRef<Path>,
@@ -31,114 +32,172 @@ pub fn create_zip(
     let destination = destination.as_ref();
     let result = create_zip_inner(source, destination);
     if let Err(error) = &result {
-        crate::observability::archive_operation_failed("create ZIP", destination, error);
+        crate::observability::archive_operation_failed_with_context(
+            "create ZIP",
+            destination,
+            Some(destination),
+            error.entry(),
+            error,
+        );
     }
     result
 }
 
 fn create_zip_inner(source: &Path, destination: &Path) -> Result<ArchiveSummary, ArchiveError> {
-    let metadata = fs::symlink_metadata(source)
-        .map_err(|error| ArchiveError::io("read ZIP source metadata", source, error))?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        return Err(ArchiveError::InvalidSource {
-            path: source.to_path_buf(),
-            reason: "source must be a directory that is not a symbolic link",
-        });
-    }
-
-    let mut entries = Vec::new();
-    collect_entries(source, source, &mut entries)?;
-    entries.sort_by(|left, right| left.relative.cmp(&right.relative));
-
-    if let Some(parent) = destination.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|error| ArchiveError::io("create ZIP destination parent", parent, error))?;
-    }
-    let file = File::create(destination)
-        .map_err(|error| ArchiveError::io("create ZIP archive", destination, error))?;
-    let mut writer = ZipWriter::new(file);
-    let file_options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    let directory_options =
-        SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
-    let mut summary = ArchiveSummary::default();
-
-    for entry in entries {
-        let name = portable_name(&entry.relative)?;
-        if entry.is_directory {
-            writer
-                .add_directory(name, directory_options)
-                .map_err(|error| {
-                    ArchiveError::zip("write directory entry to", destination, error)
-                })?;
-            summary.directories += 1;
-            continue;
+    reject_existing_destination(destination)?;
+    let source_root =
+        open_existing_directory(source, "source must be a directory that is not a symbolic link")?;
+    let temporary = temporary_path(destination);
+    let result = write_archive(&source_root, source, &temporary);
+    match result {
+        Ok(summary) => {
+            if let Err(error) = fs::hard_link(&temporary, destination) {
+                let publish_error =
+                    ArchiveError::io("publish completed ZIP archive", destination, error);
+                remove_temporary_archive(&temporary);
+                return Err(publish_error);
+            }
+            remove_temporary_archive(&temporary);
+            Ok(summary)
         }
+        Err(error) => {
+            remove_temporary_archive(&temporary);
+            Err(error)
+        }
+    }
+}
 
-        writer
-            .start_file(name, file_options)
-            .map_err(|error| ArchiveError::zip("start file entry in", destination, error))?;
-        let mut input = File::open(&entry.absolute)
-            .map_err(|error| ArchiveError::io("open ZIP source file", &entry.absolute, error))?;
-        let copied = io::copy(&mut input, &mut writer)
-            .map_err(|error| ArchiveError::io("write ZIP file entry", &entry.absolute, error))?;
-        summary.files += 1;
-        summary.bytes += copied;
+fn remove_temporary_archive(path: &Path) {
+    if let Err(error) = fs::remove_file(path) {
+        if error.kind() != io::ErrorKind::NotFound {
+            crate::observability::archive_cleanup_failed(path, &error);
+        }
+    }
+}
+
+fn reject_existing_destination(destination: &Path) -> Result<(), ArchiveError> {
+    match fs::symlink_metadata(destination) {
+        Ok(_) => {
+            return Err(ArchiveError::DestinationExists { path: destination.to_path_buf() });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(ArchiveError::io("read ZIP destination metadata", destination, error));
+        }
+    }
+    let parent = parent_path(destination);
+    fs::create_dir_all(parent)
+        .map_err(|error| ArchiveError::io("create ZIP destination parent", parent, error))?;
+    Ok(())
+}
+
+fn write_archive(
+    source_root: &Dir,
+    source_path: &Path,
+    temporary: &Path,
+) -> Result<ArchiveSummary, ArchiveError> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(temporary)
+        .map_err(|error| ArchiveError::io("create temporary ZIP archive", temporary, error))?;
+    let mut writer = ZipWriter::new(file);
+    let file_options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .large_file(true);
+    let directory_options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .large_file(true);
+    let mut summary = ArchiveSummary::default();
+    let mut directories = vec![PathBuf::new()];
+
+    while let Some(directory) = directories.pop() {
+        let mut children = source_root
+            .read_dir(if directory.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                directory.as_path()
+            })
+            .map_err(|error| {
+                ArchiveError::io("read ZIP source directory", source_path.join(&directory), error)
+            })?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                ArchiveError::io(
+                    "iterate ZIP source directory",
+                    source_path.join(&directory),
+                    error,
+                )
+            })?;
+        children.sort_by_key(|entry| entry.file_name());
+        let mut child_directories = Vec::new();
+
+        for child in children {
+            let relative = directory.join(child.file_name());
+            let display_path = source_path.join(&relative);
+            let metadata = source_root.symlink_metadata(&relative).map_err(|error| {
+                ArchiveError::io("read ZIP source entry metadata", &display_path, error)
+            })?;
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                return Err(ArchiveError::UnsupportedSourceEntry {
+                    path: display_path,
+                    kind: "symbolic link",
+                });
+            }
+            let name = portable_name(&relative)?;
+            if file_type.is_dir() {
+                writer
+                    .add_directory(name, directory_options)
+                    .map_err(|error| {
+                        ArchiveError::zip("write directory entry to", temporary, error)
+                    })?;
+                summary.directories += 1;
+                child_directories.push(relative);
+                continue;
+            }
+            if !file_type.is_file() {
+                return Err(ArchiveError::UnsupportedSourceEntry {
+                    path: display_path,
+                    kind: "special",
+                });
+            }
+
+            writer
+                .start_file(name, file_options)
+                .map_err(|error| ArchiveError::zip("start file entry in", temporary, error))?;
+            let mut input = source_root
+                .open(&relative)
+                .map_err(|error| ArchiveError::io("open ZIP source file", &display_path, error))?;
+            let copied = io::copy(&mut input, &mut writer)
+                .map_err(|error| ArchiveError::io("write ZIP file entry", &display_path, error))?;
+            summary.files += 1;
+            summary.bytes =
+                summary
+                    .bytes
+                    .checked_add(copied)
+                    .ok_or_else(|| ArchiveError::LimitExceeded {
+                        archive: temporary.to_path_buf(),
+                        limit: "archive source bytes",
+                        observed: u64::MAX,
+                        maximum: u64::MAX - 1,
+                    })?;
+        }
+        directories.extend(child_directories.into_iter().rev());
     }
 
     writer
         .finish()
-        .map_err(|error| ArchiveError::zip("finalize", destination, error))?;
+        .map_err(|error| ArchiveError::zip("finalize", temporary, error))?;
     Ok(summary)
 }
 
-#[derive(Debug)]
-struct SourceEntry {
-    absolute: PathBuf,
-    relative: PathBuf,
-    is_directory: bool,
-}
-
-fn collect_entries(
-    root: &Path,
-    directory: &Path,
-    entries: &mut Vec<SourceEntry>,
-) -> Result<(), ArchiveError> {
-    let mut children = fs::read_dir(directory)
-        .map_err(|error| ArchiveError::io("read ZIP source directory", directory, error))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| ArchiveError::io("iterate ZIP source directory", directory, error))?;
-    children.sort_by_key(|entry| entry.file_name());
-
-    for child in children {
-        let path = child.path();
-        let metadata = fs::symlink_metadata(&path)
-            .map_err(|error| ArchiveError::io("read ZIP source entry metadata", &path, error))?;
-        let relative = path
-            .strip_prefix(root)
-            .expect("child was read beneath ZIP source")
-            .to_path_buf();
-        let file_type = metadata.file_type();
-        if file_type.is_symlink() {
-            return Err(ArchiveError::UnsupportedSourceEntry { path, kind: "symbolic link" });
-        }
-        if file_type.is_dir() {
-            entries.push(SourceEntry {
-                absolute: path.clone(),
-                relative,
-                is_directory: true,
-            });
-            collect_entries(root, &path, entries)?;
-        } else if file_type.is_file() {
-            entries.push(SourceEntry {
-                absolute: path,
-                relative,
-                is_directory: false,
-            });
-        } else {
-            return Err(ArchiveError::UnsupportedSourceEntry { path, kind: "special" });
-        }
-    }
-    Ok(())
+fn temporary_path(destination: &Path) -> PathBuf {
+    let filename = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("archive.zip");
+    parent_path(destination).join(format!(".{filename}.{}.tmp", uuid::Uuid::new_v4()))
 }
 
 fn portable_name(path: &Path) -> Result<String, ArchiveError> {
@@ -187,6 +246,24 @@ mod tests {
             b"motd=Sea Lantern"
         );
         assert!(extracted.join("nested/empty").is_dir());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_replace_existing_archive() {
+        let root = crate::fs::test_dir("existing-output");
+        let source = root.join("source");
+        let archive = root.join("server.zip");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("server.properties"), b"motd=Sea Lantern").unwrap();
+        fs::write(&archive, b"existing archive").unwrap();
+
+        assert!(matches!(
+            create_zip(&source, &archive),
+            Err(ArchiveError::DestinationExists { .. })
+        ));
+        assert_eq!(fs::read(&archive).unwrap(), b"existing archive");
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/infra/src/archive/zipper.rs
+++ b/crates/infra/src/archive/zipper.rs
@@ -1,0 +1,193 @@
+use std::fs::{self, File};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+use super::ArchiveError;
+
+/// Counts entries and uncompressed bytes processed during ZIP creation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ArchiveSummary {
+    /// Number of regular files written.
+    pub files: u64,
+    /// Number of directory entries written.
+    pub directories: u64,
+    /// Total uncompressed file bytes written.
+    pub bytes: u64,
+}
+
+/// Creates a ZIP archive containing the contents of source.
+///
+/// Empty directories are retained. Symbolic links and special file types are
+/// rejected so the output has consistent behavior when consumed on another
+/// supported platform.
+pub fn create_zip(
+    source: impl AsRef<Path>,
+    destination: impl AsRef<Path>,
+) -> Result<ArchiveSummary, ArchiveError> {
+    let source = source.as_ref();
+    let destination = destination.as_ref();
+    let result = create_zip_inner(source, destination);
+    if let Err(error) = &result {
+        crate::observability::archive_operation_failed("create ZIP", destination, error);
+    }
+    result
+}
+
+fn create_zip_inner(source: &Path, destination: &Path) -> Result<ArchiveSummary, ArchiveError> {
+    let metadata = fs::symlink_metadata(source)
+        .map_err(|error| ArchiveError::io("read ZIP source metadata", source, error))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(ArchiveError::InvalidSource {
+            path: source.to_path_buf(),
+            reason: "source must be a directory that is not a symbolic link",
+        });
+    }
+
+    let mut entries = Vec::new();
+    collect_entries(source, source, &mut entries)?;
+    entries.sort_by(|left, right| left.relative.cmp(&right.relative));
+
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| ArchiveError::io("create ZIP destination parent", parent, error))?;
+    }
+    let file = File::create(destination)
+        .map_err(|error| ArchiveError::io("create ZIP archive", destination, error))?;
+    let mut writer = ZipWriter::new(file);
+    let file_options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    let directory_options =
+        SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let mut summary = ArchiveSummary::default();
+
+    for entry in entries {
+        let name = portable_name(&entry.relative)?;
+        if entry.is_directory {
+            writer
+                .add_directory(name, directory_options)
+                .map_err(|error| {
+                    ArchiveError::zip("write directory entry to", destination, error)
+                })?;
+            summary.directories += 1;
+            continue;
+        }
+
+        writer
+            .start_file(name, file_options)
+            .map_err(|error| ArchiveError::zip("start file entry in", destination, error))?;
+        let mut input = File::open(&entry.absolute)
+            .map_err(|error| ArchiveError::io("open ZIP source file", &entry.absolute, error))?;
+        let copied = io::copy(&mut input, &mut writer)
+            .map_err(|error| ArchiveError::io("write ZIP file entry", &entry.absolute, error))?;
+        summary.files += 1;
+        summary.bytes += copied;
+    }
+
+    writer
+        .finish()
+        .map_err(|error| ArchiveError::zip("finalize", destination, error))?;
+    Ok(summary)
+}
+
+#[derive(Debug)]
+struct SourceEntry {
+    absolute: PathBuf,
+    relative: PathBuf,
+    is_directory: bool,
+}
+
+fn collect_entries(
+    root: &Path,
+    directory: &Path,
+    entries: &mut Vec<SourceEntry>,
+) -> Result<(), ArchiveError> {
+    let mut children = fs::read_dir(directory)
+        .map_err(|error| ArchiveError::io("read ZIP source directory", directory, error))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| ArchiveError::io("iterate ZIP source directory", directory, error))?;
+    children.sort_by_key(|entry| entry.file_name());
+
+    for child in children {
+        let path = child.path();
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| ArchiveError::io("read ZIP source entry metadata", &path, error))?;
+        let relative = path
+            .strip_prefix(root)
+            .expect("child was read beneath ZIP source")
+            .to_path_buf();
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            return Err(ArchiveError::UnsupportedSourceEntry { path, kind: "symbolic link" });
+        }
+        if file_type.is_dir() {
+            entries.push(SourceEntry {
+                absolute: path.clone(),
+                relative,
+                is_directory: true,
+            });
+            collect_entries(root, &path, entries)?;
+        } else if file_type.is_file() {
+            entries.push(SourceEntry {
+                absolute: path,
+                relative,
+                is_directory: false,
+            });
+        } else {
+            return Err(ArchiveError::UnsupportedSourceEntry { path, kind: "special" });
+        }
+    }
+    Ok(())
+}
+
+fn portable_name(path: &Path) -> Result<String, ArchiveError> {
+    let mut name = String::new();
+    for component in path.components() {
+        let component =
+            component
+                .as_os_str()
+                .to_str()
+                .ok_or_else(|| ArchiveError::InvalidSource {
+                    path: path.to_path_buf(),
+                    reason: "path contains non-Unicode components",
+                })?;
+        if !name.is_empty() {
+            name.push('/');
+        }
+        name.push_str(component);
+    }
+    Ok(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archive::extract_zip;
+
+    #[test]
+    fn archives_and_extracts_directory_contents() {
+        let root = crate::fs::test_dir("zipper");
+        let source = root.join("source");
+        let archive = root.join("output").join("server.zip");
+        let extracted = root.join("extracted");
+        fs::create_dir_all(source.join("nested/empty")).unwrap();
+        fs::write(source.join("nested/server.properties"), b"motd=Sea Lantern").unwrap();
+
+        let created = create_zip(&source, &archive).unwrap();
+        let extracted_summary = extract_zip(&archive, &extracted).unwrap();
+
+        assert_eq!(created.files, 1);
+        assert_eq!(created.directories, 2);
+        assert_eq!(created.bytes, 16);
+        assert_eq!(created.files, extracted_summary.files);
+        assert_eq!(created.directories, extracted_summary.directories);
+        assert_eq!(
+            fs::read(extracted.join("nested/server.properties")).unwrap(),
+            b"motd=Sea Lantern"
+        );
+        assert!(extracted.join("nested/empty").is_dir());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+pub mod archive;
 pub mod download;
 pub mod fs;
 pub mod net;

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -30,16 +30,42 @@ pub const ARCHIVE_TARGET: &str = "sealantern.infra.archive";
 
 /// Event: a ZIP archive operation failed.
 pub const EVENT_ARCHIVE_OPERATION_FAILED: &str = "archive_operation_failed";
+/// Event: a temporary archive file could not be removed after publication.
+pub const EVENT_ARCHIVE_CLEANUP_FAILED: &str = "archive_cleanup_failed";
 
 /// Records an archive creation or extraction failure.
 pub fn archive_operation_failed(operation: &str, archive: &std::path::Path, error: &dyn Display) {
+    archive_operation_failed_with_context(operation, archive, None, None, error);
+}
+
+/// Records an archive failure with the affected destination and entry when available.
+pub fn archive_operation_failed_with_context(
+    operation: &str,
+    archive: &std::path::Path,
+    destination: Option<&std::path::Path>,
+    entry: Option<&str>,
+    error: &dyn Display,
+) {
     tracing::error!(
         target: ARCHIVE_TARGET,
         event_name = EVENT_ARCHIVE_OPERATION_FAILED,
         operation,
         archive = %archive.display(),
+        destination = destination.map(|path| path.display().to_string()),
+        entry,
         error = %error,
         "archive operation failed"
+    );
+}
+
+/// Records a best-effort cleanup failure after an archive was successfully published.
+pub fn archive_cleanup_failed(path: &std::path::Path, error: &dyn Display) {
+    tracing::warn!(
+        target: ARCHIVE_TARGET,
+        event_name = EVENT_ARCHIVE_CLEANUP_FAILED,
+        path = %path.display(),
+        error = %error,
+        "temporary archive cleanup failed"
     );
 }
 

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -23,6 +23,26 @@ pub const EVENT_SERIALIZATION_FAILED: &str = "serialization_failed";
 /// Event: a file lock could not be acquired.
 pub const EVENT_LOCK_ACQUIRE_FAILED: &str = "lock_acquire_failed";
 
+// -- Archive layer --
+
+/// Tracing target for archive infrastructure operations.
+pub const ARCHIVE_TARGET: &str = "sealantern.infra.archive";
+
+/// Event: a ZIP archive operation failed.
+pub const EVENT_ARCHIVE_OPERATION_FAILED: &str = "archive_operation_failed";
+
+/// Records an archive creation or extraction failure.
+pub fn archive_operation_failed(operation: &str, archive: &std::path::Path, error: &dyn Display) {
+    tracing::error!(
+        target: ARCHIVE_TARGET,
+        event_name = EVENT_ARCHIVE_OPERATION_FAILED,
+        operation,
+        archive = %archive.display(),
+        error = %error,
+        "archive operation failed"
+    );
+}
+
 /// Records an atomic write failure with its destination path.
 pub fn atomic_write_failed(path: &std::path::Path, error: &dyn Display) {
     tracing::error!(


### PR DESCRIPTION
## Discovery

The infrastructure refactor plan calls for a dedicated archive module. The initial implementation review identified unbounded extraction, symlink race windows, destructive destination handling, and incomplete archive failure context.

## Investigation

Reviewed the ZIP and capability-directory paths, then verified the implementation with targeted archive tests, full `sealantern-infra` tests, strict Clippy, all-feature compilation, formatting, and diff checks.

## Problem

Untrusted archives could exhaust extraction resources. Source entries could change between symlink validation and opening. Existing destinations could be overwritten or partially modified, and failures did not consistently retain archive entry context for tracing.

## Resolution

- Add portable ZIP creation, extraction, symlink parsing, and typed archive errors under `sealantern-infra::archive`.
- Add `ExtractionLimits` and `extract_zip_with_limits` for input size, entry count, per-entry size, total output, and compression-ratio limits.
- Preflight entry paths, duplicate outputs, and symlink payloads before creating the extraction destination.
- Require a new extraction directory and exclusive output file creation.
- Open source and destination roots through capability directories without following their final path components.
- Create archives through a temporary sibling file, publish with an atomic no-replace hard link, enable ZIP64, and use iterative directory traversal.
- Add destination and entry context to archive tracing and error reporting.

## Validation

- `cargo test -p sealantern-infra --no-fail-fast` (46 passed)
- `cargo clippy -p sealantern-infra --all-targets -- -D warnings`
- `cargo check -p sealantern-infra --all-targets --all-features`
- `cargo fmt --check --package sealantern-infra`
- `git diff --check`

## Summary by Sourcery

引入一个专用的归档模块，在具备资源限制和上下文可观测性的前提下提供强化的 ZIP 创建和解压能力。

New Features:
- 在 infra 归档模块下新增可移植的 ZIP 归档创建和解压 API，返回关于已处理文件、目录以及字节数的结构化摘要。

Enhancements:
- 对归档大小、条目数量、单条目及总体未压缩字节数、压缩比等实施严格的解压限制，以防止资源耗尽。
- 在创建目标之前验证条目路径、重复输出以及符号链接载荷，对不安全或不受支持的条目和源进行拒绝。
- 确保归档通过临时文件创建，并以原子方式发布，同时不替换已有输出，使用基于能力的目录访问控制。
- 增强可观测性，增加归档特定的追踪目标和事件，在故障或清理问题发生时包含归档、目标位置和条目上下文信息。

Tests:
- 添加单元测试，覆盖路径遍历拒绝、目标已存在检查、限制执行、目录处理顺序、符号链接验证以及归档创建/解压的往返行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated archive module providing hardened ZIP creation and extraction with resource limits and contextual observability.

New Features:
- Add portable ZIP archive creation and extraction APIs under the infra archive module, returning structured summaries of processed files, directories, and bytes.

Enhancements:
- Enforce strict extraction limits on archive size, entry count, per-entry and total uncompressed bytes, and compression ratios to guard against resource exhaustion.
- Validate entry paths, duplicate outputs, and symbolic link payloads before creating destinations, rejecting unsafe or unsupported entries and sources.
- Ensure archives are created via temporary files and published atomically without replacing existing outputs, using capability-based directory access.
- Augment observability with archive-specific tracing targets and events that include archive, destination, and entry context for failures or cleanup issues.

Tests:
- Add unit tests covering path traversal rejection, destination existence checks, limit enforcement, directory handling order, symbolic link validation, and round‑trip archive create/extract behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个专用的归档模块，在具备资源限制和上下文可观测性的前提下提供强化的 ZIP 创建和解压能力。

New Features:
- 在 infra 归档模块下新增可移植的 ZIP 归档创建和解压 API，返回关于已处理文件、目录以及字节数的结构化摘要。

Enhancements:
- 对归档大小、条目数量、单条目及总体未压缩字节数、压缩比等实施严格的解压限制，以防止资源耗尽。
- 在创建目标之前验证条目路径、重复输出以及符号链接载荷，对不安全或不受支持的条目和源进行拒绝。
- 确保归档通过临时文件创建，并以原子方式发布，同时不替换已有输出，使用基于能力的目录访问控制。
- 增强可观测性，增加归档特定的追踪目标和事件，在故障或清理问题发生时包含归档、目标位置和条目上下文信息。

Tests:
- 添加单元测试，覆盖路径遍历拒绝、目标已存在检查、限制执行、目录处理顺序、符号链接验证以及归档创建/解压的往返行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated archive module providing hardened ZIP creation and extraction with resource limits and contextual observability.

New Features:
- Add portable ZIP archive creation and extraction APIs under the infra archive module, returning structured summaries of processed files, directories, and bytes.

Enhancements:
- Enforce strict extraction limits on archive size, entry count, per-entry and total uncompressed bytes, and compression ratios to guard against resource exhaustion.
- Validate entry paths, duplicate outputs, and symbolic link payloads before creating destinations, rejecting unsafe or unsupported entries and sources.
- Ensure archives are created via temporary files and published atomically without replacing existing outputs, using capability-based directory access.
- Augment observability with archive-specific tracing targets and events that include archive, destination, and entry context for failures or cleanup issues.

Tests:
- Add unit tests covering path traversal rejection, destination existence checks, limit enforcement, directory handling order, symbolic link validation, and round‑trip archive create/extract behavior.

</details>

</details>