### PR TITLE
feat: add network proxy policy

### DIFF
--- a/crates/infra/src/net/client.rs
+++ b/crates/infra/src/net/client.rs
@@ -95,23 +95,6 @@ impl Default for ClientConfig {
     }
 }
 
-impl ClientConfig {
-    /// Applies a resolved proxy decision to this HTTP client configuration.
-    ///
-    /// Proxy policy and configuration persistence live outside the HTTP client.
-    /// Callers rebuild a client from the updated configuration after the effective
-    /// proxy changes.
-    pub fn apply_effective_proxy(&mut self, proxy: &EffectiveProxy) {
-        self.proxy = proxy.proxy_url().map(ToOwned::to_owned);
-    }
-
-    /// Returns this configuration with a resolved proxy decision applied.
-    pub fn with_effective_proxy(mut self, proxy: &EffectiveProxy) -> Self {
-        self.apply_effective_proxy(proxy);
-        self
-    }
-}
-
 /// Async HTTP client.
 ///
 /// Wraps a `reqwest::Client` built from caller-supplied configuration.
@@ -141,23 +124,31 @@ impl NetClient {
     ///
     /// Returns a configured `NetClient` instance; returns `NetError::Config` on configuration error
     pub fn from_config(config: &ClientConfig) -> Result<Self, NetError> {
+        let effective_proxy = config
+            .proxy
+            .as_deref()
+            .map(EffectiveProxy::proxy)
+            .unwrap_or(EffectiveProxy::Direct);
+        Self::from_config_with_effective_proxy(config, &effective_proxy)
+    }
+
+    /// Creates a client from base settings and an already-resolved proxy policy.
+    pub fn from_config_with_effective_proxy(
+        config: &ClientConfig,
+        effective_proxy: &EffectiveProxy,
+    ) -> Result<Self, NetError> {
         let mut builder = reqwest::Client::builder()
             .connect_timeout(config.timeout.connect)
             .read_timeout(config.timeout.read)
             .timeout(config.timeout.total)
             .user_agent(&config.user_agent);
 
-        if let Some(ref proxy_url) = config.proxy {
-            let proxy = reqwest::Proxy::all(proxy_url).map_err(|e| {
-                observability::proxy_config_invalid(proxy_url, &e);
-                NetError::Config(format!("代理配置无效: {}", e))
-            })?;
-            builder = builder.proxy(proxy);
-        }
+        builder = apply_async_proxy_routes(builder, effective_proxy)?;
 
-        let inner = builder
-            .build()
-            .map_err(|e| NetError::Config(format!("创建 HTTP 客户端失败: {}", e)))?;
+        let inner = builder.build().map_err(|_| {
+            observability::http_client_build_failed();
+            NetError::Config("无法创建 HTTP 客户端".into())
+        })?;
 
         Ok(Self { inner, retry_policy: config.retry_policy })
     }
@@ -299,22 +290,30 @@ impl NetBlockingClient {
     ///
     /// Returns a configured `NetBlockingClient` instance; returns `NetError::Config` on configuration error
     pub fn from_config(config: &ClientConfig) -> Result<Self, NetError> {
+        let effective_proxy = config
+            .proxy
+            .as_deref()
+            .map(EffectiveProxy::proxy)
+            .unwrap_or(EffectiveProxy::Direct);
+        Self::from_config_with_effective_proxy(config, &effective_proxy)
+    }
+
+    /// Creates a blocking client from base settings and a resolved proxy policy.
+    pub fn from_config_with_effective_proxy(
+        config: &ClientConfig,
+        effective_proxy: &EffectiveProxy,
+    ) -> Result<Self, NetError> {
         let mut builder = reqwest::blocking::Client::builder()
             .connect_timeout(config.timeout.connect)
             .timeout(config.timeout.total)
             .user_agent(&config.user_agent);
 
-        if let Some(ref proxy_url) = config.proxy {
-            let proxy = reqwest::Proxy::all(proxy_url).map_err(|e| {
-                observability::proxy_config_invalid(proxy_url, &e);
-                NetError::Config(format!("代理配置无效: {}", e))
-            })?;
-            builder = builder.proxy(proxy);
-        }
+        builder = apply_blocking_proxy_routes(builder, effective_proxy)?;
 
-        let inner = builder
-            .build()
-            .map_err(|e| NetError::Config(format!("创建阻塞 HTTP 客户端失败: {}", e)))?;
+        let inner = builder.build().map_err(|_| {
+            observability::http_client_build_failed();
+            NetError::Config("无法创建阻塞 HTTP 客户端".into())
+        })?;
 
         Ok(Self { inner, retry_policy: config.retry_policy })
     }
@@ -341,6 +340,65 @@ impl NetBlockingClient {
     pub fn retry_policy(&self) -> &RetryPolicy {
         &self.retry_policy
     }
+}
+
+fn no_proxy(routes: &crate::net::proxy::ProxyRoutes) -> Option<reqwest::NoProxy> {
+    (!routes.no_proxy().is_empty())
+        .then(|| reqwest::NoProxy::from_string(&routes.no_proxy().join(",")))?
+}
+
+fn proxy_config_error(scope: &str) -> NetError {
+    observability::proxy_config_invalid(scope);
+    NetError::Config(format!("{scope} 代理配置无效"))
+}
+
+fn apply_async_proxy_routes(
+    mut builder: reqwest::ClientBuilder,
+    effective_proxy: &EffectiveProxy,
+) -> Result<reqwest::ClientBuilder, NetError> {
+    let Some(routes) = effective_proxy.routes_ref() else {
+        return Ok(builder);
+    };
+    let no_proxy = no_proxy(routes);
+
+    if let Some(proxy_url) = routes.http_proxy() {
+        let proxy = reqwest::Proxy::http(proxy_url)
+            .map_err(|_| proxy_config_error("HTTP"))?
+            .no_proxy(no_proxy.clone());
+        builder = builder.proxy(proxy);
+    }
+    if let Some(proxy_url) = routes.https_proxy() {
+        let proxy = reqwest::Proxy::https(proxy_url)
+            .map_err(|_| proxy_config_error("HTTPS"))?
+            .no_proxy(no_proxy);
+        builder = builder.proxy(proxy);
+    }
+    Ok(builder)
+}
+
+#[cfg(feature = "blocking")]
+fn apply_blocking_proxy_routes(
+    mut builder: reqwest::blocking::ClientBuilder,
+    effective_proxy: &EffectiveProxy,
+) -> Result<reqwest::blocking::ClientBuilder, NetError> {
+    let Some(routes) = effective_proxy.routes_ref() else {
+        return Ok(builder);
+    };
+    let no_proxy = no_proxy(routes);
+
+    if let Some(proxy_url) = routes.http_proxy() {
+        let proxy = reqwest::Proxy::http(proxy_url)
+            .map_err(|_| proxy_config_error("HTTP"))?
+            .no_proxy(no_proxy.clone());
+        builder = builder.proxy(proxy);
+    }
+    if let Some(proxy_url) = routes.https_proxy() {
+        let proxy = reqwest::Proxy::https(proxy_url)
+            .map_err(|_| proxy_config_error("HTTPS"))?
+            .no_proxy(no_proxy);
+        builder = builder.proxy(proxy);
+    }
+    Ok(builder)
 }
 
 #[cfg(test)]
@@ -388,22 +446,30 @@ mod tests {
     }
 
     #[test]
-    fn effective_proxy_is_applied_to_client_config() {
-        let config = ClientConfig::default()
-            .with_effective_proxy(&EffectiveProxy::proxy("http://127.0.0.1:7890"));
+    fn effective_proxy_routes_build_a_client() {
+        let effective_proxy = EffectiveProxy::routes(
+            crate::net::proxy::ProxyRoutes::split(
+                Some("http://127.0.0.1:7890".into()),
+                Some("http://127.0.0.1:7891".into()),
+            )
+            .with_no_proxy(vec!["localhost".into()]),
+        );
 
-        assert_eq!(config.proxy.as_deref(), Some("http://127.0.0.1:7890"));
+        assert!(NetClient::from_config_with_effective_proxy(
+            &ClientConfig::default(),
+            &effective_proxy
+        )
+        .is_ok());
     }
 
     #[test]
-    fn direct_effective_proxy_clears_client_config() {
-        let mut config = ClientConfig {
-            proxy: Some("http://127.0.0.1:7890".into()),
-            ..Default::default()
-        };
+    fn invalid_proxy_error_does_not_echo_credentials() {
+        let effective_proxy = EffectiveProxy::proxy("http://user:secret@[::1");
+        let error =
+            NetClient::from_config_with_effective_proxy(&ClientConfig::default(), &effective_proxy)
+                .unwrap_err();
 
-        config.apply_effective_proxy(&EffectiveProxy::Direct);
-
-        assert!(config.proxy.is_none());
+        assert!(matches!(error, NetError::Config(_)));
+        assert!(!error.to_string().contains("secret"));
     }
 }

--- a/crates/infra/src/net/client.rs
+++ b/crates/infra/src/net/client.rs
@@ -1,15 +1,8 @@
 //! Unified HTTP client.
 //!
-//! Solves the problem of `reqwest::Client` being constructed ad-hoc across the project
-//! with no centralized proxy configuration management.
-//! Provides a pre-configured client instance with global settings (proxy, timeout, UA, etc.),
-//! so upper layers can use it directly without worrying about underlying configuration details.
-//!
-//! # TODO: Improve proxy configuration
-//!
-//! Since the refactoring is not yet complete, reading the SeaLantern config file directly is not feasible.
-//! Currently `from_settings()` returns a default configuration (no proxy).
-//! Once the configuration module is ready, it should be integrated to read proxy, timeout and other global settings.
+//! Prevents `reqwest::Client` construction from being scattered across the project.
+//! Callers provide resolved settings for proxy, timeout, User-Agent, and retry behavior.
+//! Application configuration and system-proxy detection remain outside this module.
 
 use std::time::Duration;
 
@@ -17,6 +10,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 use crate::net::error::NetError;
+use crate::net::proxy::EffectiveProxy;
 use crate::net::request::RequestBuilder;
 use crate::observability;
 
@@ -101,10 +95,27 @@ impl Default for ClientConfig {
     }
 }
 
+impl ClientConfig {
+    /// Applies a resolved proxy decision to this HTTP client configuration.
+    ///
+    /// Proxy policy and configuration persistence live outside the HTTP client.
+    /// Callers rebuild a client from the updated configuration after the effective
+    /// proxy changes.
+    pub fn apply_effective_proxy(&mut self, proxy: &EffectiveProxy) {
+        self.proxy = proxy.proxy_url().map(ToOwned::to_owned);
+    }
+
+    /// Returns this configuration with a resolved proxy decision applied.
+    pub fn with_effective_proxy(mut self, proxy: &EffectiveProxy) -> Self {
+        self.apply_effective_proxy(proxy);
+        self
+    }
+}
+
 /// Async HTTP client.
 ///
-/// Wraps `reqwest::Client` and automatically loads global configuration such as proxy at construction.
-/// Upper layers use this struct to make requests without worrying about how the underlying client is assembled.
+/// Wraps a `reqwest::Client` built from caller-supplied configuration.
+/// Upper layers use this struct without needing to assemble the HTTP client directly.
 ///
 /// # Parameters
 ///
@@ -151,24 +162,16 @@ impl NetClient {
         Ok(Self { inner, retry_policy: config.retry_policy })
     }
 
-    /// Creates a client with default global configuration.
-    ///
-    /// Currently returns a default configuration without proxy;
-    /// will read global settings once the configuration module is ready.
+    /// Creates a client with the default configuration.
     pub fn new() -> Result<Self, NetError> {
         Self::from_settings()
     }
 
-    /// Loads client configuration from application global settings.
+    /// Creates a client from the default configuration for compatibility.
     ///
-    /// Reads proxy, timeout and other configuration items from SeaLantern global settings,
-    /// and creates a client accordingly.
-    ///
-    /// # TODO: Improve proxy configuration
-    ///
-    /// Integrate global settings reading; currently returns default configuration.
+    /// Application settings are intentionally not read from `infra`; composition
+    /// roots must resolve them and use [`Self::from_config`] instead.
     pub fn from_settings() -> Result<Self, NetError> {
-        // TODO: read proxy, timeout and other settings from global configuration
         Self::from_config(&ClientConfig::default())
     }
 
@@ -316,19 +319,15 @@ impl NetBlockingClient {
         Ok(Self { inner, retry_policy: config.retry_policy })
     }
 
-    /// Creates a blocking client with default global configuration.
-    ///
-    /// Currently returns a default configuration without proxy;
-    /// will read global settings once the configuration module is ready.
+    /// Creates a blocking client with the default configuration.
     pub fn new() -> Result<Self, NetError> {
         Self::from_settings()
     }
 
-    /// Loads configuration from application global settings.
+    /// Creates a blocking client from the default configuration for compatibility.
     ///
-    /// # TODO: Improve proxy configuration
-    ///
-    /// Integrate global settings reading; currently returns default configuration.
+    /// Application settings are intentionally not read from `infra`; composition
+    /// roots must resolve them and use [`Self::from_config`] instead.
     pub fn from_settings() -> Result<Self, NetError> {
         Self::from_config(&ClientConfig::default())
     }
@@ -386,5 +385,25 @@ mod tests {
         };
         let client = NetClient::from_config(&config);
         assert!(client.is_ok());
+    }
+
+    #[test]
+    fn effective_proxy_is_applied_to_client_config() {
+        let config = ClientConfig::default()
+            .with_effective_proxy(&EffectiveProxy::proxy("http://127.0.0.1:7890"));
+
+        assert_eq!(config.proxy.as_deref(), Some("http://127.0.0.1:7890"));
+    }
+
+    #[test]
+    fn direct_effective_proxy_clears_client_config() {
+        let mut config = ClientConfig {
+            proxy: Some("http://127.0.0.1:7890".into()),
+            ..Default::default()
+        };
+
+        config.apply_effective_proxy(&EffectiveProxy::Direct);
+
+        assert!(config.proxy.is_none());
     }
 }

