### PR TITLE
feat(infra): add coordinated persistence primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6022,6 +6022,7 @@ dependencies = [
  "cap-std",
  "futures",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -15,6 +15,7 @@ blocking = ["reqwest/blocking"]
 atomicwrites = "0.4"
 cap-std = "4"
 reqwest = { version = "0.12", features = ["json", "stream"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 tracing = "0.1"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "rt-multi-thread", "macros", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -5,6 +5,26 @@
 
 use std::fmt::Display;
 
+// ── 持久化层 ──
+
+/// 持久化基础设施模块的 tracing 目标。
+pub const PERSISTENCE_TARGET: &str = "sealantern.infra.persistence";
+
+/// Event: 持久化操作失败。
+pub const EVENT_PERSISTENCE_OPERATION_FAILED: &str = "persistence_operation_failed";
+
+/// 记录持久化操作失败，不记录 SQL 文本或参数值。
+pub fn persistence_operation_failed(operation: &str, path: &std::path::Path, error: &dyn Display) {
+    tracing::error!(
+        target: PERSISTENCE_TARGET,
+        event_name = EVENT_PERSISTENCE_OPERATION_FAILED,
+        operation,
+        path = %path.display(),
+        error = %error,
+        "persistence operation failed"
+    );
+}
+
 // -- 平台层 --
 
 /// 平台基础设施模块的 tracing 目标。

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -200,27 +200,39 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         f(&mut self.data);
     }
 
+    /// 在单个文件锁内加载、更新并持久化配置。
+    ///
+    /// 多个任务可能修改同一配置文件时，应使用此方法，而不是分别调用
+    /// `load`、`update` 和 `save`，以避免基于过期快照覆盖其他修改。
+    pub async fn update_persisted(
+        path: impl Into<PathBuf>,
+        default: T,
+        auto_backup: bool,
+        update: impl FnOnce(&mut T),
+    ) -> Result<T, FsError> {
+        let path = path.into();
+        let format = ConfigFormat::from_extension(&path)?;
+        let _guard = lock_config(&path).await?;
+        let mut data = load_data_or_default(&path, format, default).await?;
+
+        update(&mut data);
+        if auto_backup && path.exists() {
+            backup_path(&path).await?;
+        }
+        let content = format.serialize(&data).map_err(|error| {
+            FsError::serialization("config", "encode", &path, error.to_string())
+        })?;
+        write_atomic(&path, content.as_bytes()).await?;
+        Ok(data)
+    }
+
     pub async fn backup(&self) -> Result<PathBuf, FsError> {
         let _guard = lock_config(&self.path).await?;
         self.backup_unlocked().await
     }
 
     async fn backup_unlocked(&self) -> Result<PathBuf, FsError> {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis();
-        let file_name = self
-            .path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("config");
-        let backup_name = format!("{}.bak-{}", file_name, timestamp);
-        let backup_path = self.path.with_file_name(&backup_name);
-        tokio::fs::copy(&self.path, &backup_path)
-            .await
-            .map_err(|e| FsError::io("backup config", &self.path, e))?;
-        Ok(backup_path)
+        backup_path(&self.path).await
     }
 }
 
@@ -229,6 +241,39 @@ async fn lock_config(path: &Path) -> Result<tokio::sync::OwnedMutexGuard<()>, Fs
         observability::persistence_operation_failed("coordinate config access", path, &error);
         FsError::task("coordinate config access", error.to_string())
     })
