### PR TITLE
feat(infra): add platform system utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,6 +6025,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sysinfo",
  "tokio",
  "tokio-util",
  "toml 0.8.2",

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -26,3 +26,4 @@ sha2 = "0.10"
 toml = "0.8"
 uuid = { version = "1", features = ["v4"] }
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
+sysinfo = "0.32"

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -6,3 +6,4 @@ pub mod fs;
 pub mod net;
 pub mod observability;
 pub mod persistence;
+pub mod platform;

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -5,6 +5,25 @@
 
 use std::fmt::Display;
 
+// -- 平台层 --
+
+/// 平台基础设施模块的 tracing 目标。
+pub const PLATFORM_TARGET: &str = "sealantern.infra.platform";
+
+/// Event: 平台操作失败。
+pub const EVENT_PLATFORM_OPERATION_FAILED: &str = "platform_operation_failed";
+
+/// 记录平台操作失败，不记录环境变量值或证书内容。
+pub fn platform_operation_failed(operation: &str, error: &dyn Display) {
+    tracing::error!(
+        target: PLATFORM_TARGET,
+        event_name = EVENT_PLATFORM_OPERATION_FAILED,
+        operation,
+        error = %error,
+        "platform operation failed"
+    );
+}
+
 // -- 文件系统层 --
 
 /// 文件系统基础设施模块的 tracing 目标。