--- a/crates/infra/src/net/client.rs
+++ b/crates/infra/src/net/client.rs
@@ -343,8 +343,11 @@ impl NetBlockingClient {
 }
 
 fn no_proxy(routes: &crate::net::proxy::ProxyRoutes) -> Option<reqwest::NoProxy> {
-    (!routes.no_proxy().is_empty())
-        .then(|| reqwest::NoProxy::from_string(&routes.no_proxy().join(",")))?
+    if routes.no_proxy().is_empty() {
+        None
+    } else {
+        reqwest::NoProxy::from_string(&routes.no_proxy().join(","))
+    }
 }
 
 fn proxy_config_error(scope: &str) -> NetError {
@@ -352,25 +355,42 @@ fn proxy_config_error(scope: &str) -> NetError {
     NetError::Config(format!("{scope} 代理配置无效"))
 }
 
+fn configured_proxy_routes(
+    effective_proxy: &EffectiveProxy,
+) -> Result<[Option<reqwest::Proxy>; 2], NetError> {
+    let Some(routes) = effective_proxy.routes_ref() else {
+        return Ok([None, None]);
+    };
+    let no_proxy = no_proxy(routes);
+
+    let http_proxy = routes
+        .http_proxy()
+        .map(|proxy_url| {
+            reqwest::Proxy::http(proxy_url)
+                .map_err(|_| proxy_config_error("HTTP"))
+                .map(|proxy| proxy.no_proxy(no_proxy.clone()))
+        })
+        .transpose()?;
+    let https_proxy = routes
+        .https_proxy()
+        .map(|proxy_url| {
+            reqwest::Proxy::https(proxy_url)
+                .map_err(|_| proxy_config_error("HTTPS"))
+                .map(|proxy| proxy.no_proxy(no_proxy))
+        })
+        .transpose()?;
+
+    Ok([http_proxy, https_proxy])
+}
+
 fn apply_async_proxy_routes(
     mut builder: reqwest::ClientBuilder,
     effective_proxy: &EffectiveProxy,
 ) -> Result<reqwest::ClientBuilder, NetError> {
-    let Some(routes) = effective_proxy.routes_ref() else {
-        return Ok(builder);
-    };
-    let no_proxy = no_proxy(routes);
-
-    if let Some(proxy_url) = routes.http_proxy() {
-        let proxy = reqwest::Proxy::http(proxy_url)
-            .map_err(|_| proxy_config_error("HTTP"))?
-            .no_proxy(no_proxy.clone());
-        builder = builder.proxy(proxy);
-    }
-    if let Some(proxy_url) = routes.https_proxy() {
-        let proxy = reqwest::Proxy::https(proxy_url)
-            .map_err(|_| proxy_config_error("HTTPS"))?
-            .no_proxy(no_proxy);
+    for proxy in configured_proxy_routes(effective_proxy)?
+        .into_iter()
+        .flatten()
+    {
         builder = builder.proxy(proxy);
     }
     Ok(builder)
@@ -381,21 +401,10 @@ fn apply_blocking_proxy_routes(
     mut builder: reqwest::blocking::ClientBuilder,
     effective_proxy: &EffectiveProxy,
 ) -> Result<reqwest::blocking::ClientBuilder, NetError> {
-    let Some(routes) = effective_proxy.routes_ref() else {
-        return Ok(builder);
-    };
-    let no_proxy = no_proxy(routes);
-
-    if let Some(proxy_url) = routes.http_proxy() {
-        let proxy = reqwest::Proxy::http(proxy_url)
-            .map_err(|_| proxy_config_error("HTTP"))?
-            .no_proxy(no_proxy.clone());
-        builder = builder.proxy(proxy);
-    }
-    if let Some(proxy_url) = routes.https_proxy() {
-        let proxy = reqwest::Proxy::https(proxy_url)
-            .map_err(|_| proxy_config_error("HTTPS"))?
-            .no_proxy(no_proxy);
+    for proxy in configured_proxy_routes(effective_proxy)?
+        .into_iter()
+        .flatten()
+    {
         builder = builder.proxy(proxy);
     }
     Ok(builder)

--- a/crates/infra/src/net/mod.rs
+++ b/crates/infra/src/net/mod.rs
@@ -1,9 +1,14 @@
 pub mod client;
 pub mod error;
+pub mod proxy;
 pub mod request;
 
 pub use client::{ClientConfig, NetClient, RemoteFileInfo, RetryPolicy, TimeoutPolicy};
 pub use error::NetError;
+pub use proxy::{
+    EffectiveProxy, ProxyConfigError, ProxyController, ProxyMode, ProxyMonitor, ProxySettings,
+    ProxyUpdate, SystemProxyProvider, SystemProxySnapshot,
+};
 pub use request::RequestBuilder;
 
 #[cfg(feature = "blocking")]

--- a/crates/infra/src/net/proxy/config.rs
+++ b/crates/infra/src/net/proxy/config.rs
@@ -28,6 +28,17 @@ impl ProxySettings {
     }
 }
 
+impl ProxyMode {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Adaptive => "adaptive",
+            Self::Preserve => "preserve",
+            Self::Manual { .. } => "manual",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
 /// Policy used to select an outbound proxy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]

--- a/crates/infra/src/net/proxy/config.rs
+++ b/crates/infra/src/net/proxy/config.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Serialize};
+
+/// Persistable intent for selecting an outbound proxy.
+///
+/// The application configuration layer owns where this value is stored and how
+/// it is migrated. This type deliberately contains no file-system behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxySettings {
+    pub mode: ProxyMode,
+}
+
+impl Default for ProxySettings {
+    fn default() -> Self {
+        Self { mode: ProxyMode::Adaptive }
+    }
+}
+
+impl ProxySettings {
+    /// Validates settings before they are applied to a controller.
+    pub fn validate(&self) -> Result<(), ProxyConfigError> {
+        if let ProxyMode::Manual { proxy_url } = &self.mode {
+            if proxy_url.trim().is_empty() {
+                return Err(ProxyConfigError::EmptyManualProxy);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Policy used to select an outbound proxy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ProxyMode {
+    /// Follow the latest proxy reported by the operating system.
+    Adaptive,
+    /// Resolve the system proxy once and ignore subsequent network changes.
+    Preserve,
+    /// Always use the explicitly configured proxy URL.
+    Manual { proxy_url: String },
+    /// Never use a proxy, even when the operating system reports one.
+    Disabled,
+}
+
+/// Settings rejected before an HTTP client is constructed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProxyConfigError {
+    EmptyManualProxy,
+}
+
+impl std::fmt::Display for ProxyConfigError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyManualProxy => formatter.write_str("manual proxy URL must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for ProxyConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_settings_are_adaptive() {
+        assert_eq!(ProxySettings::default().mode, ProxyMode::Adaptive);
+    }
+
+    #[test]
+    fn empty_manual_proxy_is_rejected() {
+        let settings = ProxySettings {
+            mode: ProxyMode::Manual { proxy_url: "  ".into() },
+        };
+
+        assert_eq!(settings.validate(), Err(ProxyConfigError::EmptyManualProxy));
+    }
+}

--- a/crates/infra/src/net/proxy/mod.rs
+++ b/crates/infra/src/net/proxy/mod.rs
@@ -12,4 +12,4 @@ mod system;
 pub use config::{ProxyConfigError, ProxyMode, ProxySettings};
 pub use monitor::ProxyMonitor;
 pub use policy::{EffectiveProxy, ProxyController, ProxyUpdate};
-pub use system::{SystemProxyProvider, SystemProxySnapshot};
+pub use system::{read_system_proxy, ProxyRoutes, SystemProxyProvider, SystemProxySnapshot};

--- a/crates/infra/src/net/proxy/mod.rs
+++ b/crates/infra/src/net/proxy/mod.rs
@@ -1,0 +1,15 @@
+//! Proxy policy for outbound network clients.
+//!
+//! This module owns proxy settings and their in-memory resolution. It does not
+//! read application configuration files or detect operating-system changes.
+//! Application configuration and platform adapters provide those inputs.
+
+mod config;
+mod monitor;
+mod policy;
+mod system;
+
+pub use config::{ProxyConfigError, ProxyMode, ProxySettings};
+pub use monitor::ProxyMonitor;
+pub use policy::{EffectiveProxy, ProxyController, ProxyUpdate};
+pub use system::{SystemProxyProvider, SystemProxySnapshot};

--- a/crates/infra/src/net/proxy/monitor.rs
+++ b/crates/infra/src/net/proxy/monitor.rs
@@ -1,0 +1,54 @@
+use super::{ProxyController, ProxyUpdate, SystemProxySnapshot};
+
+/// Accepts network-change snapshots from a platform adapter.
+///
+/// This type intentionally does not poll or subscribe to an operating system.
+/// The composition root owns the platform-specific event source and forwards
+/// each updated proxy snapshot here.
+#[derive(Debug)]
+pub struct ProxyMonitor {
+    controller: ProxyController,
+}
+
+impl ProxyMonitor {
+    /// Creates a monitor around a configured proxy controller.
+    pub fn new(controller: ProxyController) -> Self {
+        Self { controller }
+    }
+
+    /// Applies a system proxy snapshot received after a network change.
+    pub fn network_changed(&mut self, system_proxy: SystemProxySnapshot) -> ProxyUpdate {
+        self.controller.handle_system_proxy_change(system_proxy)
+    }
+
+    /// Returns the proxy controller so callers can apply user settings updates.
+    pub fn controller(&self) -> &ProxyController {
+        &self.controller
+    }
+
+    /// Returns mutable access for applying user settings updates.
+    pub fn controller_mut(&mut self) -> &mut ProxyController {
+        &mut self.controller
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::proxy::{ProxySettings, SystemProxySnapshot};
+
+    #[test]
+    fn network_change_is_forwarded_to_the_controller() {
+        let controller =
+            ProxyController::new(ProxySettings::default(), SystemProxySnapshot::direct()).unwrap();
+        let mut monitor = ProxyMonitor::new(controller);
+
+        let update = monitor.network_changed(SystemProxySnapshot::proxy("http://127.0.0.1:7890"));
+
+        assert!(update.changed());
+        assert_eq!(
+            monitor.controller().effective_proxy().proxy_url(),
+            Some("http://127.0.0.1:7890")
+        );
+    }
+}

--- a/crates/infra/src/net/proxy/monitor.rs
+++ b/crates/infra/src/net/proxy/monitor.rs
@@ -1,4 +1,6 @@
-use super::{ProxyController, ProxyUpdate, SystemProxySnapshot};
+use super::{
+    read_system_proxy, ProxyController, ProxyUpdate, SystemProxyProvider, SystemProxySnapshot,
+};
 
 /// Accepts network-change snapshots from a platform adapter.
 ///
@@ -19,6 +21,14 @@ impl ProxyMonitor {
     /// Applies a system proxy snapshot received after a network change.
     pub fn network_changed(&mut self, system_proxy: SystemProxySnapshot) -> ProxyUpdate {
         self.controller.handle_system_proxy_change(system_proxy)
+    }
+
+    /// Reads the latest snapshot after a platform network-change notification.
+    pub fn refresh<P: SystemProxyProvider>(
+        &mut self,
+        provider: &P,
+    ) -> Result<ProxyUpdate, P::Error> {
+        Ok(self.network_changed(read_system_proxy(provider)?))
     }
 
     /// Returns the proxy controller so callers can apply user settings updates.
@@ -47,8 +57,35 @@ mod tests {
 
         assert!(update.changed());
         assert_eq!(
-            monitor.controller().effective_proxy().proxy_url(),
+            monitor
+                .controller()
+                .effective_proxy()
+                .routes_ref()
+                .unwrap()
+                .http_proxy(),
             Some("http://127.0.0.1:7890")
         );
+    }
+
+    #[derive(Debug)]
+    struct FailingProvider;
+
+    impl SystemProxyProvider for FailingProvider {
+        type Error = std::io::Error;
+
+        fn current_system_proxy(&self) -> Result<SystemProxySnapshot, Self::Error> {
+            Err(std::io::Error::other("provider failed"))
+        }
+    }
+
+    #[test]
+    fn refresh_returns_provider_errors() {
+        let controller =
+            ProxyController::new(ProxySettings::default(), SystemProxySnapshot::direct()).unwrap();
+        let mut monitor = ProxyMonitor::new(controller);
+
+        let error = monitor.refresh(&FailingProvider).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
     }
 }

--- a/crates/infra/src/net/proxy/policy.rs
+++ b/crates/infra/src/net/proxy/policy.rs
@@ -1,24 +1,28 @@
-use super::{ProxyConfigError, ProxyMode, ProxySettings, SystemProxySnapshot};
+use super::{ProxyConfigError, ProxyMode, ProxyRoutes, ProxySettings, SystemProxySnapshot};
 use crate::observability;
 
 /// Proxy that an HTTP client should use after policy resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EffectiveProxy {
     Direct,
-    Proxy { proxy_url: String },
+    Routes(ProxyRoutes),
 }
 
 impl EffectiveProxy {
     /// Creates a proxy decision that applies the URL to all HTTP client traffic.
     pub fn proxy(proxy_url: impl Into<String>) -> Self {
-        Self::Proxy { proxy_url: proxy_url.into() }
+        Self::Routes(ProxyRoutes::all(proxy_url))
     }
 
-    /// Returns the proxy URL used to configure an HTTP client.
-    pub fn proxy_url(&self) -> Option<&str> {
+    /// Creates a decision from independently resolved HTTP and HTTPS routes.
+    pub fn routes(routes: ProxyRoutes) -> Self {
+        Self::Routes(routes)
+    }
+
+    pub fn routes_ref(&self) -> Option<&ProxyRoutes> {
         match self {
             Self::Direct => None,
-            Self::Proxy { proxy_url } => Some(proxy_url),
+            Self::Routes(routes) => Some(routes),
         }
     }
 }
@@ -57,6 +61,7 @@ impl ProxyController {
             .validate()
             .inspect_err(|error| observability::proxy_settings_invalid(error))?;
         let effective_proxy = resolve(&settings, &system_proxy);
+        observability::proxy_decision_updated("initial", settings.mode.as_str(), true);
 
         Ok(Self { settings, effective_proxy })
     }
@@ -81,7 +86,13 @@ impl ProxyController {
             .validate()
             .inspect_err(|error| observability::proxy_settings_invalid(error))?;
         self.settings = settings;
-        Ok(self.replace_effective_proxy(resolve(&self.settings, &system_proxy)))
+        let update = self.replace_effective_proxy(resolve(&self.settings, &system_proxy));
+        observability::proxy_decision_updated(
+            "settings",
+            self.settings.mode.as_str(),
+            update.changed(),
+        );
+        Ok(update)
     }
 
     /// Applies an operating-system network change.
@@ -96,7 +107,13 @@ impl ProxyController {
             }
         };
 
-        self.replace_effective_proxy(next)
+        let update = self.replace_effective_proxy(next);
+        observability::proxy_decision_updated(
+            "system",
+            self.settings.mode.as_str(),
+            update.changed(),
+        );
+        update
     }
 
     fn replace_effective_proxy(&mut self, current: EffectiveProxy) -> ProxyUpdate {
@@ -107,10 +124,14 @@ impl ProxyController {
 
 fn resolve(settings: &ProxySettings, system_proxy: &SystemProxySnapshot) -> EffectiveProxy {
     match &settings.mode {
-        ProxyMode::Adaptive | ProxyMode::Preserve => system_proxy
-            .proxy_url()
-            .map(EffectiveProxy::proxy)
-            .unwrap_or(EffectiveProxy::Direct),
+        ProxyMode::Adaptive | ProxyMode::Preserve => {
+            let routes = system_proxy.routes().clone();
+            if routes.http_proxy().is_some() || routes.https_proxy().is_some() {
+                EffectiveProxy::routes(routes)
+            } else {
+                EffectiveProxy::Direct
+            }
+        }
         ProxyMode::Manual { proxy_url } => EffectiveProxy::proxy(proxy_url),
         ProxyMode::Disabled => EffectiveProxy::Direct,
     }
@@ -133,7 +154,14 @@ mod tests {
             controller.handle_system_proxy_change(SystemProxySnapshot::proxy(SECOND_PROXY));
 
         assert!(update.changed());
-        assert_eq!(controller.effective_proxy().proxy_url(), Some(SECOND_PROXY));
+        assert_eq!(
+            controller
+                .effective_proxy()
+                .routes_ref()
+                .unwrap()
+                .http_proxy(),
+            Some(SECOND_PROXY)
+        );
     }
 
     #[test]
@@ -148,7 +176,14 @@ mod tests {
             controller.handle_system_proxy_change(SystemProxySnapshot::proxy(SECOND_PROXY));
 
         assert!(!update.changed());
-        assert_eq!(controller.effective_proxy().proxy_url(), Some(FIRST_PROXY));
+        assert_eq!(
+            controller
+                .effective_proxy()
+                .routes_ref()
+                .unwrap()
+                .http_proxy(),
+            Some(FIRST_PROXY)
+        );
     }
 
     #[test]
@@ -165,7 +200,14 @@ mod tests {
             controller.handle_system_proxy_change(SystemProxySnapshot::proxy(SECOND_PROXY));
 
         assert!(!update.changed());
-        assert_eq!(controller.effective_proxy().proxy_url(), Some(FIRST_PROXY));
+        assert_eq!(
+            controller
+                .effective_proxy()
+                .routes_ref()
+                .unwrap()
+                .http_proxy(),
+            Some(FIRST_PROXY)
+        );
     }
 
     #[test]
@@ -192,6 +234,6 @@ mod tests {
             .unwrap();
 
         assert!(update.changed());
-        assert_eq!(update.current.proxy_url(), Some(FIRST_PROXY));
+        assert_eq!(update.current.routes_ref().unwrap().http_proxy(), Some(FIRST_PROXY));
     }
 }

--- a/crates/infra/src/net/proxy/policy.rs
+++ b/crates/infra/src/net/proxy/policy.rs
@@ -1,0 +1,197 @@
+use super::{ProxyConfigError, ProxyMode, ProxySettings, SystemProxySnapshot};
+use crate::observability;
+
+/// Proxy that an HTTP client should use after policy resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EffectiveProxy {
+    Direct,
+    Proxy { proxy_url: String },
+}
+
+impl EffectiveProxy {
+    /// Creates a proxy decision that applies the URL to all HTTP client traffic.
+    pub fn proxy(proxy_url: impl Into<String>) -> Self {
+        Self::Proxy { proxy_url: proxy_url.into() }
+    }
+
+    /// Returns the proxy URL used to configure an HTTP client.
+    pub fn proxy_url(&self) -> Option<&str> {
+        match self {
+            Self::Direct => None,
+            Self::Proxy { proxy_url } => Some(proxy_url),
+        }
+    }
+}
+
+/// Result of applying settings or a system network-change event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyUpdate {
+    pub previous: EffectiveProxy,
+    pub current: EffectiveProxy,
+}
+
+impl ProxyUpdate {
+    /// Returns whether a caller needs to rebuild its HTTP client.
+    pub fn changed(&self) -> bool {
+        self.previous != self.current
+    }
+}
+
+/// Resolves proxy policy and holds its current in-memory decision.
+///
+/// Configuration files and OS event loops remain outside this type. A host
+/// supplies snapshots through [`Self::handle_system_proxy_change`].
+#[derive(Debug, Clone)]
+pub struct ProxyController {
+    settings: ProxySettings,
+    effective_proxy: EffectiveProxy,
+}
+
+impl ProxyController {
+    /// Creates a controller from application settings and the current system proxy.
+    pub fn new(
+        settings: ProxySettings,
+        system_proxy: SystemProxySnapshot,
+    ) -> Result<Self, ProxyConfigError> {
+        settings
+            .validate()
+            .inspect_err(|error| observability::proxy_settings_invalid(error))?;
+        let effective_proxy = resolve(&settings, &system_proxy);
+
+        Ok(Self { settings, effective_proxy })
+    }
+
+    /// Returns the settings currently owned by this controller.
+    pub fn settings(&self) -> &ProxySettings {
+        &self.settings
+    }
+
+    /// Returns the proxy currently selected for newly built HTTP clients.
+    pub fn effective_proxy(&self) -> &EffectiveProxy {
+        &self.effective_proxy
+    }
+
+    /// Replaces settings and resolves them against the current system snapshot.
+    pub fn update_settings(
+        &mut self,
+        settings: ProxySettings,
+        system_proxy: SystemProxySnapshot,
+    ) -> Result<ProxyUpdate, ProxyConfigError> {
+        settings
+            .validate()
+            .inspect_err(|error| observability::proxy_settings_invalid(error))?;
+        self.settings = settings;
+        Ok(self.replace_effective_proxy(resolve(&self.settings, &system_proxy)))
+    }
+
+    /// Applies an operating-system network change.
+    ///
+    /// Only adaptive settings follow later system changes. Preserve, manual,
+    /// and disabled modes intentionally retain their existing decision.
+    pub fn handle_system_proxy_change(&mut self, system_proxy: SystemProxySnapshot) -> ProxyUpdate {
+        let next = match self.settings.mode {
+            ProxyMode::Adaptive => resolve(&self.settings, &system_proxy),
+            ProxyMode::Preserve | ProxyMode::Manual { .. } | ProxyMode::Disabled => {
+                self.effective_proxy.clone()
+            }
+        };
+
+        self.replace_effective_proxy(next)
+    }
+
+    fn replace_effective_proxy(&mut self, current: EffectiveProxy) -> ProxyUpdate {
+        let previous = std::mem::replace(&mut self.effective_proxy, current.clone());
+        ProxyUpdate { previous, current }
+    }
+}
+
+fn resolve(settings: &ProxySettings, system_proxy: &SystemProxySnapshot) -> EffectiveProxy {
+    match &settings.mode {
+        ProxyMode::Adaptive | ProxyMode::Preserve => system_proxy
+            .proxy_url()
+            .map(EffectiveProxy::proxy)
+            .unwrap_or(EffectiveProxy::Direct),
+        ProxyMode::Manual { proxy_url } => EffectiveProxy::proxy(proxy_url),
+        ProxyMode::Disabled => EffectiveProxy::Direct,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIRST_PROXY: &str = "http://127.0.0.1:7890";
+    const SECOND_PROXY: &str = "http://127.0.0.1:7891";
+
+    #[test]
+    fn adaptive_mode_follows_system_proxy_changes() {
+        let mut controller =
+            ProxyController::new(ProxySettings::default(), SystemProxySnapshot::proxy(FIRST_PROXY))
+                .unwrap();
+
+        let update =
+            controller.handle_system_proxy_change(SystemProxySnapshot::proxy(SECOND_PROXY));
+
+        assert!(update.changed());
+        assert_eq!(controller.effective_proxy().proxy_url(), Some(SECOND_PROXY));
+    }
+
+    #[test]
+    fn preserve_mode_keeps_the_initial_system_proxy() {
+        let mut controller = ProxyController::new(
+            ProxySettings { mode: ProxyMode::Preserve },
+            SystemProxySnapshot::proxy(FIRST_PROXY),
+        )
+        .unwrap();
+
+        let update =
+            controller.handle_system_proxy_change(SystemProxySnapshot::proxy(SECOND_PROXY));
+
+        assert!(!update.changed());
+        assert_eq!(controller.effective_proxy().proxy_url(), Some(FIRST_PROXY));
+    }
+
+    #[test]
+    fn manual_mode_ignores_system_proxy_changes() {
+        let mut controller = ProxyController::new(
+            ProxySettings {
+                mode: ProxyMode::Manual { proxy_url: FIRST_PROXY.into() },
+            },
+            SystemProxySnapshot::direct(),
+        )
+        .unwrap();
+
+        let update =
+            controller.handle_system_proxy_change(SystemProxySnapshot::proxy(SECOND_PROXY));
+
+        assert!(!update.changed());
+        assert_eq!(controller.effective_proxy().proxy_url(), Some(FIRST_PROXY));
+    }
+
+    #[test]
+    fn disabled_mode_forces_direct_connections() {
+        let controller = ProxyController::new(
+            ProxySettings { mode: ProxyMode::Disabled },
+            SystemProxySnapshot::proxy(FIRST_PROXY),
+        )
+        .unwrap();
+
+        assert_eq!(controller.effective_proxy(), &EffectiveProxy::Direct);
+    }
+
+    #[test]
+    fn changing_to_preserve_uses_the_current_snapshot_once() {
+        let mut controller =
+            ProxyController::new(ProxySettings::default(), SystemProxySnapshot::direct()).unwrap();
+
+        let update = controller
+            .update_settings(
+                ProxySettings { mode: ProxyMode::Preserve },
+                SystemProxySnapshot::proxy(FIRST_PROXY),
+            )
+            .unwrap();
+
+        assert!(update.changed());
+        assert_eq!(update.current.proxy_url(), Some(FIRST_PROXY));
+    }
+}

--- a/crates/infra/src/net/proxy/system.rs
+++ b/crates/infra/src/net/proxy/system.rs
@@ -1,0 +1,48 @@
+/// Snapshot of the proxy currently reported by the operating system.
+///
+/// A missing URL means direct connections. Platform adapters may obtain this
+/// value from Windows, macOS, Linux, or another host-specific source.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SystemProxySnapshot {
+    proxy_url: Option<String>,
+}
+
+impl SystemProxySnapshot {
+    /// Creates a snapshot that requests direct connections.
+    pub const fn direct() -> Self {
+        Self { proxy_url: None }
+    }
+
+    /// Creates a snapshot with one proxy applied to all HTTP client traffic.
+    pub fn proxy(proxy_url: impl Into<String>) -> Self {
+        Self { proxy_url: Some(proxy_url.into()) }
+    }
+
+    /// Returns the reported proxy URL, if any.
+    pub fn proxy_url(&self) -> Option<&str> {
+        self.proxy_url.as_deref()
+    }
+}
+
+/// Supplies the current system proxy without coupling network policy to an OS.
+pub trait SystemProxyProvider {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    fn current_system_proxy(&self) -> Result<SystemProxySnapshot, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_snapshot_has_no_proxy() {
+        assert_eq!(SystemProxySnapshot::direct().proxy_url(), None);
+    }
+
+    #[test]
+    fn proxy_snapshot_exposes_its_url() {
+        let snapshot = SystemProxySnapshot::proxy("http://127.0.0.1:7890");
+        assert_eq!(snapshot.proxy_url(), Some("http://127.0.0.1:7890"));
+    }
+}

--- a/crates/infra/src/net/proxy/system.rs
+++ b/crates/infra/src/net/proxy/system.rs
@@ -1,26 +1,91 @@
-/// Snapshot of the proxy currently reported by the operating system.
+/// Static proxy routes resolved from operating-system configuration.
 ///
-/// A missing URL means direct connections. Platform adapters may obtain this
-/// value from Windows, macOS, Linux, or another host-specific source.
+/// Platform adapters must resolve PAC or other dynamic configuration before
+/// constructing this value. The network layer never executes external scripts.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProxyRoutes {
+    http_proxy: Option<String>,
+    https_proxy: Option<String>,
+    no_proxy: Vec<String>,
+}
+
+impl ProxyRoutes {
+    /// Creates direct routes for both HTTP and HTTPS traffic.
+    pub const fn direct() -> Self {
+        Self {
+            http_proxy: None,
+            https_proxy: None,
+            no_proxy: Vec::new(),
+        }
+    }
+
+    /// Creates routes that apply one proxy to both HTTP and HTTPS traffic.
+    pub fn all(proxy_url: impl Into<String>) -> Self {
+        let proxy_url = proxy_url.into();
+        Self {
+            http_proxy: Some(proxy_url.clone()),
+            https_proxy: Some(proxy_url),
+            no_proxy: Vec::new(),
+        }
+    }
+
+    /// Creates routes with independent HTTP and HTTPS proxy endpoints.
+    pub fn split(http_proxy: Option<String>, https_proxy: Option<String>) -> Self {
+        Self {
+            http_proxy,
+            https_proxy,
+            no_proxy: Vec::new(),
+        }
+    }
+
+    /// Adds host, domain, IP, or CIDR entries that bypass configured proxies.
+    pub fn with_no_proxy(mut self, no_proxy: Vec<String>) -> Self {
+        self.no_proxy = no_proxy;
+        self
+    }
+
+    pub fn http_proxy(&self) -> Option<&str> {
+        self.http_proxy.as_deref()
+    }
+
+    pub fn https_proxy(&self) -> Option<&str> {
+        self.https_proxy.as_deref()
+    }
+
+    pub fn no_proxy(&self) -> &[String] {
+        &self.no_proxy
+    }
+}
+
+/// Snapshot of static proxy routes currently reported by the operating system.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SystemProxySnapshot {
-    proxy_url: Option<String>,
+    routes: ProxyRoutes,
 }
 
 impl SystemProxySnapshot {
     /// Creates a snapshot that requests direct connections.
     pub const fn direct() -> Self {
-        Self { proxy_url: None }
+        Self { routes: ProxyRoutes::direct() }
     }
 
-    /// Creates a snapshot with one proxy applied to all HTTP client traffic.
+    /// Creates a snapshot with one proxy applied to HTTP and HTTPS traffic.
     pub fn proxy(proxy_url: impl Into<String>) -> Self {
-        Self { proxy_url: Some(proxy_url.into()) }
+        Self::from_routes(ProxyRoutes::all(proxy_url))
     }
 
-    /// Returns the reported proxy URL, if any.
-    pub fn proxy_url(&self) -> Option<&str> {
-        self.proxy_url.as_deref()
+    /// Creates a snapshot with independent HTTP and HTTPS routes.
+    pub fn split(http_proxy: Option<String>, https_proxy: Option<String>) -> Self {
+        Self::from_routes(ProxyRoutes::split(http_proxy, https_proxy))
+    }
+
+    /// Creates a snapshot from platform-resolved routes.
+    pub fn from_routes(routes: ProxyRoutes) -> Self {
+        Self { routes }
+    }
+
+    pub fn routes(&self) -> &ProxyRoutes {
+        &self.routes
     }
 }
 
@@ -31,18 +96,58 @@ pub trait SystemProxyProvider {
     fn current_system_proxy(&self) -> Result<SystemProxySnapshot, Self::Error>;
 }
 
+/// Reads a platform proxy snapshot and records a stable failure event.
+pub fn read_system_proxy<P: SystemProxyProvider>(
+    provider: &P,
+) -> Result<SystemProxySnapshot, P::Error> {
+    provider
+        .current_system_proxy()
+        .inspect_err(|_| crate::observability::system_proxy_read_failed())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn direct_snapshot_has_no_proxy() {
-        assert_eq!(SystemProxySnapshot::direct().proxy_url(), None);
+    fn direct_snapshot_has_no_routes() {
+        let snapshot = SystemProxySnapshot::direct();
+        let routes = snapshot.routes();
+        assert_eq!(routes.http_proxy(), None);
+        assert_eq!(routes.https_proxy(), None);
     }
 
     #[test]
-    fn proxy_snapshot_exposes_its_url() {
-        let snapshot = SystemProxySnapshot::proxy("http://127.0.0.1:7890");
-        assert_eq!(snapshot.proxy_url(), Some("http://127.0.0.1:7890"));
+    fn split_snapshot_preserves_routes_and_bypass_rules() {
+        let snapshot = SystemProxySnapshot::split(
+            Some("http://127.0.0.1:7890".into()),
+            Some("http://127.0.0.1:7891".into()),
+        );
+        let routes = snapshot
+            .routes()
+            .clone()
+            .with_no_proxy(vec!["localhost".into()]);
+
+        assert_eq!(routes.http_proxy(), Some("http://127.0.0.1:7890"));
+        assert_eq!(routes.https_proxy(), Some("http://127.0.0.1:7891"));
+        assert_eq!(routes.no_proxy(), &["localhost".to_owned()]);
+    }
+
+    #[derive(Debug)]
+    struct FailingProvider;
+
+    impl SystemProxyProvider for FailingProvider {
+        type Error = std::io::Error;
+
+        fn current_system_proxy(&self) -> Result<SystemProxySnapshot, Self::Error> {
+            Err(std::io::Error::other("system settings unavailable"))
+        }
+    }
+
+    #[test]
+    fn provider_errors_are_returned_to_the_caller() {
+        let error = read_system_proxy(&FailingProvider).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
     }
 }

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -157,6 +157,8 @@ pub const EVENT_REQUEST_COMPLETED: &str = "request_completed";
 pub const EVENT_REQUEST_RETRY: &str = "request_retry";
 /// Event: the proxy configuration is invalid.
 pub const EVENT_PROXY_CONFIG_INVALID: &str = "proxy_config_invalid";
+/// Event: proxy settings could not be applied.
+pub const EVENT_PROXY_SETTINGS_INVALID: &str = "proxy_settings_invalid";
 
 /// Records a proxy configuration invalid event.
 pub fn proxy_config_invalid(proxy_url: &str, error: &dyn Display) {
@@ -166,6 +168,16 @@ pub fn proxy_config_invalid(proxy_url: &str, error: &dyn Display) {
         proxy_url,
         error = %error,
         "proxy config invalid"
+    );
+}
+
+/// Records invalid proxy settings rejected before a client is built.
+pub fn proxy_settings_invalid(error: &dyn Display) {
+    tracing::warn!(
+        target: NET_TARGET,
+        event_name = EVENT_PROXY_SETTINGS_INVALID,
+        error = %error,
+        "proxy settings invalid"
     );
 }
 

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -159,14 +159,19 @@ pub const EVENT_REQUEST_RETRY: &str = "request_retry";
 pub const EVENT_PROXY_CONFIG_INVALID: &str = "proxy_config_invalid";
 /// Event: proxy settings could not be applied.
 pub const EVENT_PROXY_SETTINGS_INVALID: &str = "proxy_settings_invalid";
+/// Event: proxy routing policy was evaluated.
+pub const EVENT_PROXY_DECISION_UPDATED: &str = "proxy_decision_updated";
+/// Event: platform proxy discovery failed.
+pub const EVENT_SYSTEM_PROXY_READ_FAILED: &str = "system_proxy_read_failed";
+/// Event: an HTTP client could not be constructed.
+pub const EVENT_HTTP_CLIENT_BUILD_FAILED: &str = "http_client_build_failed";
 
 /// Records a proxy configuration invalid event.
-pub fn proxy_config_invalid(proxy_url: &str, error: &dyn Display) {
+pub fn proxy_config_invalid(scope: &str) {
     tracing::error!(
         target: NET_TARGET,
         event_name = EVENT_PROXY_CONFIG_INVALID,
-        proxy_url,
-        error = %error,
+        scope,
         "proxy config invalid"
     );
 }
@@ -178,6 +183,36 @@ pub fn proxy_settings_invalid(error: &dyn Display) {
         event_name = EVENT_PROXY_SETTINGS_INVALID,
         error = %error,
         "proxy settings invalid"
+    );
+}
+
+/// Records an evaluated proxy decision without exposing endpoint credentials.
+pub fn proxy_decision_updated(source: &str, mode: &str, changed: bool) {
+    tracing::info!(
+        target: NET_TARGET,
+        event_name = EVENT_PROXY_DECISION_UPDATED,
+        source,
+        mode,
+        changed,
+        "proxy decision updated"
+    );
+}
+
+/// Records a platform proxy-read failure without logging provider-controlled text.
+pub fn system_proxy_read_failed() {
+    tracing::warn!(
+        target: NET_TARGET,
+        event_name = EVENT_SYSTEM_PROXY_READ_FAILED,
+        "system proxy read failed"
+    );
+}
+
+/// Records an HTTP client construction failure without logging configuration values.
+pub fn http_client_build_failed() {
+    tracing::error!(
+        target: NET_TARGET,
+        event_name = EVENT_HTTP_CLIENT_BUILD_FAILED,
+        "HTTP client build failed"
     );
 }
 


### PR DESCRIPTION
## Discovery
While defining the network proxy boundary, the existing client treated proxy configuration as one URL and logged that URL when parsing failed.

## Investigation
Reviewed the network client, proxy policy, observability contract, and reqwest proxy capabilities. The client supports independent HTTP/HTTPS proxies and no-proxy exclusions, while the initial policy model could not retain those semantics.

## Problem
A proxy URL can contain credentials, so recording it in error events could leak secrets. The single-route model would also discard protocol-specific system settings and bypass rules. System-proxy provider failures had no shared refresh path or stable event.

## Resolution
- Add resolved HTTP/HTTPS proxy routes with NO_PROXY-style bypass rules.
- Build async and blocking clients directly from an EffectiveProxy decision.
- Remove proxy URLs and provider-controlled error text from tracing and returned configuration errors.
- Add stable decision, provider-read-failure, and client-build-failure events.
- Add a monitor refresh API that records and returns platform provider errors.

## Validation
- cargo test -p sealantern-infra --lib --all-features (70 passed)
- cargo fmt --all -- --check
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- fuck-u-code analyze crates/infra -l zh -t 20 (92.62/100; proxy module is not a hotspot)

## Summary by Sourcery

引入一个代理策略层，将 HTTP 客户端的构建与应用/系统配置解耦，同时保留协议特定的路由和绕过规则，并增强可观测性，防止代理凭据泄漏。

新特性：
- 添加一个代理配置模块，为出站网络客户端提供设置、模式（adaptive、preserve、manual、disabled）以及校验功能。
- 添加代理策略类型（EffectiveProxy、ProxyController、ProxyUpdate），用于将应用设置和系统代理快照解析为具体的路由决策。
- 添加系统代理抽象（ProxyRoutes、SystemProxySnapshot、SystemProxyProvider、read_system_proxy），用于建模操作系统层面的代理路由，包括类似 NO_PROXY 的绕过规则。
- 添加 ProxyMonitor，用于应用网络变更快照，并提供刷新 API，以暴露系统代理提供方的错误。

缺陷修复：
- 防止在配置和 HTTP 客户端构建错误中记录或回显代理 URL 和凭据。

改进增强：
- 更新异步和阻塞式 HTTP 客户端，使其由 EffectiveProxy 决策进行构建，支持分别配置 HTTP/HTTPS 代理以及绕过规则。
- 优化客户端配置 API，使其依赖调用方提供的设置，而不是从基础设施读取应用全局配置。
- 添加可观测性事件，用于记录无效代理配置、无效代理设置、代理决策更新、系统代理读取失败以及 HTTP 客户端构建失败。
- 添加测试，覆盖代理路由、策略模式、监视器刷新行为，并确保在错误消息中代理凭据不会泄露。

文档：
- 更新 HTTP 客户端模块文档，说明其依赖外部解析的代理和配置设置，而非全局配置管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a proxy policy layer that decouples HTTP client construction from application/system configuration while preserving protocol-specific routes and bypass rules, and hardening observability against leaking proxy credentials.

New Features:
- Add a proxy configuration module with settings, modes (adaptive, preserve, manual, disabled), and validation for outbound network clients.
- Add proxy policy types (EffectiveProxy, ProxyController, ProxyUpdate) to resolve application settings and system proxy snapshots into concrete routing decisions.
- Add system proxy abstractions (ProxyRoutes, SystemProxySnapshot, SystemProxyProvider, read_system_proxy) to model OS-level proxy routes including NO_PROXY-style bypass rules.
- Add a ProxyMonitor to apply network-change snapshots and provide a refresh API that surfaces system proxy provider errors.

Bug Fixes:
- Prevent proxy URLs and credentials from being logged or echoed in configuration and HTTP client build errors.

Enhancements:
- Update async and blocking HTTP clients to be constructed from an EffectiveProxy decision, supporting separate HTTP/HTTPS proxies and bypass rules.
- Refine client configuration APIs to rely on caller-supplied settings instead of reading application globals from infra.
- Add observability events for invalid proxy config, invalid proxy settings, proxy decision updates, system proxy read failures, and HTTP client construction failures.
- Add tests covering proxy routing, policy modes, monitor refresh behavior, and ensuring proxy credential secrecy in error messages.

Documentation:
- Update HTTP client module documentation to describe its dependency on externally resolved proxy and configuration settings rather than global config management.

</details>