### PR TITLE
refactor(server): compose core process runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6039,6 +6039,7 @@ dependencies = [
 name = "sealantern-server"
 version = "0.1.0"
 dependencies = [
+ "sealantern-core",
  "tracing",
 ]
 

--- a/crates/core/src/process/terminal.rs
+++ b/crates/core/src/process/terminal.rs
@@ -45,6 +45,8 @@ pub struct Terminal {
 
 impl Terminal {
     /// 根据用于启动守护进程的请求，从守护进程转移已配置的流。
+    ///
+    /// 此方法仅从请求推导输入策略，其余流转移统一委托给 [`Self::from_daemon_with_input`]。
     pub fn from_daemon(daemon: &mut Daemon, request: &CommandBuildRequest<'_>) -> Self {
         Self::from_daemon_with_input(
             daemon,

--- a/crates/core/src/process/terminal.rs
+++ b/crates/core/src/process/terminal.rs
@@ -46,11 +46,19 @@ pub struct Terminal {
 impl Terminal {
     /// 根据用于启动守护进程的请求，从守护进程转移已配置的流。
     pub fn from_daemon(daemon: &mut Daemon, request: &CommandBuildRequest<'_>) -> Self {
+        Self::from_daemon_with_input(
+            daemon,
+            matches!(request.console_input_policy(), ConsoleInputPolicy::Enabled),
+        )
+    }
+
+    /// 从守护进程转移标准流，并由宿主显式声明是否保留控制台输入。
+    ///
+    /// 适用于已经在 core 外部构建进程命令、但仍希望复用守护进程和终端所有权模型的宿主。
+    pub fn from_daemon_with_input(daemon: &mut Daemon, accepts_input: bool) -> Self {
         let stdin = daemon.take_stdin();
         Self {
-            stdin: matches!(request.console_input_policy(), ConsoleInputPolicy::Enabled)
-                .then_some(stdin)
-                .flatten(),
+            stdin: accepts_input.then_some(stdin).flatten(),
             stdout: daemon.take_stdout(),
             stderr: daemon.take_stderr(),
         }
@@ -219,12 +227,11 @@ mod tests {
     }
 
     #[test]
-    fn writes_and_flushes_a_command_line_to_daemon_input() {
+    fn host_selected_console_input_writes_and_flushes_a_command_line() {
         let mut command = command_reader_command();
         command.stdin(Stdio::piped()).stdout(Stdio::piped());
         let mut daemon = Daemon::spawn(&mut command).expect("spawn test process");
-        let request = request(CommandBuildMode::DirectJar);
-        let mut terminal = Terminal::from_daemon(&mut daemon, &request);
+        let mut terminal = Terminal::from_daemon_with_input(&mut daemon, true);
 
         terminal
             .write_line("say hello")

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,4 +8,5 @@ license = "GPL-3.0-only"
 path = "src/lib.rs"
 
 [dependencies]
+sealantern-core = { path = "../crates/core" }
 tracing = "0.1"

--- a/server/src/rpc/service/mod.rs
+++ b/server/src/rpc/service/mod.rs
@@ -2,6 +2,10 @@
 
 use std::fmt::Display;
 
+mod runtime;
+
+pub use runtime::ServerRuntime;
+
 /// 由宿主实现的运行中实例控制台写入能力。
 ///
 /// 此 trait 保持应用服务与 Tauri、HTTP 或插件运行时的具体实现解耦。

--- a/server/src/rpc/service/runtime.rs
+++ b/server/src/rpc/service/runtime.rs
@@ -16,15 +16,33 @@ pub struct ServerRuntime {
 }
 
 impl ServerRuntime {
-    /// 启动服务器进程，并为控制台和日志消费者保留标准流。
+    /// 使用调用方配置的标准流启动服务器进程。
+    ///
+    /// 调用方可以按托管场景选择 pipe、inherit、null 或文件重定向。未配置为 pipe 的流
+    /// 不会出现在此运行时的终端接口中。
     pub fn spawn(command: &mut Command, accepts_console_input: bool) -> io::Result<Self> {
+        let daemon = Daemon::spawn(command)?;
+        Ok(Self::from_daemon(daemon, accepts_console_input))
+    }
+
+    /// 使用 piped 标准流启动服务器进程。
+    ///
+    /// 适用于宿主需要发送控制台命令并将 stdout/stderr 交给日志读取器的默认场景。
+    pub fn spawn_with_piped_stdio(
+        command: &mut Command,
+        accepts_console_input: bool,
+    ) -> io::Result<Self> {
         command.stdin(Stdio::piped());
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
 
-        let mut daemon = Daemon::spawn(command)?;
+        Self::spawn(command, accepts_console_input)
+    }
+
+    /// 从已启动的 core 守护进程接管服务器运行时。
+    pub fn from_daemon(mut daemon: Daemon, accepts_console_input: bool) -> Self {
         let terminal = Terminal::from_daemon_with_input(&mut daemon, accepts_console_input);
-        Ok(Self { daemon, terminal })
+        Self { daemon, terminal }
     }
 
     /// 返回操作系统进程标识符。
@@ -86,7 +104,8 @@ mod tests {
     #[test]
     fn takes_server_output_for_a_host_reader() {
         let mut command = command_reader();
-        let mut runtime = ServerRuntime::spawn(&mut command, true).expect("spawn server runtime");
+        let mut runtime = ServerRuntime::spawn_with_piped_stdio(&mut command, true)
+            .expect("spawn server runtime");
 
         runtime
             .send_console_command("say hello")
@@ -99,5 +118,24 @@ mod tests {
 
         assert!(runtime.wait().expect("wait for server process").success());
         assert!(text.contains("say hello"));
+    }
+
+    #[test]
+    fn preserves_caller_stdio_configuration() {
+        let mut command = Command::new(if cfg!(windows) { "cmd" } else { "sh" });
+        if cfg!(windows) {
+            command.args(["/C", "exit 0"]);
+        } else {
+            command.args(["-c", "exit 0"]);
+        }
+
+        let mut runtime = ServerRuntime::spawn(&mut command, true).expect("spawn server runtime");
+
+        assert!(runtime.take_output(TerminalStream::Stdout).is_none());
+        assert!(matches!(
+            runtime.send_console_command("stop"),
+            Err(TerminalWriteError::InputUnavailable)
+        ));
+        assert!(runtime.wait().expect("wait for server process").success());
     }
 }

--- a/server/src/rpc/service/runtime.rs
+++ b/server/src/rpc/service/runtime.rs
@@ -1,0 +1,103 @@
+use std::io;
+use std::process::{Command, ExitStatus, Stdio};
+use std::time::Duration;
+
+use sealantern_core::process::{
+    Daemon, DaemonTerminationError, Terminal, TerminalOutput, TerminalStream, TerminalWriteError,
+};
+
+/// 一个拥有服务器子进程及其终端流的运行时服务。
+///
+/// 该服务不依赖 Tauri、HTTP 或事件传输。宿主负责构建命令、持久化配置和消费输出，
+/// 服务只保证进程和终端流以 core 定义的所有权模型协作。
+pub struct ServerRuntime {
+    daemon: Daemon,
+    terminal: Terminal,
+}
+
+impl ServerRuntime {
+    /// 启动服务器进程，并为控制台和日志消费者保留标准流。
+    pub fn spawn(command: &mut Command, accepts_console_input: bool) -> io::Result<Self> {
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let mut daemon = Daemon::spawn(command)?;
+        let terminal = Terminal::from_daemon_with_input(&mut daemon, accepts_console_input);
+        Ok(Self { daemon, terminal })
+    }
+
+    /// 返回操作系统进程标识符。
+    pub fn id(&self) -> u32 {
+        self.daemon.id()
+    }
+
+    /// 非阻塞地查询服务器是否已退出。
+    pub fn poll(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.daemon.poll()
+    }
+
+    /// 等待服务器进程退出。
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.daemon.wait()
+    }
+
+    /// 将一行命令写入服务器控制台。
+    pub fn send_console_command(&mut self, command: &str) -> Result<(), TerminalWriteError> {
+        self.terminal.write_line(command)
+    }
+
+    /// 将一个输出流交给宿主的日志读取器。
+    pub fn take_output(&mut self, stream: TerminalStream) -> Option<TerminalOutput> {
+        self.terminal.take_output(stream)
+    }
+
+    /// 使用默认的有界宽限期终止服务器进程树。
+    pub fn terminate_tree(&mut self) -> Result<(), DaemonTerminationError> {
+        self.daemon.terminate_tree()
+    }
+
+    /// 立即终止服务器进程树，供确认后的强制停止操作使用。
+    pub fn force_terminate_tree(&mut self) -> Result<(), DaemonTerminationError> {
+        self.daemon.terminate_tree_with_timeout(Duration::ZERO)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use super::*;
+
+    #[cfg(unix)]
+    fn command_reader() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "read line; printf '%s' \"$line\""]);
+        command
+    }
+
+    #[cfg(windows)]
+    fn command_reader() -> Command {
+        let mut command = Command::new("cmd");
+        command.args(["/V:ON", "/C", "set /p line=& echo !line!"]);
+        command
+    }
+
+    #[test]
+    fn takes_server_output_for_a_host_reader() {
+        let mut command = command_reader();
+        let mut runtime = ServerRuntime::spawn(&mut command, true).expect("spawn server runtime");
+
+        runtime
+            .send_console_command("say hello")
+            .expect("write console command");
+        let mut output = runtime
+            .take_output(TerminalStream::Stdout)
+            .expect("stdout should be available");
+        let mut text = String::new();
+        output.read_to_string(&mut text).expect("read stdout");
+
+        assert!(runtime.wait().expect("wait for server process").success());
+        assert!(text.contains("say hello"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a host-selectable terminal input constructor to sealantern-core
- compose core Daemon and Terminal into server::rpc::service::ServerRuntime
- keep src-tauri unchanged while exposing process lifecycle and output ownership for future adapters

## Validation
- cargo fmt -p sealantern-core -p sealantern-server -- --check
- cargo test -p sealantern-core --lib
- cargo test -p sealantern-server
- cargo clippy -p sealantern-core --lib -- -D warnings
- cargo clippy -p sealantern-server --all-targets -- -D warnings

## Summary by Sourcery

构建一个可复用的服务器运行时，它负责核心守护进程和终端流的所有权，同时允许宿主控制控制台输入的使用方式。

新功能：
- 引入一个可由宿主选择的终端构造器，可以在核心命令构建器之外复用核心守护进程和终端所有权。
- 添加一个 `ServerRuntime` 类型，用于封装服务器进程的启动、生命周期管理、控制台命令发送以及输出流所有权。

增强：
- 将 `server` crate 接线依赖到 `sealantern-core`，以共享进程和终端所有权模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Compose a reusable server runtime that owns the core daemon process and terminal streams, while allowing hosts to control console input usage.

New Features:
- Introduce a host-selectable terminal constructor that can reuse core daemon and terminal ownership outside the core command builder.
- Add a ServerRuntime type that encapsulates spawning, lifecycle management, console command sending, and output stream ownership for server processes.

Enhancements:
- Wire the server crate to depend on sealantern-core to share the process and terminal ownership model.

</details>