+}
+
+async fn load_data_or_default<T: Serialize + DeserializeOwned>(
+    path: &Path,
+    format: ConfigFormat,
+    default: T,
+) -> Result<T, FsError> {
+    if !path.exists() {
+        return Ok(default);
+    }
+    let content = read_limited(path, CONFIG_READ_LIMIT).await?;
+    let text = String::from_utf8(content).map_err(|error| {
+        FsError::serialization("config", "decode UTF-8", path, error.to_string())
+    })?;
+    format
+        .deserialize(&text)
+        .map_err(|error| FsError::serialization("config", "decode", path, error.to_string()))
+}
+
+async fn backup_path(path: &Path) -> Result<PathBuf, FsError> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config");
+    let backup_path = path.with_file_name(format!("{file_name}.bak-{timestamp}"));
+    tokio::fs::copy(path, &backup_path)
+        .await
+        .map_err(|error| FsError::io("backup config", path, error))?;
+    Ok(backup_path)
 }
 
 impl<T: Serialize + DeserializeOwned + Default> ConfigFile<T> {
@@ -409,6 +454,37 @@ mod tests {
 
         cfg.update(|c| c.port = 8888);
         assert_eq!(cfg.get().port, 8888);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn update_persisted_keeps_disjoint_concurrent_changes() {
+        let dir = test_dir("update_persisted");
+        let path = dir.join("settings.json");
+        ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
+
+        let first_path = path.clone();
+        let first = tokio::spawn(async move {
+            ConfigFile::update_persisted(first_path, TestConfig::default(), false, |config| {
+                config.port = 30000;
+            })
+            .await
+        });
+        let second_path = path.clone();
+        let second = tokio::spawn(async move {
+            ConfigFile::update_persisted(second_path, TestConfig::default(), false, |config| {
+                config.enabled = false;
+            })
+            .await
+        });
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+
+        let saved = ConfigFile::<TestConfig>::load(&path).await.unwrap();
+        assert_eq!(saved.get().port, 30000);
+        assert!(!saved.get().enabled);
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::fs::{ensure_parent, read_limited, write_atomic, DataLimit, FsError};
+use crate::fs::{ensure_parent, read_limited, write_atomic, DataLimit, FileLock, FsError};
 use crate::observability;
 
 use super::process_lock_registry;
@@ -236,10 +236,31 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     }
 }
 
-async fn lock_config(path: &Path) -> Result<tokio::sync::OwnedMutexGuard<()>, FsError> {
-    process_lock_registry().lock(path).await.map_err(|error| {
+struct ConfigLockGuard {
+    _file_lock: FileLock,
+    _process_guard: tokio::sync::OwnedRwLockWriteGuard<()>,
+}
+
+async fn lock_config(path: &Path) -> Result<ConfigLockGuard, FsError> {
+    let resource = process_lock_registry().resource(path).map_err(|error| {
         observability::persistence_operation_failed("coordinate config access", path, &error);
         FsError::task("coordinate config access", error.to_string())
+    })?;
+    let process_guard = resource.write().await;
+    let lock_path = path.to_path_buf();
+    let file_lock = tokio::task::spawn_blocking(move || FileLock::try_acquire(&lock_path))
+        .await
+        .map_err(|error| {
+            let error = FsError::task("acquire config file lock", error.to_string());
+            observability::persistence_operation_failed("acquire config file lock", path, &error);
+            error
+        })?
+        .inspect_err(|error| {
+            observability::persistence_operation_failed("acquire config file lock", path, error);
+        })?;
+    Ok(ConfigLockGuard {
+        _file_lock: file_lock,
+        _process_guard: process_guard,
     })
 }
 
@@ -269,7 +290,8 @@ async fn backup_path(path: &Path) -> Result<PathBuf, FsError> {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("config");
-    let backup_path = path.with_file_name(format!("{file_name}.bak-{timestamp}"));
+    let backup_path =
+        path.with_file_name(format!("{file_name}.bak-{timestamp}-{}", uuid::Uuid::new_v4()));
     tokio::fs::copy(path, &backup_path)
         .await
         .map_err(|error| FsError::io("backup config", path, error))?;
@@ -441,6 +463,34 @@ mod tests {
         std::fs::copy(&backup_path, &path).unwrap();
         let restored = ConfigFile::<TestConfig>::load(&path).await.unwrap();
         assert_eq!(restored.get().name, "before");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn backup_names_are_unique_within_the_same_millisecond() {
+        let dir = test_dir("backup_unique");
+        let path = dir.join("settings.json");
+        let config = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default())
+            .await
+            .unwrap();
+
+        let first = config.backup().await.unwrap();
+        let second = config.backup().await.unwrap();
+        assert_ne!(first, second);
+        assert!(first.exists());
+        assert!(second.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn returns_an_error_when_the_file_lock_is_already_held() {
+        let dir = test_dir("cross_process_lock");
+        let path = dir.join("settings.json");
+        let file_lock = FileLock::try_acquire(&path).unwrap();
+
+        let result = ConfigFile::<TestConfig>::load_or_create(&path, TestConfig::default()).await;
+        assert!(matches!(result, Err(FsError::AlreadyLocked(_))));
+        drop(file_lock);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -4,6 +4,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::fs::{ensure_parent, read_limited, write_atomic, DataLimit, FsError};
+use crate::observability;
+
+use super::process_lock_registry;
 
 /// 配置文件读取上限：最大 10 MiB。
 const CONFIG_READ_LIMIT: DataLimit = DataLimit::new(10 * 1024 * 1024);
@@ -120,6 +123,7 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     pub async fn load_or_create(path: impl Into<PathBuf>, default: T) -> Result<Self, FsError> {
         let path = path.into();
         let format = ConfigFormat::from_extension(&path)?;
+        let _guard = lock_config(&path).await?;
 
         let data = if path.exists() {
             let content = read_limited(&path, CONFIG_READ_LIMIT).await?;
@@ -144,6 +148,7 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     pub async fn load(path: impl Into<PathBuf>) -> Result<Self, FsError> {
         let path = path.into();
         let format = ConfigFormat::from_extension(&path)?;
+        let _guard = lock_config(&path).await?;
         let content = read_limited(&path, CONFIG_READ_LIMIT).await?;
         let text = String::from_utf8(content)
             .map_err(|e| FsError::serialization("config", "decode UTF-8", &path, e.to_string()))?;
@@ -158,8 +163,9 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     /// 当 `auto_backup` 为 true 时，在写入新内容之前备份先前版本，
     /// 以便在新文件损坏时能够恢复。
     pub async fn save(&self, auto_backup: bool) -> Result<(), FsError> {
+        let _guard = lock_config(&self.path).await?;
         if auto_backup && self.path.exists() {
-            self.backup().await?;
+            self.backup_unlocked().await?;
         }
         let content = self
             .format
@@ -169,6 +175,7 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     }
 
     pub async fn reload(&mut self) -> Result<(), FsError> {
+        let _guard = lock_config(&self.path).await?;
         let content = read_limited(&self.path, CONFIG_READ_LIMIT).await?;
         let text = String::from_utf8(content).map_err(|e| {
             FsError::serialization("config", "decode UTF-8", &self.path, e.to_string())
@@ -194,6 +201,11 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     }
 
     pub async fn backup(&self) -> Result<PathBuf, FsError> {
+        let _guard = lock_config(&self.path).await?;
+        self.backup_unlocked().await
+    }
+
+    async fn backup_unlocked(&self) -> Result<PathBuf, FsError> {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -210,6 +222,13 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
             .map_err(|e| FsError::io("backup config", &self.path, e))?;
         Ok(backup_path)
     }
+}
+
+async fn lock_config(path: &Path) -> Result<tokio::sync::OwnedMutexGuard<()>, FsError> {
+    process_lock_registry().lock(path).await.map_err(|error| {
+        observability::persistence_operation_failed("coordinate config access", path, &error);
+        FsError::task("coordinate config access", error.to_string())
+    })
 }
 
 impl<T: Serialize + DeserializeOwned + Default> ConfigFile<T> {

--- a/crates/infra/src/persistence/coordination.rs
+++ b/crates/infra/src/persistence/coordination.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use super::PersistenceError;
+
+/// 按资源路径协调同一进程内的异步持久化操作。
+///
+/// 此协调器只处理进程内竞争。SQLite 的 WAL 和 busy timeout
+/// 仍负责与其他进程的协调。
+#[derive(Default)]
+pub struct ProcessLockRegistry {
+    locks: Mutex<HashMap<PathBuf, Weak<AsyncMutex<()>>>>,
+}
+
+impl ProcessLockRegistry {
+    /// 获取资源的独占异步锁。
+    pub async fn lock(
+        &self,
+        resource: impl AsRef<Path>,
+    ) -> Result<OwnedMutexGuard<()>, PersistenceError> {
+        let resource = resource_identity(resource.as_ref())?;
+        let lock = {
+            let mut locks = self
+                .locks
+                .lock()
+                .map_err(|error| PersistenceError::Coordination {
+                    resource: resource.clone(),
+                    message: error.to_string(),
+                })?;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            match locks.get(&resource).and_then(Weak::upgrade) {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(AsyncMutex::new(()));
+                    locks.insert(resource, Arc::downgrade(&lock));
+                    lock
+                }
+            }
+        };
+        Ok(lock.lock_owned().await)
+    }
+}
+
+/// 返回进程级的资源协调器。
+pub fn process_lock_registry() -> &'static ProcessLockRegistry {
+    static REGISTRY: OnceLock<ProcessLockRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(ProcessLockRegistry::default)
+}
+
+fn resource_identity(path: &Path) -> Result<PathBuf, PersistenceError> {
+    if path.as_os_str().is_empty() {
+        return Err(PersistenceError::Coordination {
+            resource: path.to_path_buf(),
+            message: "resource path is empty".to_owned(),
+        });
+    }
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|current_dir| current_dir.join(path))
+            .map_err(|error| PersistenceError::Coordination {
+                resource: path.to_path_buf(),
+                message: error.to_string(),
+            })?
+    };
+    if let Ok(canonical) = std::fs::canonicalize(&absolute) {
+        return Ok(canonical);
+    }
+    if let (Some(parent), Some(name)) = (absolute.parent(), absolute.file_name()) {
+        if let Ok(canonical_parent) = std::fs::canonicalize(parent) {
+            return Ok(canonical_parent.join(name));
+        }
+    }
+    Ok(absolute)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn serializes_access_to_the_same_resource() {
+        let registry = Arc::new(ProcessLockRegistry::default());
+        let first = registry.lock("same-resource").await.unwrap();
+        let second_registry = Arc::clone(&registry);
+        let waiting = tokio::spawn(async move { second_registry.lock("same-resource").await });
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!waiting.is_finished());
+        drop(first);
+        assert!(waiting.await.unwrap().is_ok());
+    }
+}

--- a/crates/infra/src/persistence/coordination.rs
+++ b/crates/infra/src/persistence/coordination.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 
-use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock as AsyncRwLock};
 
 use super::PersistenceError;
 
@@ -12,15 +12,33 @@ use super::PersistenceError;
 /// 仍负责与其他进程的协调。
 #[derive(Default)]
 pub struct ProcessLockRegistry {
-    locks: Mutex<HashMap<PathBuf, Weak<AsyncMutex<()>>>>,
+    locks: Mutex<HashMap<PathBuf, Weak<AsyncRwLock<()>>>>,
+}
+
+/// 已绑定到单个资源的进程内读写协调器。
+#[derive(Clone)]
+pub struct ProcessResourceLock {
+    lock: Arc<AsyncRwLock<()>>,
+}
+
+impl ProcessResourceLock {
+    /// 获取资源的共享读取锁。
+    pub async fn read(&self) -> OwnedRwLockReadGuard<()> {
+        Arc::clone(&self.lock).read_owned().await
+    }
+
+    /// 获取资源的独占写入锁。
+    pub async fn write(&self) -> OwnedRwLockWriteGuard<()> {
+        Arc::clone(&self.lock).write_owned().await
+    }
 }
 
 impl ProcessLockRegistry {
     /// 获取资源的独占异步锁。
-    pub async fn lock(
+    pub fn resource(
         &self,
         resource: impl AsRef<Path>,
-    ) -> Result<OwnedMutexGuard<()>, PersistenceError> {
+    ) -> Result<ProcessResourceLock, PersistenceError> {
         let resource = resource_identity(resource.as_ref())?;
         let lock = {
             let mut locks = self
@@ -34,13 +52,21 @@ impl ProcessLockRegistry {
             match locks.get(&resource).and_then(Weak::upgrade) {
                 Some(lock) => lock,
                 None => {
-                    let lock = Arc::new(AsyncMutex::new(()));
+                    let lock = Arc::new(AsyncRwLock::new(()));
                     locks.insert(resource, Arc::downgrade(&lock));
                     lock
                 }
             }
         };
-        Ok(lock.lock_owned().await)
+        Ok(ProcessResourceLock { lock })
+    }
+
+    /// 获取资源的独占写入锁。
+    pub async fn lock(
+        &self,
+        resource: impl AsRef<Path>,
+    ) -> Result<OwnedRwLockWriteGuard<()>, PersistenceError> {
+        Ok(self.resource(resource)?.write().await)
     }
 }
 
@@ -95,5 +121,17 @@ mod tests {
         assert!(!waiting.is_finished());
         drop(first);
         assert!(waiting.await.unwrap().is_ok());
+    }
+
+    #[tokio::test]
+    async fn permits_concurrent_reads_for_the_same_resource() {
+        let registry = ProcessLockRegistry::default();
+        let resource = registry.resource("same-resource").unwrap();
+        let first = resource.read().await;
+        let second =
+            tokio::time::timeout(std::time::Duration::from_millis(20), resource.read()).await;
+
+        assert!(second.is_ok());
+        drop(first);
     }
 }

--- a/crates/infra/src/persistence/error.rs
+++ b/crates/infra/src/persistence/error.rs
@@ -24,6 +24,8 @@ pub enum PersistenceError {
     Coordination { resource: PathBuf, message: String },
     /// 迁移清单不满足版本顺序约束。
     InvalidMigration { version: i64, reason: &'static str },
+    /// 已应用的迁移与当前迁移清单不一致。
+    MigrationIntegrity { version: i64, message: String },
 }
 
 impl fmt::Display for PersistenceError {
@@ -55,6 +57,9 @@ impl fmt::Display for PersistenceError {
             }
             Self::InvalidMigration { version, reason } => {
                 write!(formatter, "migration {version} is invalid: {reason}")
+            }
+            Self::MigrationIntegrity { version, message } => {
+                write!(formatter, "migration {version} integrity check failed: {message}")
             }
         }
     }

--- a/crates/infra/src/persistence/error.rs
+++ b/crates/infra/src/persistence/error.rs
@@ -13,12 +13,12 @@ pub enum PersistenceError {
     Sqlite {
         operation: &'static str,
         path: PathBuf,
-        message: String,
+        source: rusqlite::Error,
     },
     /// 阻塞数据库任务未能完成。
     Task {
         operation: &'static str,
-        message: String,
+        source: tokio::task::JoinError,
     },
     /// 进程内协调器状态异常。
     Coordination { resource: PathBuf, message: String },
@@ -38,15 +38,15 @@ impl fmt::Display for PersistenceError {
                     path.display()
                 )
             }
-            Self::Sqlite { operation, path, message } => {
+            Self::Sqlite { operation, path, source } => {
                 write!(
                     formatter,
-                    "SQLite operation '{operation}' failed for '{}': {message}",
+                    "SQLite operation '{operation}' failed for '{}': {source}",
                     path.display()
                 )
             }
-            Self::Task { operation, message } => {
-                write!(formatter, "database task '{operation}' failed: {message}")
+            Self::Task { operation, source } => {
+                write!(formatter, "database task '{operation}' failed: {source}")
             }
             Self::Coordination { resource, message } => {
                 write!(
@@ -69,6 +69,8 @@ impl std::error::Error for PersistenceError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::CreateParent { source, .. } => Some(source),
+            Self::Sqlite { source, .. } => Some(source),
+            Self::Task { source, .. } => Some(source),
             _ => None,
         }
     }

--- a/crates/infra/src/persistence/error.rs
+++ b/crates/infra/src/persistence/error.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+use std::path::PathBuf;
+
+/// 持久化基础设施操作返回的错误。
+#[derive(Debug)]
+pub enum PersistenceError {
+    /// 数据库文件的父目录无法创建。
+    CreateParent {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// SQLite 操作失败。
+    Sqlite {
+        operation: &'static str,
+        path: PathBuf,
+        message: String,
+    },
+    /// 阻塞数据库任务未能完成。
+    Task {
+        operation: &'static str,
+        message: String,
+    },
+    /// 进程内协调器状态异常。
+    Coordination { resource: PathBuf, message: String },
+    /// 迁移清单不满足版本顺序约束。
+    InvalidMigration { version: i64, reason: &'static str },
+}
+
+impl fmt::Display for PersistenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CreateParent { path, source } => {
+                write!(
+                    formatter,
+                    "failed to create database parent for '{}': {source}",
+                    path.display()
+                )
+            }
+            Self::Sqlite { operation, path, message } => {
+                write!(
+                    formatter,
+                    "SQLite operation '{operation}' failed for '{}': {message}",
+                    path.display()
+                )
+            }
+            Self::Task { operation, message } => {
+                write!(formatter, "database task '{operation}' failed: {message}")
+            }
+            Self::Coordination { resource, message } => {
+                write!(
+                    formatter,
+                    "failed to coordinate access to '{}': {message}",
+                    resource.display()
+                )
+            }
+            Self::InvalidMigration { version, reason } => {
+                write!(formatter, "migration {version} is invalid: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PersistenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CreateParent { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/crates/infra/src/persistence/mod.rs
+++ b/crates/infra/src/persistence/mod.rs
@@ -1,3 +1,9 @@
 pub mod config;
+mod coordination;
+mod error;
+mod sqlite;
 
 pub use config::{ConfigError, ConfigFile, ConfigFormat};
+pub use coordination::{process_lock_registry, ProcessLockRegistry};
+pub use error::PersistenceError;
+pub use sqlite::{Migration, SqlValue, SqliteDatabase, SqliteOptions};

--- a/crates/infra/src/persistence/mod.rs
+++ b/crates/infra/src/persistence/mod.rs
@@ -4,6 +4,6 @@ mod error;
 mod sqlite;
 
 pub use config::{ConfigError, ConfigFile, ConfigFormat};
-pub use coordination::{process_lock_registry, ProcessLockRegistry};
+pub use coordination::{process_lock_registry, ProcessLockRegistry, ProcessResourceLock};
 pub use error::PersistenceError;
-pub use sqlite::{Migration, SqlValue, SqliteDatabase, SqliteOptions};
+pub use sqlite::{Migration, SqlValue, SqliteDatabase, SqliteOptions, SqliteSynchronousMode};

--- a/crates/infra/src/persistence/sqlite.rs
+++ b/crates/infra/src/persistence/sqlite.rs
@@ -6,7 +6,7 @@ use rusqlite::{Connection, OptionalExtension, Row, Transaction, TransactionBehav
 
 use crate::observability;
 
-use super::{process_lock_registry, PersistenceError};
+use super::{process_lock_registry, PersistenceError, ProcessResourceLock};
 
 /// 可安全传入 SQLite 参数绑定的动态值。
 pub use rusqlite::types::Value as SqlValue;
@@ -20,6 +20,28 @@ pub struct SqliteOptions {
     pub foreign_keys: bool,
     /// 是否使用 WAL 日志模式以允许并发读。
     pub wal: bool,
+    /// 提交事务时的崩溃耐久性策略。
+    pub synchronous: SqliteSynchronousMode,
+}
+
+/// SQLite 的同步写入策略。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqliteSynchronousMode {
+    Off,
+    Normal,
+    Full,
+    Extra,
+}
+
+impl SqliteSynchronousMode {
+    const fn as_pragma(self) -> &'static str {
+        match self {
+            Self::Off => "OFF",
+            Self::Normal => "NORMAL",
+            Self::Full => "FULL",
+            Self::Extra => "EXTRA",
+        }
+    }
 }
 
 impl Default for SqliteOptions {
@@ -28,6 +50,7 @@ impl Default for SqliteOptions {
             busy_timeout: Duration::from_secs(5),
             foreign_keys: true,
             wal: true,
+            synchronous: SqliteSynchronousMode::Full,
         }
     }
 }
@@ -50,6 +73,7 @@ pub struct Migration {
 #[derive(Clone)]
 pub struct SqliteDatabase {
     path: PathBuf,
+    coordination: ProcessResourceLock,
     connection: Arc<Mutex<Connection>>,
 }
 
@@ -67,16 +91,18 @@ impl SqliteDatabase {
         let path = path.into();
         let operation_path = path.clone();
         let result = async {
-            let _guard = lock_database(&path).await?;
+            let coordination = process_lock_registry().resource(&path)?;
+            let _guard = coordination.write().await;
             let opened = tokio::task::spawn_blocking(move || open_connection(&path, &options))
                 .await
                 .map_err(|error| PersistenceError::Task {
                     operation: "open SQLite database",
-                    message: error.to_string(),
+                    source: error,
                 })?;
             let connection = opened?;
             Ok(Self {
                 path: operation_path.clone(),
+                coordination,
                 connection: Arc::new(Mutex::new(connection)),
             })
         }
@@ -101,7 +127,7 @@ impl SqliteDatabase {
     {
         let sql = sql.into();
         let result = self
-            .with_connection("execute", move |connection| {
+            .with_mut_connection("execute", move |connection| {
                 connection.execute(&sql, rusqlite::params_from_iter(params))
             })
             .await;
@@ -113,7 +139,7 @@ impl SqliteDatabase {
     pub async fn execute_batch(&self, sql: impl Into<String>) -> Result<(), PersistenceError> {
         let sql = sql.into();
         let result = self
-            .with_connection("execute batch", move |connection| connection.execute_batch(&sql))
+            .with_mut_connection("execute batch", move |connection| connection.execute_batch(&sql))
             .await;
         report_operation_error("execute batch", &self.path, &result);
         result
@@ -241,7 +267,7 @@ impl SqliteDatabase {
         F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
     {
         let path = self.path.clone();
-        let process_guard = lock_database(&path).await?;
+        let process_guard = self.coordination.read().await;
         let connection = Arc::clone(&self.connection);
         let result = tokio::task::spawn_blocking(move || {
             let _process_guard = process_guard;
@@ -254,11 +280,11 @@ impl SqliteDatabase {
             work(&connection).map_err(|error| PersistenceError::Sqlite {
                 operation,
                 path,
-                message: error.to_string(),
+                source: error,
             })
         })
         .await
-        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
+        .map_err(|error| PersistenceError::Task { operation, source: error })?;
         result
     }
 
@@ -272,7 +298,7 @@ impl SqliteDatabase {
         F: FnOnce(&mut Connection) -> rusqlite::Result<T> + Send + 'static,
     {
         let path = self.path.clone();
-        let process_guard = lock_database(&path).await?;
+        let process_guard = self.coordination.write().await;
         let connection = Arc::clone(&self.connection);
         let result = tokio::task::spawn_blocking(move || {
             let _process_guard = process_guard;
@@ -286,17 +312,13 @@ impl SqliteDatabase {
             work(&mut connection).map_err(|error| PersistenceError::Sqlite {
                 operation,
                 path,
-                message: error.to_string(),
+                source: error,
             })
         })
         .await
-        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
+        .map_err(|error| PersistenceError::Task { operation, source: error })?;
         result
     }
-}
-
-async fn lock_database(path: &Path) -> Result<tokio::sync::OwnedMutexGuard<()>, PersistenceError> {
-    process_lock_registry().lock(path).await
 }
 
 fn open_connection(path: &Path, options: &SqliteOptions) -> Result<Connection, PersistenceError> {
@@ -309,21 +331,21 @@ fn open_connection(path: &Path, options: &SqliteOptions) -> Result<Connection, P
     let connection = Connection::open(path).map_err(|error| PersistenceError::Sqlite {
         operation: "open",
         path: path.to_path_buf(),
-        message: error.to_string(),
+        source: error,
     })?;
     connection
         .busy_timeout(options.busy_timeout)
         .map_err(|error| PersistenceError::Sqlite {
             operation: "configure busy timeout",
             path: path.to_path_buf(),
-            message: error.to_string(),
+            source: error,
         })?;
     connection
         .pragma_update(None, "foreign_keys", options.foreign_keys)
         .map_err(|error| PersistenceError::Sqlite {
             operation: "enable foreign keys",
             path: path.to_path_buf(),
-            message: error.to_string(),
+            source: error,
         })?;
     if options.wal {
         connection
@@ -331,16 +353,16 @@ fn open_connection(path: &Path, options: &SqliteOptions) -> Result<Connection, P
             .map_err(|error| PersistenceError::Sqlite {
                 operation: "enable WAL",
                 path: path.to_path_buf(),
-                message: error.to_string(),
-            })?;
-        connection
-            .pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|error| PersistenceError::Sqlite {
-                operation: "configure synchronous mode",
-                path: path.to_path_buf(),
-                message: error.to_string(),
+                source: error,
             })?;
     }
+    connection
+        .pragma_update(None, "synchronous", options.synchronous.as_pragma())
+        .map_err(|error| PersistenceError::Sqlite {
+            operation: "configure synchronous mode",
+            path: path.to_path_buf(),
+            source: error,
+        })?;
     Ok(connection)
 }
 
@@ -356,6 +378,8 @@ fn report_operation_error<T>(
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
     use super::*;
 
     fn database_path(label: &str) -> PathBuf {
@@ -387,6 +411,28 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(names, ["O'Reilly"]);
+        drop(database);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn applies_the_selected_synchronous_mode() {
+        let path = database_path("sqlite-synchronous");
+        let database = SqliteDatabase::open_with_options(
+            &path,
+            SqliteOptions {
+                synchronous: SqliteSynchronousMode::Normal,
+                ..SqliteOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let mode = database
+            .query("PRAGMA synchronous", [], |row| row.get::<_, i64>(0))
+            .await
+            .unwrap();
+        assert_eq!(mode, [1]);
         drop(database);
         std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
     }
@@ -454,7 +500,8 @@ mod tests {
                 Ok(())
             })
             .await;
-        assert!(matches!(result, Err(PersistenceError::Sqlite { .. })));
+        assert!(matches!(&result, Err(PersistenceError::Sqlite { .. })));
+        assert!(result.unwrap_err().source().is_some());
         let count = database
             .query("SELECT COUNT(*) FROM records", vec![], |row| row.get::<_, i64>(0))
             .await

--- a/crates/infra/src/persistence/sqlite.rs
+++ b/crates/infra/src/persistence/sqlite.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use rusqlite::{Connection, Row, Transaction, TransactionBehavior};
+use rusqlite::{Connection, OptionalExtension, Row, Transaction, TransactionBehavior};
 
 use crate::observability;
 
@@ -65,13 +65,17 @@ impl SqliteDatabase {
         options: SqliteOptions,
     ) -> Result<Self, PersistenceError> {
         let path = path.into();
-        let _guard = process_lock_registry().lock(&path).await?;
+        let _guard = lock_database("open", &path).await?;
         let operation_path = path.clone();
         let opened = tokio::task::spawn_blocking(move || open_connection(&path, &options))
             .await
-            .map_err(|error| PersistenceError::Task {
-                operation: "open SQLite database",
-                message: error.to_string(),
+            .map_err(|error| {
+                let error = PersistenceError::Task {
+                    operation: "open SQLite database",
+                    message: error.to_string(),
+                };
+                observability::persistence_operation_failed("open", &operation_path, &error);
+                error
             })?;
         match opened {
             Ok(connection) => Ok(Self {
@@ -165,33 +169,51 @@ impl SqliteDatabase {
             }
         }
 
-        self.with_mut_connection("migrate", move |connection| {
+        let result = self
+            .with_mut_connection("migrate", move |connection| {
             let transaction =
                 connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
             transaction.execute_batch(
                 "CREATE TABLE IF NOT EXISTS _sealantern_schema_migrations (\
                     version INTEGER PRIMARY KEY NOT NULL,\
                     name TEXT NOT NULL,\
+                    checksum TEXT NOT NULL,\
                     applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP\
                  )",
             )?;
             for migration in migrations {
-                let already_applied: bool = transaction.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM _sealantern_schema_migrations WHERE version = ?1)",
+                let checksum = crate::fs::sha256_hex(migration.sql);
+                let applied: Option<(String, String)> = transaction
+                    .query_row(
+                    "SELECT name, checksum FROM _sealantern_schema_migrations WHERE version = ?1",
                     [migration.version],
-                    |row| row.get(0),
-                )?;
-                if !already_applied {
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                    .optional()?;
+                if let Some((applied_name, applied_checksum)) = applied {
+                    if applied_name != migration.name || applied_checksum != checksum {
+                        return Ok(Err(PersistenceError::MigrationIntegrity {
+                            version: migration.version,
+                            message: "applied name or SQL checksum differs from the migration manifest"
+                                .to_owned(),
+                        }));
+                    }
+                } else {
                     transaction.execute_batch(migration.sql)?;
                     transaction.execute(
-                        "INSERT INTO _sealantern_schema_migrations (version, name) VALUES (?1, ?2)",
-                        (migration.version, migration.name),
+                        "INSERT INTO _sealantern_schema_migrations (version, name, checksum) VALUES (?1, ?2, ?3)",
+                        (migration.version, migration.name, checksum),
                     )?;
                 }
             }
-            transaction.commit()
+            transaction.commit()?;
+            Ok(Ok(()))
         })
-        .await
+        .await?;
+        if let Err(error) = &result {
+            observability::persistence_operation_failed("migrate", &self.path, error);
+        }
+        result
     }
 
     async fn with_connection<T, F>(
@@ -204,7 +226,7 @@ impl SqliteDatabase {
         F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
     {
         let path = self.path.clone();
-        let process_guard = process_lock_registry().lock(&path).await?;
+        let process_guard = lock_database(operation, &path).await?;
         let connection = Arc::clone(&self.connection);
         let result = tokio::task::spawn_blocking(move || {
             let _process_guard = process_guard;
@@ -221,7 +243,11 @@ impl SqliteDatabase {
             })
         })
         .await
-        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
+        .map_err(|error| {
+            let error = PersistenceError::Task { operation, message: error.to_string() };
+            observability::persistence_operation_failed(operation, &self.path, &error);
+            error
+        })?;
         report_operation_error(operation, &self.path, &result);
         result
     }
@@ -236,7 +262,7 @@ impl SqliteDatabase {
         F: FnOnce(&mut Connection) -> rusqlite::Result<T> + Send + 'static,
     {
         let path = self.path.clone();
-        let process_guard = process_lock_registry().lock(&path).await?;
+        let process_guard = lock_database(operation, &path).await?;
         let connection = Arc::clone(&self.connection);
         let result = tokio::task::spawn_blocking(move || {
             let _process_guard = process_guard;
@@ -254,10 +280,26 @@ impl SqliteDatabase {
             })
         })
         .await
-        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
+        .map_err(|error| {
+            let error = PersistenceError::Task { operation, message: error.to_string() };
+            observability::persistence_operation_failed(operation, &self.path, &error);
+            error
+        })?;
         report_operation_error(operation, &self.path, &result);
         result
     }
+}
+
+async fn lock_database(
+    operation: &'static str,
+    path: &Path,
+) -> Result<tokio::sync::OwnedMutexGuard<()>, PersistenceError> {
+    process_lock_registry()
+        .lock(path)
+        .await
+        .inspect_err(|error| {
+            observability::persistence_operation_failed(operation, path, error);
+        })
 }
 
 fn open_connection(path: &Path, options: &SqliteOptions) -> Result<Connection, PersistenceError> {
@@ -369,6 +411,31 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(versions, [1]);
+        drop(database);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_migration_manifest_drift() {
+        let path = database_path("sqlite-migration-drift");
+        let database = SqliteDatabase::open(&path).await.unwrap();
+        database
+            .migrate(vec![Migration {
+                version: 1,
+                name: "create records",
+                sql: "CREATE TABLE records (id INTEGER PRIMARY KEY)",
+            }])
+            .await
+            .unwrap();
+
+        let result = database
+            .migrate(vec![Migration {
+                version: 1,
+                name: "create records",
+                sql: "CREATE TABLE records (id INTEGER PRIMARY KEY, name TEXT)",
+            }])
+            .await;
+        assert!(matches!(result, Err(PersistenceError::MigrationIntegrity { version: 1, .. })));
         drop(database);
         std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
     }

--- a/crates/infra/src/persistence/sqlite.rs
+++ b/crates/infra/src/persistence/sqlite.rs
@@ -1,0 +1,444 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rusqlite::{Connection, Row, Transaction, TransactionBehavior};
+
+use crate::observability;
+
+use super::{process_lock_registry, PersistenceError};
+
+/// 可安全传入 SQLite 参数绑定的动态值。
+pub use rusqlite::types::Value as SqlValue;
+
+/// SQLite 连接的底层运行参数。
+#[derive(Debug, Clone)]
+pub struct SqliteOptions {
+    /// 发生跨进程锁竞争时等待的最长时间。
+    pub busy_timeout: Duration,
+    /// 是否为数据库启用外键约束。
+    pub foreign_keys: bool,
+    /// 是否使用 WAL 日志模式以允许并发读。
+    pub wal: bool,
+}
+
+impl Default for SqliteOptions {
+    fn default() -> Self {
+        Self {
+            busy_timeout: Duration::from_secs(5),
+            foreign_keys: true,
+            wal: true,
+        }
+    }
+}
+
+/// 调用方提供的版本化数据库迁移。
+///
+/// `sql` 必须是受信任的静态 SQL；运行时值应使用 `execute` 或
+/// `query` 的参数绑定传递，不能拼接到此处。
+#[derive(Debug, Clone, Copy)]
+pub struct Migration {
+    pub version: i64,
+    pub name: &'static str,
+    pub sql: &'static str,
+}
+
+/// 进程内串行、跨进程可协调的 SQLite 数据库访问接口。
+///
+/// 不承载业务表定义或业务数据类型。上层仅通过参数绑定、行映射闭包、
+/// 事务闭包和迁移清单传入自己的数据模型。
+#[derive(Clone)]
+pub struct SqliteDatabase {
+    path: PathBuf,
+    connection: Arc<Mutex<Connection>>,
+}
+
+impl SqliteDatabase {
+    /// 使用默认选项打开或创建数据库。
+    pub async fn open(path: impl Into<PathBuf>) -> Result<Self, PersistenceError> {
+        Self::open_with_options(path, SqliteOptions::default()).await
+    }
+
+    /// 使用显式选项打开或创建数据库。
+    pub async fn open_with_options(
+        path: impl Into<PathBuf>,
+        options: SqliteOptions,
+    ) -> Result<Self, PersistenceError> {
+        let path = path.into();
+        let _guard = process_lock_registry().lock(&path).await?;
+        let operation_path = path.clone();
+        let opened = tokio::task::spawn_blocking(move || open_connection(&path, &options))
+            .await
+            .map_err(|error| PersistenceError::Task {
+                operation: "open SQLite database",
+                message: error.to_string(),
+            })?;
+        match opened {
+            Ok(connection) => Ok(Self {
+                path: operation_path,
+                connection: Arc::new(Mutex::new(connection)),
+            }),
+            Err(error) => {
+                observability::persistence_operation_failed("open", &operation_path, &error);
+                Err(error)
+            }
+        }
+    }
+
+    /// 返回数据库文件路径。
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// 执行单条使用参数绑定的写入或控制语句。
+    pub async fn execute(
+        &self,
+        sql: impl Into<String>,
+        params: Vec<SqlValue>,
+    ) -> Result<usize, PersistenceError> {
+        let sql = sql.into();
+        self.with_connection("execute", move |connection| {
+            connection.execute(&sql, rusqlite::params_from_iter(params))
+        })
+        .await
+    }
+
+    /// 执行仅由受信任代码构造的多条 SQL 语句。
+    pub async fn execute_batch(&self, sql: impl Into<String>) -> Result<(), PersistenceError> {
+        let sql = sql.into();
+        self.with_connection("execute batch", move |connection| connection.execute_batch(&sql))
+            .await
+    }
+
+    /// 查询记录，并通过调用方提供的闭包映射每一行。
+    pub async fn query<T, F>(
+        &self,
+        sql: impl Into<String>,
+        params: Vec<SqlValue>,
+        mut map_row: F,
+    ) -> Result<Vec<T>, PersistenceError>
+    where
+        T: Send + 'static,
+        F: FnMut(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        let sql = sql.into();
+        self.with_connection("query", move |connection| {
+            let mut statement = connection.prepare(&sql)?;
+            let rows =
+                statement.query_map(rusqlite::params_from_iter(params), |row| map_row(row))?;
+            rows.collect()
+        })
+        .await
+    }
+
+    /// 在 `BEGIN IMMEDIATE` 事务中运行上层定义的写入操作。
+    pub async fn write<T, F>(&self, operation: &'static str, work: F) -> Result<T, PersistenceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Transaction<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        self.with_mut_connection(operation, move |connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let result = work(&transaction)?;
+            transaction.commit()?;
+            Ok(result)
+        })
+        .await
+    }
+
+    /// 以单个原子事务应用未执行过的迁移。
+    pub async fn migrate(&self, mut migrations: Vec<Migration>) -> Result<(), PersistenceError> {
+        migrations.sort_by_key(|migration| migration.version);
+        if let Some(migration) = migrations.iter().find(|migration| migration.version < 0) {
+            return Err(PersistenceError::InvalidMigration {
+                version: migration.version,
+                reason: "migration versions must not be negative",
+            });
+        }
+        for pair in migrations.windows(2) {
+            if pair[0].version == pair[1].version {
+                return Err(PersistenceError::InvalidMigration {
+                    version: pair[0].version,
+                    reason: "migration versions must be unique",
+                });
+            }
+        }
+
+        self.with_mut_connection("migrate", move |connection| {
+            let transaction =
+                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            transaction.execute_batch(
+                "CREATE TABLE IF NOT EXISTS _sealantern_schema_migrations (\
+                    version INTEGER PRIMARY KEY NOT NULL,\
+                    name TEXT NOT NULL,\
+                    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP\
+                 )",
+            )?;
+            for migration in migrations {
+                let already_applied: bool = transaction.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM _sealantern_schema_migrations WHERE version = ?1)",
+                    [migration.version],
+                    |row| row.get(0),
+                )?;
+                if !already_applied {
+                    transaction.execute_batch(migration.sql)?;
+                    transaction.execute(
+                        "INSERT INTO _sealantern_schema_migrations (version, name) VALUES (?1, ?2)",
+                        (migration.version, migration.name),
+                    )?;
+                }
+            }
+            transaction.commit()
+        })
+        .await
+    }
+
+    async fn with_connection<T, F>(
+        &self,
+        operation: &'static str,
+        work: F,
+    ) -> Result<T, PersistenceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
+    {
+        let path = self.path.clone();
+        let process_guard = process_lock_registry().lock(&path).await?;
+        let connection = Arc::clone(&self.connection);
+        let result = tokio::task::spawn_blocking(move || {
+            let _process_guard = process_guard;
+            let connection = connection
+                .lock()
+                .map_err(|error| PersistenceError::Coordination {
+                    resource: path.clone(),
+                    message: error.to_string(),
+                })?;
+            work(&connection).map_err(|error| PersistenceError::Sqlite {
+                operation,
+                path,
+                message: error.to_string(),
+            })
+        })
+        .await
+        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
+        report_operation_error(operation, &self.path, &result);
+        result
+    }
+
+    async fn with_mut_connection<T, F>(
+        &self,
+        operation: &'static str,
+        work: F,
+    ) -> Result<T, PersistenceError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> rusqlite::Result<T> + Send + 'static,
+    {
+        let path = self.path.clone();
+        let process_guard = process_lock_registry().lock(&path).await?;
+        let connection = Arc::clone(&self.connection);
+        let result = tokio::task::spawn_blocking(move || {
+            let _process_guard = process_guard;
+            let mut connection =
+                connection
+                    .lock()
+                    .map_err(|error| PersistenceError::Coordination {
+                        resource: path.clone(),
+                        message: error.to_string(),
+                    })?;
+            work(&mut connection).map_err(|error| PersistenceError::Sqlite {
+                operation,
+                path,
+                message: error.to_string(),
+            })
+        })
+        .await
+        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
+        report_operation_error(operation, &self.path, &result);
+        result
+    }
+}
+
+fn open_connection(path: &Path, options: &SqliteOptions) -> Result<Connection, PersistenceError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| PersistenceError::CreateParent {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let connection = Connection::open(path).map_err(|error| PersistenceError::Sqlite {
+        operation: "open",
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    connection
+        .busy_timeout(options.busy_timeout)
+        .map_err(|error| PersistenceError::Sqlite {
+            operation: "configure busy timeout",
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })?;
+    connection
+        .pragma_update(None, "foreign_keys", options.foreign_keys)
+        .map_err(|error| PersistenceError::Sqlite {
+            operation: "enable foreign keys",
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })?;
+    if options.wal {
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .map_err(|error| PersistenceError::Sqlite {
+                operation: "enable WAL",
+                path: path.to_path_buf(),
+                message: error.to_string(),
+            })?;
+        connection
+            .pragma_update(None, "synchronous", "NORMAL")
+            .map_err(|error| PersistenceError::Sqlite {
+                operation: "configure synchronous mode",
+                path: path.to_path_buf(),
+                message: error.to_string(),
+            })?;
+    }
+    Ok(connection)
+}
+
+fn report_operation_error<T>(
+    operation: &'static str,
+    path: &Path,
+    result: &Result<T, PersistenceError>,
+) {
+    if let Err(error) = result {
+        observability::persistence_operation_failed(operation, path, error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn database_path(label: &str) -> PathBuf {
+        crate::fs::test_dir(label).join("state.sqlite")
+    }
+
+    #[tokio::test]
+    async fn executes_queries_and_binds_values() {
+        let path = database_path("sqlite-query");
+        let database = SqliteDatabase::open(&path).await.unwrap();
+        database
+            .execute_batch("CREATE TABLE records (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+            .await
+            .unwrap();
+        database
+            .execute(
+                "INSERT INTO records (id, name) VALUES (?1, ?2)",
+                vec![SqlValue::Integer(7), SqlValue::Text("O'Reilly".to_owned())],
+            )
+            .await
+            .unwrap();
+
+        let names = database
+            .query("SELECT name FROM records WHERE id = ?1", vec![SqlValue::Integer(7)], |row| {
+                row.get::<_, String>(0)
+            })
+            .await
+            .unwrap();
+        assert_eq!(names, ["O'Reilly"]);
+        drop(database);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn applies_migrations_only_once() {
+        let path = database_path("sqlite-migration");
+        let database = SqliteDatabase::open(&path).await.unwrap();
+        let migrations = vec![Migration {
+            version: 1,
+            name: "create records",
+            sql: "CREATE TABLE records (id INTEGER PRIMARY KEY)",
+        }];
+        database.migrate(migrations.clone()).await.unwrap();
+        database.migrate(migrations).await.unwrap();
+
+        let versions = database
+            .query("SELECT version FROM _sealantern_schema_migrations", vec![], |row| {
+                row.get::<_, i64>(0)
+            })
+            .await
+            .unwrap();
+        assert_eq!(versions, [1]);
+        drop(database);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn write_rolls_back_when_the_work_fails() {
+        let path = database_path("sqlite-transaction");
+        let database = SqliteDatabase::open(&path).await.unwrap();
+        database
+            .execute_batch("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+            .await
+            .unwrap();
+        let result = database
+            .write("insert duplicate records", |transaction| {
+                transaction.execute("INSERT INTO records (id) VALUES (1)", [])?;
+                transaction.execute("INSERT INTO records (id) VALUES (1)", [])?;
+                Ok(())
+            })
+            .await;
+        assert!(matches!(result, Err(PersistenceError::Sqlite { .. })));
+        let count = database
+            .query("SELECT COUNT(*) FROM records", vec![], |row| row.get::<_, i64>(0))
+            .await
+            .unwrap();
+        assert_eq!(count, [0]);
+        drop(database);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn serializes_separately_opened_database_handles() {
+        let path = database_path("sqlite-coordination");
+        let first = SqliteDatabase::open(&path).await.unwrap();
+        let second = SqliteDatabase::open(&path).await.unwrap();
+        first
+            .execute_batch("CREATE TABLE records (id INTEGER PRIMARY KEY)")
+            .await
+            .unwrap();
+
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let first_write = tokio::spawn(async move {
+            first
+                .write("hold transaction", move |transaction| {
+                    let _ = entered_tx.send(());
+                    std::thread::sleep(Duration::from_millis(50));
+                    transaction.execute("INSERT INTO records (id) VALUES (1)", [])?;
+                    Ok(())
+                })
+                .await
+        });
+        entered_rx.await.unwrap();
+
+        let mut second_write = tokio::spawn(async move {
+            second
+                .execute("INSERT INTO records (id) VALUES (?1)", vec![SqlValue::Integer(2)])
+                .await
+        });
+        assert!(tokio::time::timeout(Duration::from_millis(10), &mut second_write)
+            .await
+            .is_err());
+        first_write.await.unwrap().unwrap();
+        second_write.await.unwrap().unwrap();
+
+        let reopened = SqliteDatabase::open(&path).await.unwrap();
+        let ids = reopened
+            .query("SELECT id FROM records ORDER BY id", vec![], |row| row.get::<_, i64>(0))
+            .await
+            .unwrap();
+        assert_eq!(ids, [1, 2]);
+        drop(reopened);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+}

--- a/crates/infra/src/persistence/sqlite.rs
+++ b/crates/infra/src/persistence/sqlite.rs
@@ -65,28 +65,24 @@ impl SqliteDatabase {
         options: SqliteOptions,
     ) -> Result<Self, PersistenceError> {
         let path = path.into();
-        let _guard = lock_database("open", &path).await?;
         let operation_path = path.clone();
-        let opened = tokio::task::spawn_blocking(move || open_connection(&path, &options))
-            .await
-            .map_err(|error| {
-                let error = PersistenceError::Task {
+        let result = async {
+            let _guard = lock_database(&path).await?;
+            let opened = tokio::task::spawn_blocking(move || open_connection(&path, &options))
+                .await
+                .map_err(|error| PersistenceError::Task {
                     operation: "open SQLite database",
                     message: error.to_string(),
-                };
-                observability::persistence_operation_failed("open", &operation_path, &error);
-                error
-            })?;
-        match opened {
-            Ok(connection) => Ok(Self {
-                path: operation_path,
+                })?;
+            let connection = opened?;
+            Ok(Self {
+                path: operation_path.clone(),
                 connection: Arc::new(Mutex::new(connection)),
-            }),
-            Err(error) => {
-                observability::persistence_operation_failed("open", &operation_path, &error);
-                Err(error)
-            }
+            })
         }
+        .await;
+        report_operation_error("open", &operation_path, &result);
+        result
     }
 
     /// 返回数据库文件路径。
@@ -95,44 +91,57 @@ impl SqliteDatabase {
     }
 
     /// 执行单条使用参数绑定的写入或控制语句。
-    pub async fn execute(
+    pub async fn execute<P>(
         &self,
         sql: impl Into<String>,
-        params: Vec<SqlValue>,
-    ) -> Result<usize, PersistenceError> {
+        params: P,
+    ) -> Result<usize, PersistenceError>
+    where
+        P: IntoIterator<Item = SqlValue> + Send + 'static,
+    {
         let sql = sql.into();
-        self.with_connection("execute", move |connection| {
-            connection.execute(&sql, rusqlite::params_from_iter(params))
-        })
-        .await
+        let result = self
+            .with_connection("execute", move |connection| {
+                connection.execute(&sql, rusqlite::params_from_iter(params))
+            })
+            .await;
+        report_operation_error("execute", &self.path, &result);
+        result
     }
 
     /// 执行仅由受信任代码构造的多条 SQL 语句。
     pub async fn execute_batch(&self, sql: impl Into<String>) -> Result<(), PersistenceError> {
         let sql = sql.into();
-        self.with_connection("execute batch", move |connection| connection.execute_batch(&sql))
-            .await
+        let result = self
+            .with_connection("execute batch", move |connection| connection.execute_batch(&sql))
+            .await;
+        report_operation_error("execute batch", &self.path, &result);
+        result
     }
 
     /// 查询记录，并通过调用方提供的闭包映射每一行。
-    pub async fn query<T, F>(
+    pub async fn query<T, P, F>(
         &self,
         sql: impl Into<String>,
-        params: Vec<SqlValue>,
+        params: P,
         mut map_row: F,
     ) -> Result<Vec<T>, PersistenceError>
     where
         T: Send + 'static,
+        P: IntoIterator<Item = SqlValue> + Send + 'static,
         F: FnMut(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
     {
         let sql = sql.into();
-        self.with_connection("query", move |connection| {
-            let mut statement = connection.prepare(&sql)?;
-            let rows =
-                statement.query_map(rusqlite::params_from_iter(params), |row| map_row(row))?;
-            rows.collect()
-        })
-        .await
+        let result = self
+            .with_connection("query", move |connection| {
+                let mut statement = connection.prepare(&sql)?;
+                let rows =
+                    statement.query_map(rusqlite::params_from_iter(params), |row| map_row(row))?;
+                rows.collect()
+            })
+            .await;
+        report_operation_error("query", &self.path, &result);
+        result
     }
 
     /// 在 `BEGIN IMMEDIATE` 事务中运行上层定义的写入操作。
@@ -141,31 +150,38 @@ impl SqliteDatabase {
         T: Send + 'static,
         F: FnOnce(&Transaction<'_>) -> rusqlite::Result<T> + Send + 'static,
     {
-        self.with_mut_connection(operation, move |connection| {
-            let transaction =
-                connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-            let result = work(&transaction)?;
-            transaction.commit()?;
-            Ok(result)
-        })
-        .await
+        let result = self
+            .with_mut_connection(operation, move |connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let result = work(&transaction)?;
+                transaction.commit()?;
+                Ok(result)
+            })
+            .await;
+        report_operation_error(operation, &self.path, &result);
+        result
     }
 
     /// 以单个原子事务应用未执行过的迁移。
     pub async fn migrate(&self, mut migrations: Vec<Migration>) -> Result<(), PersistenceError> {
         migrations.sort_by_key(|migration| migration.version);
         if let Some(migration) = migrations.iter().find(|migration| migration.version < 0) {
-            return Err(PersistenceError::InvalidMigration {
+            let result = Err(PersistenceError::InvalidMigration {
                 version: migration.version,
                 reason: "migration versions must not be negative",
             });
+            report_operation_error("migrate", &self.path, &result);
+            return result;
         }
         for pair in migrations.windows(2) {
             if pair[0].version == pair[1].version {
-                return Err(PersistenceError::InvalidMigration {
+                let result = Err(PersistenceError::InvalidMigration {
                     version: pair[0].version,
                     reason: "migration versions must be unique",
                 });
+                report_operation_error("migrate", &self.path, &result);
+                return result;
             }
         }
 
@@ -209,10 +225,9 @@ impl SqliteDatabase {
             transaction.commit()?;
             Ok(Ok(()))
         })
-        .await?;
-        if let Err(error) = &result {
-            observability::persistence_operation_failed("migrate", &self.path, error);
-        }
+        .await
+        .and_then(|result| result);
+        report_operation_error("migrate", &self.path, &result);
         result
     }
 
@@ -226,7 +241,7 @@ impl SqliteDatabase {
         F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
     {
         let path = self.path.clone();
-        let process_guard = lock_database(operation, &path).await?;
+        let process_guard = lock_database(&path).await?;
         let connection = Arc::clone(&self.connection);
         let result = tokio::task::spawn_blocking(move || {
             let _process_guard = process_guard;
@@ -243,12 +258,7 @@ impl SqliteDatabase {
             })
         })
         .await
-        .map_err(|error| {
-            let error = PersistenceError::Task { operation, message: error.to_string() };
-            observability::persistence_operation_failed(operation, &self.path, &error);
-            error
-        })?;
-        report_operation_error(operation, &self.path, &result);
+        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
         result
     }
 
@@ -262,7 +272,7 @@ impl SqliteDatabase {
         F: FnOnce(&mut Connection) -> rusqlite::Result<T> + Send + 'static,
     {
         let path = self.path.clone();
-        let process_guard = lock_database(operation, &path).await?;
+        let process_guard = lock_database(&path).await?;
         let connection = Arc::clone(&self.connection);
         let result = tokio::task::spawn_blocking(move || {
             let _process_guard = process_guard;
@@ -280,26 +290,13 @@ impl SqliteDatabase {
             })
         })
         .await
-        .map_err(|error| {
-            let error = PersistenceError::Task { operation, message: error.to_string() };
-            observability::persistence_operation_failed(operation, &self.path, &error);
-            error
-        })?;
-        report_operation_error(operation, &self.path, &result);
+        .map_err(|error| PersistenceError::Task { operation, message: error.to_string() })?;
         result
     }
 }
 
-async fn lock_database(
-    operation: &'static str,
-    path: &Path,
-) -> Result<tokio::sync::OwnedMutexGuard<()>, PersistenceError> {
-    process_lock_registry()
-        .lock(path)
-        .await
-        .inspect_err(|error| {
-            observability::persistence_operation_failed(operation, path, error);
-        })
+async fn lock_database(path: &Path) -> Result<tokio::sync::OwnedMutexGuard<()>, PersistenceError> {
+    process_lock_registry().lock(path).await
 }
 
 fn open_connection(path: &Path, options: &SqliteOptions) -> Result<Connection, PersistenceError> {
@@ -376,15 +373,17 @@ mod tests {
         database
             .execute(
                 "INSERT INTO records (id, name) VALUES (?1, ?2)",
-                vec![SqlValue::Integer(7), SqlValue::Text("O'Reilly".to_owned())],
+                [SqlValue::Integer(7), SqlValue::Text("O'Reilly".to_owned())],
             )
             .await
             .unwrap();
 
         let names = database
-            .query("SELECT name FROM records WHERE id = ?1", vec![SqlValue::Integer(7)], |row| {
-                row.get::<_, String>(0)
-            })
+            .query(
+                "SELECT name FROM records WHERE id = ?1",
+                std::iter::once(SqlValue::Integer(7)),
+                |row| row.get::<_, String>(0),
+            )
             .await
             .unwrap();
         assert_eq!(names, ["O'Reilly"]);


### PR DESCRIPTION
## 更改
- 完善 persistence 的耐久性、并发协调与错误回传。

## 验证
- `cargo test -p sealantern-infra persistence::`
- `cargo clippy -p sealantern-infra --lib -- -D warnings`