--- a/crates/infra/src/platform/certificate.rs
+++ b/crates/infra/src/platform/certificate.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+use crate::observability;
+
+use super::PlatformError;
+
+/// 经解析的 PEM CA 证书束，可用于构建隔离的 HTTP 客户端信任链。
+#[derive(Debug)]
+pub struct CaCertificateBundle {
+    certificates: Vec<reqwest::Certificate>,
+}
+
+impl CaCertificateBundle {
+    /// 返回证书数量。
+    pub fn len(&self) -> usize {
+        self.certificates.len()
+    }
+
+    /// 证书束是否为空。
+    pub fn is_empty(&self) -> bool {
+        self.certificates.is_empty()
+    }
+
+    /// 将全部 CA 证书添加到 HTTP 客户端构建器。
+    pub fn apply_to(self, builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+        self.certificates
+            .into_iter()
+            .fold(builder, |builder, certificate| builder.add_root_certificate(certificate))
+    }
+}
+
+/// 从 PEM 字节解析一个或多个 CA 证书。
+pub fn parse_ca_certificate_bundle(pem: &[u8]) -> Result<CaCertificateBundle, PlatformError> {
+    let certificates = reqwest::Certificate::from_pem_bundle(pem).map_err(|error| {
+        let error = PlatformError::InvalidCertificate { message: error.to_string() };
+        observability::platform_operation_failed("parse CA certificate bundle", &error);
+        error
+    })?;
+
+    if certificates.is_empty() {
+        let error = PlatformError::InvalidCertificate {
+            message: "certificate bundle is empty".into(),
+        };
+        observability::platform_operation_failed("parse CA certificate bundle", &error);
+        return Err(error);
+    }
+
+    Ok(CaCertificateBundle { certificates })
+}
+
+/// 从文件加载 PEM CA 证书束。
+///
+/// 此函数只解析本次客户端要追加的信任根，绝不写入操作系统的全局证书存储。
+pub fn load_ca_certificate_bundle(
+    path: impl AsRef<Path>,
+) -> Result<CaCertificateBundle, PlatformError> {
+    let path = path.as_ref();
+    let pem = std::fs::read(path).map_err(|source| {
+        let error = PlatformError::ReadCertificate { path: path.to_path_buf(), source };
+        observability::platform_operation_failed("read CA certificate bundle", &error);
+        error
+    })?;
+    parse_ca_certificate_bundle(&pem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_pem() {
+        let error = parse_ca_certificate_bundle(b"not a certificate").unwrap_err();
+
+        assert!(matches!(error, PlatformError::InvalidCertificate { .. }));
+    }
+
+    #[test]
+    fn file_errors_include_the_path() {
+        let path = std::env::temp_dir().join("sealantern-ca-certificate-does-not-exist.pem");
+        let error = load_ca_certificate_bundle(&path).unwrap_err();
+
+        assert!(matches!(error, PlatformError::ReadCertificate { .. }));
+        assert!(error.to_string().contains(&path.display().to_string()));
+    }
+}

--- a/crates/infra/src/platform/elevation.rs
+++ b/crates/infra/src/platform/elevation.rs
@@ -1,0 +1,217 @@
+use std::ffi::OsStr;
+use std::process::Command;
+
+use crate::observability;
+
+use super::PlatformError;
+
+/// 已启动或已提交给系统授权对话框的提权请求。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElevationLaunch {
+    /// Unix `sudo` 已启动，进程 ID 属于 sudo 包装进程。
+    Started { process_id: u32 },
+    /// Windows 或 macOS 已将请求交给系统授权界面。
+    Requested,
+}
+
+/// 返回当前进程是否以管理员或 root 权限运行。
+pub fn is_elevated() -> Result<bool, PlatformError> {
+    let result = imp::is_elevated();
+    result.inspect_err(|error| observability::platform_operation_failed("check elevation", error))
+}
+
+/// 请求操作系统以提升后的权限启动指定程序。
+///
+/// Unix 平台启动 `sudo -- <program> <args>`。Windows 和 macOS 会显示操作系统原生
+/// 授权对话框，调用方应在请求后结束当前工作流而不是等待子进程。
+pub fn request_elevation(
+    program: impl AsRef<OsStr>,
+    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+) -> Result<ElevationLaunch, PlatformError> {
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_owned())
+        .collect::<Vec<_>>();
+    let result = imp::request_elevation(program.as_ref(), &args);
+    result.inspect_err(|error| observability::platform_operation_failed("request elevation", error))
+}
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use super::*;
+
+    pub fn is_elevated() -> Result<bool, PlatformError> {
+        let output = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)",
+            ])
+            .output()
+            .map_err(|source| PlatformError::Command { operation: "check Windows elevation", source })?;
+        if !output.status.success() {
+            return Err(PlatformError::InvalidCommandOutput {
+                operation: "check Windows elevation",
+            });
+        }
+        match String::from_utf8_lossy(&output.stdout).trim() {
+            "True" => Ok(true),
+            "False" => Ok(false),
+            _ => Err(PlatformError::InvalidCommandOutput { operation: "check Windows elevation" }),
+        }
+    }
+
+    pub fn request_elevation(
+        program: &OsStr,
+        args: &[std::ffi::OsString],
+    ) -> Result<ElevationLaunch, PlatformError> {
+        let program = powershell_quote(&program.to_string_lossy());
+        let arguments = args
+            .iter()
+            .map(|arg| format!("'{}'", powershell_quote(&arg.to_string_lossy())))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let command = format!(
+            "$ErrorActionPreference = 'Stop'; Start-Process -FilePath '{program}' -ArgumentList @({arguments}) -Verb RunAs"
+        );
+        let status = Command::new("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", &command])
+            .status()
+            .map_err(|source| PlatformError::Command {
+                operation: "request Windows elevation",
+                source,
+            })?;
+        if status.success() {
+            Ok(ElevationLaunch::Requested)
+        } else {
+            Err(PlatformError::InvalidCommandOutput { operation: "request Windows elevation" })
+        }
+    }
+
+    pub(super) fn powershell_quote(value: &str) -> String {
+        value.replace('\'', "''")
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::*;
+
+    pub fn is_elevated() -> Result<bool, PlatformError> {
+        super::unix_is_elevated()
+    }
+
+    pub fn request_elevation(
+        program: &OsStr,
+        args: &[std::ffi::OsString],
+    ) -> Result<ElevationLaunch, PlatformError> {
+        let command = shell_command(program, args);
+        let script = format!(
+            "do shell script {} with administrator privileges",
+            applescript_quote(&command)
+        );
+        let status = Command::new("osascript")
+            .args(["-e", &script])
+            .status()
+            .map_err(|source| PlatformError::Command {
+                operation: "request macOS elevation",
+                source,
+            })?;
+        if status.success() {
+            Ok(ElevationLaunch::Requested)
+        } else {
+            Err(PlatformError::InvalidCommandOutput { operation: "request macOS elevation" })
+        }
+    }
+
+    fn applescript_quote(value: &str) -> String {
+        format!("\"{}\"", value.replace('\\', "\\\\").replace('\"', "\\\""))
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+mod imp {
+    use super::*;
+
+    pub fn is_elevated() -> Result<bool, PlatformError> {
+        super::unix_is_elevated()
+    }
+
+    pub fn request_elevation(
+        program: &OsStr,
+        args: &[std::ffi::OsString],
+    ) -> Result<ElevationLaunch, PlatformError> {
+        let child = Command::new("sudo")
+            .arg("--")
+            .arg(program)
+            .args(args)
+            .spawn()
+            .map_err(|source| PlatformError::Command { operation: "start sudo", source })?;
+        Ok(ElevationLaunch::Started { process_id: child.id() })
+    }
+}
+
+#[cfg(unix)]
+fn unix_is_elevated() -> Result<bool, PlatformError> {
+    let output =
+        Command::new("id")
+            .arg("-u")
+            .output()
+            .map_err(|source| PlatformError::Command {
+                operation: "check Unix elevation",
+                source,
+            })?;
+    if !output.status.success() {
+        return Err(PlatformError::InvalidCommandOutput { operation: "check Unix elevation" });
+    }
+    match String::from_utf8_lossy(&output.stdout).trim() {
+        "0" => Ok(true),
+        value if value.parse::<u32>().is_ok() => Ok(false),
+        _ => Err(PlatformError::InvalidCommandOutput { operation: "check Unix elevation" }),
+    }
+}
+
+#[cfg(not(any(windows, unix)))]
+mod imp {
+    use super::*;
+
+    pub fn is_elevated() -> Result<bool, PlatformError> {
+        Err(PlatformError::Unsupported { operation: "check elevation" })
+    }
+
+    pub fn request_elevation(
+        _program: &OsStr,
+        _args: &[std::ffi::OsString],
+    ) -> Result<ElevationLaunch, PlatformError> {
+        Err(PlatformError::Unsupported { operation: "request elevation" })
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn shell_command(program: &OsStr, args: &[std::ffi::OsString]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().map(|arg| arg.as_os_str()))
+        .map(|value| format!("'{}'", value.to_string_lossy().replace('\'', "'\\''")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elevation_check_returns_a_boolean_or_contextual_error() {
+        match is_elevated() {
+            Ok(_) => {}
+            Err(error) => assert!(error.to_string().contains("elevation")),
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn powershell_quotes_single_quotes() {
+        assert_eq!(imp::powershell_quote("C:\\O'Brien"), "C:\\O''Brien");
+    }
+}

--- a/crates/infra/src/platform/environment.rs
+++ b/crates/infra/src/platform/environment.rs
@@ -1,0 +1,126 @@
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::path::PathBuf;
+
+/// 进程环境变量访问错误。
+#[derive(Debug)]
+pub enum EnvironmentError {
+    InvalidKey,
+    InvalidValue,
+    NotUnicode { key: String },
+}
+
+impl fmt::Display for EnvironmentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidKey => write!(formatter, "environment variable name is invalid"),
+            Self::InvalidValue => write!(formatter, "environment variable value contains NUL"),
+            Self::NotUnicode { key } => {
+                write!(formatter, "environment variable '{key}' is not valid Unicode")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EnvironmentError {}
+
+/// 进程环境变量的受控访问入口。
+pub struct Environment;
+
+impl Environment {
+    /// 返回原始平台字符串，避免丢失非 UTF-8 环境变量。
+    pub fn get_os(key: impl AsRef<OsStr>) -> Option<OsString> {
+        env::var_os(key)
+    }
+
+    /// 读取 UTF-8 环境变量；变量不存在时返回 `Ok(None)`。
+    pub fn get(key: &str) -> Result<Option<String>, EnvironmentError> {
+        match env::var(key) {
+            Ok(value) => Ok(Some(value)),
+            Err(env::VarError::NotPresent) => Ok(None),
+            Err(env::VarError::NotUnicode(_)) => {
+                Err(EnvironmentError::NotUnicode { key: key.into() })
+            }
+        }
+    }
+
+    /// 设置进程环境变量。
+    ///
+    /// 该操作影响整个进程。调用方必须在启动线程或加载不受控库之前完成写入，
+    /// 避免与并发环境读取产生未定义的外部行为。
+    pub fn set(key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> Result<(), EnvironmentError> {
+        validate_key(key.as_ref())?;
+        validate_value(value.as_ref())?;
+        env::set_var(key, value);
+        Ok(())
+    }
+
+    /// 删除进程环境变量。与 [`Self::set`] 一样，必须由调用方保证没有并发访问。
+    pub fn remove(key: impl AsRef<OsStr>) -> Result<(), EnvironmentError> {
+        validate_key(key.as_ref())?;
+        env::remove_var(key);
+        Ok(())
+    }
+
+    /// 返回 `PATH` 的已解析条目；未设置时返回空列表。
+    pub fn path_entries() -> Vec<PathBuf> {
+        env::var_os("PATH")
+            .map(|value| env::split_paths(&value).collect())
+            .unwrap_or_default()
+    }
+
+    /// 设置 `PATH` 的全部条目。
+    pub fn set_path(entries: impl IntoIterator<Item = PathBuf>) -> Result<(), EnvironmentError> {
+        Self::set("PATH", env::join_paths(entries).map_err(|_| EnvironmentError::InvalidValue)?)
+    }
+}
+
+fn validate_key(key: &OsStr) -> Result<(), EnvironmentError> {
+    let key = key.to_string_lossy();
+    if key.is_empty() || key.contains('=') || key.contains('\0') {
+        return Err(EnvironmentError::InvalidKey);
+    }
+    Ok(())
+}
+
+fn validate_value(value: &OsStr) -> Result<(), EnvironmentError> {
+    if value.to_string_lossy().contains('\0') {
+        return Err(EnvironmentError::InvalidValue);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, OnceLock};
+
+    use super::*;
+
+    fn environment_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn reads_writes_and_removes_a_utf8_value() {
+        let _guard = environment_lock().lock().unwrap();
+        let key = "SEALANTERN_INFRA_PLATFORM_ENVIRONMENT_TEST";
+        let previous = Environment::get_os(key);
+
+        Environment::set(key, "value").unwrap();
+        assert_eq!(Environment::get(key).unwrap(), Some("value".into()));
+        Environment::remove(key).unwrap();
+        assert_eq!(Environment::get(key).unwrap(), None);
+
+        if let Some(previous) = previous {
+            Environment::set(key, previous).unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_variable_names() {
+        assert!(matches!(Environment::set("", "value"), Err(EnvironmentError::InvalidKey)));
+        assert!(matches!(Environment::remove("A=B"), Err(EnvironmentError::InvalidKey)));
+    }
+}

--- a/crates/infra/src/platform/error.rs
+++ b/crates/infra/src/platform/error.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+use std::path::PathBuf;
+
+/// 平台基础设施操作返回的错误。
+#[derive(Debug)]
+pub enum PlatformError {
+    /// 无法读取 CA 证书文件。
+    ReadCertificate {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// PEM 内容不是有效的 CA 证书束。
+    InvalidCertificate { message: String },
+    /// 当前平台不支持请求的系统操作。
+    Unsupported { operation: &'static str },
+    /// 系统命令无法启动或以失败状态退出。
+    Command {
+        operation: &'static str,
+        source: std::io::Error,
+    },
+    /// 系统命令返回了无法解释的输出。
+    InvalidCommandOutput { operation: &'static str },
+}
+
+impl fmt::Display for PlatformError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadCertificate { path, source } => {
+                write!(formatter, "failed to read CA certificate '{}': {source}", path.display())
+            }
+            Self::InvalidCertificate { message } => {
+                write!(formatter, "invalid CA certificate bundle: {message}")
+            }
+            Self::Unsupported { operation } => {
+                write!(formatter, "{operation} is not supported on this platform")
+            }
+            Self::Command { operation, source } => {
+                write!(formatter, "failed to {operation}: {source}")
+            }
+            Self::InvalidCommandOutput { operation } => {
+                write!(formatter, "{operation} returned an unexpected result")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PlatformError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ReadCertificate { source, .. } | Self::Command { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -1,0 +1,18 @@
+//! 跨平台的系统级基础设施。
+//!
+//! 此模块只封装可移植的系统交互原语。应用策略、配置持久化和 UI 授权流程
+//! 由上层负责；尤其是 CA 证书仅供 HTTP 客户端使用，不会修改操作系统信任库。
+
+mod certificate;
+mod elevation;
+mod environment;
+mod error;
+mod system;
+
+pub use certificate::{
+    load_ca_certificate_bundle, parse_ca_certificate_bundle, CaCertificateBundle,
+};
+pub use elevation::{is_elevated, request_elevation, ElevationLaunch};
+pub use environment::{Environment, EnvironmentError};
+pub use error::PlatformError;
+pub use system::{collect_system_info, SystemInfo};

--- a/crates/infra/src/platform/system.rs
+++ b/crates/infra/src/platform/system.rs
@@ -1,0 +1,59 @@
+use sysinfo::System;
+
+/// 当前机器的稳定系统信息快照。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemInfo {
+    pub operating_system: &'static str,
+    pub architecture: &'static str,
+    pub family: &'static str,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub kernel_version: Option<String>,
+    pub host_name: Option<String>,
+    pub logical_cpu_count: usize,
+    pub physical_cpu_count: Option<usize>,
+    pub total_memory_bytes: u64,
+    pub available_memory_bytes: u64,
+    pub uptime_seconds: u64,
+}
+
+/// 采集当前机器的系统信息。
+///
+/// `sysinfo` 在无法取得某项操作系统元数据时返回 `None`，因此采集不会因单个
+/// 信息缺失而失败。
+pub fn collect_system_info() -> SystemInfo {
+    let mut system = System::new();
+    system.refresh_memory();
+    system.refresh_cpu_all();
+
+    SystemInfo {
+        operating_system: std::env::consts::OS,
+        architecture: std::env::consts::ARCH,
+        family: std::env::consts::FAMILY,
+        name: System::name(),
+        version: System::os_version(),
+        kernel_version: System::kernel_version(),
+        host_name: System::host_name(),
+        logical_cpu_count: system.cpus().len(),
+        physical_cpu_count: system.physical_core_count(),
+        total_memory_bytes: system.total_memory(),
+        available_memory_bytes: system.available_memory(),
+        uptime_seconds: System::uptime(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collects_compile_target_and_runtime_memory() {
+        let info = collect_system_info();
+
+        assert_eq!(info.operating_system, std::env::consts::OS);
+        assert_eq!(info.architecture, std::env::consts::ARCH);
+        assert!(!info.family.is_empty());
+        assert!(info.logical_cpu_count > 0);
+        assert!(info.total_memory_bytes >= info.available_memory_bytes);
+    }
+}


### PR DESCRIPTION
## Summary
- add cross-platform system information snapshots
- add controlled environment-variable and PATH access
- add PEM CA bundle loading for reqwest clients
- add elevation status checks and launch requests

## Validation
- cargo fmt --all -- --check
- cargo test -p sealantern-infra --lib
- cargo clippy -p sealantern-infra --lib -- -D warnings

## Sourcery 总结

引入一个新的跨平台基础设施模块，用于提供系统工具与错误处理能力。

新功能：
- 新增用于平台操作失败的“平台可观测性”目标和事件。
- 暴露一个新的平台模块，支持跨平台的提权检查和启动请求。
- 提供受控访问器和辅助函数，用于管理环境变量和 `PATH`。
- 支持为 HTTP 客户端加载和应用 PEM 格式的 CA 证书包。
- 添加基于 `sysinfo` 构建的系统信息快照 API。

增强项：
- 将基础设施可观测性扩展到涵盖平台级故障。

构建：
- 添加 `sysinfo` 作为系统信息收集的依赖项。

测试：
- 添加单元测试，覆盖环境变量处理、提权行为接口、证书错误场景以及系统信息收集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new cross-platform platform infrastructure module providing system utilities and error handling.

New Features:
- Add a platform observability target and event for failed platform operations.
- Expose a new platform module with cross-platform elevation checks and launch requests.
- Provide controlled accessors and helpers for environment variables and PATH management.
- Support loading and applying PEM CA certificate bundles for HTTP clients.
- Add a system information snapshot API built on top of sysinfo.

Enhancements:
- Extend infra observability to cover platform-level failures.

Build:
- Add sysinfo as a dependency for system information collection.

Tests:
- Add unit tests covering environment variable handling, elevation behavior surface, certificate error cases, and system info collection.

</details>