### PR TITLE
feat: 搭建 RPC 基础框架

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6041,6 +6041,8 @@ name = "sealantern-server"
 version = "0.1.0"
 dependencies = [
  "sealantern-core",
+ "serde",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6042,6 +6042,7 @@ version = "0.1.0"
 dependencies = [
  "sealantern-core",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,4 +13,5 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 
 [dev-dependencies]
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,4 +9,8 @@ path = "src/lib.rs"
 
 [dependencies]
 sealantern-core = { path = "../crates/core" }
+serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/server/src/observability.rs
+++ b/server/src/observability.rs
@@ -3,6 +3,8 @@ pub const SERVER_TARGET: &str = "sealantern.server";
 
 /// Event: 已处理一条服务器控制台命令。
 pub const EVENT_CONSOLE_COMMAND_DISPATCHED: &str = "console_command_dispatched";
+/// Event: RPC 方法调用失败。
+pub const EVENT_RPC_METHOD_FAILED: &str = "rpc_method_failed";
 
 /// 记录控制台命令的处理结果，不记录命令正文或执行错误。
 pub fn console_command_dispatched(instance_id: &str, command_char_count: usize, succeeded: bool) {
@@ -25,4 +27,22 @@ pub fn console_command_dispatched(instance_id: &str, command_char_count: usize, 
             "console command dispatch failed"
         );
     }
+}
+
+/// 记录 RPC 方法失败，不记录参数、响应正文或错误消息。
+pub fn rpc_method_failed(
+    method: &str,
+    context: &crate::rpc::RpcContext,
+    error: &crate::rpc::RpcError,
+) {
+    tracing::warn!(
+        target: SERVER_TARGET,
+        event_name = EVENT_RPC_METHOD_FAILED,
+        method,
+        request_id = context.request_id().as_str(),
+        transport = context.transport().as_str(),
+        error_code = error.code().as_str(),
+        retryable = error.is_retryable(),
+        "rpc method failed"
+    );
 }

--- a/server/src/rpc/access.rs
+++ b/server/src/rpc/access.rs
@@ -1,0 +1,90 @@
+//! RPC 方法的权限契约。
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use super::RpcMethodName;
+
+/// 可由受信任适配器授予的稳定 RPC 权限。
+///
+/// 权限名称遵循与 RPC 方法相同的小写点分规则，但它是独立的授权契约；调用方法本身不等于
+/// 调用方已获授权限。
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RpcPermission(&'static str);
+
+impl RpcPermission {
+    /// 使用编译期校验的静态权限名称创建权限。
+    pub const fn new(value: &'static str) -> Self {
+        assert!(RpcMethodName::is_valid(value), "invalid RPC permission name");
+        Self(value)
+    }
+
+    /// 返回稳定的机器可读权限名称。
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Debug for RpcPermission {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("RpcPermission")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl fmt::Display for RpcPermission {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+/// 当前请求已经通过身份验证和授权后获得的权限集合。
+///
+/// 此类型仅能由受信任的进程内适配器或后续授权服务构建，绝不能反序列化自 HTTP、Tauri
+/// 或插件请求的参数。默认值不包含任何权限。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RpcAccess {
+    permissions: BTreeSet<RpcPermission>,
+}
+
+impl RpcAccess {
+    /// 构建不授予任何权限的访问集合。
+    pub fn deny_all() -> Self {
+        Self::default()
+    }
+
+    /// 使用已由受信任边界决定的权限构建访问集合。
+    pub fn allow(permissions: impl IntoIterator<Item = RpcPermission>) -> Self {
+        Self {
+            permissions: permissions.into_iter().collect(),
+        }
+    }
+
+    /// 判断当前调用是否已获授指定权限。
+    pub fn allows(&self, permission: RpcPermission) -> bool {
+        self.permissions.contains(&permission)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONSOLE_SEND: RpcPermission = RpcPermission::new("server.console.send");
+    const INSTANCE_CREATE: RpcPermission = RpcPermission::new("server.instance.create");
+
+    #[test]
+    fn denies_permissions_by_default() {
+        assert!(!RpcAccess::deny_all().allows(CONSOLE_SEND));
+    }
+
+    #[test]
+    fn grants_only_explicit_permissions() {
+        let access = RpcAccess::allow([CONSOLE_SEND]);
+
+        assert!(access.allows(CONSOLE_SEND));
+        assert!(!access.allows(INSTANCE_CREATE));
+    }
+}

--- a/server/src/rpc/context.rs
+++ b/server/src/rpc/context.rs
@@ -1,0 +1,154 @@
+//! RPC 请求元数据和传输无关的请求封装。
+
+use serde::Serialize;
+
+use super::{RpcError, RpcResult};
+
+const MAX_REQUEST_ID_LENGTH: usize = 128;
+
+/// 由受信任传输适配器生成或校验后的请求关联标识。
+///
+/// 此标识仅用于关联日志和返回给调用方排障，不能用作身份凭据或授权依据。
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RpcRequestId(String);
+
+impl RpcRequestId {
+    /// 构建一个适合记录到结构化日志中的请求标识。
+    ///
+    /// 仅允许 ASCII 字母、数字、`-` 和 `_`，防止调用方通过关联标识注入控制字符或
+    /// 破坏日志字段格式。
+    pub fn new(value: impl Into<String>) -> RpcResult<Self> {
+        let value = value.into();
+        if value.is_empty() || value.len() > MAX_REQUEST_ID_LENGTH {
+            return Err(RpcError::invalid_argument(
+                "request_id",
+                "must contain between 1 and 128 characters",
+            ));
+        }
+
+        if !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(RpcError::invalid_argument(
+                "request_id",
+                "may contain only ASCII letters, digits, hyphens, and underscores",
+            ));
+        }
+
+        Ok(Self(value))
+    }
+
+    /// 返回用于传输响应和结构化日志的标识文本。
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for RpcRequestId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// 进入 RPC 层的传输类型。
+///
+/// 该字段只用于审计和可观测性。鉴权必须在适配器或后续显式授权端口中完成，不能仅凭
+/// 此枚举授予权限。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcTransport {
+    /// Tauri `invoke` 请求。
+    TauriInvoke,
+    /// Axum HTTP 请求。
+    Http,
+    /// 插件桥接请求。
+    Plugin,
+    /// 可信进程内调用。
+    Internal,
+}
+
+impl RpcTransport {
+    /// 返回稳定的可观测性字段值。
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TauriInvoke => "tauri_invoke",
+            Self::Http => "http",
+            Self::Plugin => "plugin",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+/// RPC 方法执行时可安全使用的请求元数据。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct RpcContext {
+    request_id: RpcRequestId,
+    transport: RpcTransport,
+}
+
+impl RpcContext {
+    /// 由传输适配器构建请求上下文。
+    pub fn new(request_id: RpcRequestId, transport: RpcTransport) -> Self {
+        Self { request_id, transport }
+    }
+
+    /// 返回当前调用的关联标识。
+    pub fn request_id(&self) -> &RpcRequestId {
+        &self.request_id
+    }
+
+    /// 返回当前调用的传输类型。
+    pub const fn transport(&self) -> RpcTransport {
+        self.transport
+    }
+}
+
+/// 传输适配器传给 RPC 方法的已解析请求。
+///
+/// 参数由该类型拥有，调用方法时会被消费，从而避免为跨异步边界保留请求数据而额外克隆。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RpcRequest<T> {
+    context: RpcContext,
+    params: T,
+}
+
+impl<T> RpcRequest<T> {
+    /// 使用已校验的上下文和已解析参数构建 RPC 请求。
+    pub fn new(context: RpcContext, params: T) -> Self {
+        Self { context, params }
+    }
+
+    /// 取出请求上下文和参数供调度器执行。
+    pub fn into_parts(self) -> (RpcContext, T) {
+        (self.context, self.params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_log_safe_request_id() {
+        let request_id = RpcRequestId::new("http_42-request").expect("request id should be valid");
+
+        assert_eq!(request_id.as_str(), "http_42-request");
+    }
+
+    #[test]
+    fn rejects_control_characters_in_request_id() {
+        let error = RpcRequestId::new("request\n42").expect_err("newline must be rejected");
+
+        assert_eq!(error.code(), super::super::RpcErrorCode::InvalidArgument);
+    }
+
+    #[test]
+    fn rejects_request_ids_that_are_too_long() {
+        let error = RpcRequestId::new("a".repeat(MAX_REQUEST_ID_LENGTH + 1))
+            .expect_err("oversized request id must be rejected");
+
+        assert_eq!(error.code(), super::super::RpcErrorCode::InvalidArgument);
+    }
+}

--- a/server/src/rpc/context.rs
+++ b/server/src/rpc/context.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use super::{RpcError, RpcResult};
+use super::{RpcAccess, RpcError, RpcResult};
 
 const MAX_REQUEST_ID_LENGTH: usize = 128;
 
@@ -82,16 +82,29 @@ impl RpcTransport {
 }
 
 /// RPC 方法执行时可安全使用的请求元数据。
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RpcContext {
     request_id: RpcRequestId,
     transport: RpcTransport,
+    access: RpcAccess,
 }
 
 impl RpcContext {
     /// 由传输适配器构建请求上下文。
     pub fn new(request_id: RpcRequestId, transport: RpcTransport) -> Self {
-        Self { request_id, transport }
+        Self {
+            request_id,
+            transport,
+            access: RpcAccess::deny_all(),
+        }
+    }
+
+    /// 附加已由受信任适配器完成认证和授权的访问集合。
+    ///
+    /// 未调用此方法的上下文不会拥有任何方法权限，调度器将拒绝受保护的 RPC 方法。
+    pub fn with_access(mut self, access: RpcAccess) -> Self {
+        self.access = access;
+        self
     }
 
     /// 返回当前调用的关联标识。
@@ -102,6 +115,11 @@ impl RpcContext {
     /// 返回当前调用的传输类型。
     pub const fn transport(&self) -> RpcTransport {
         self.transport
+    }
+
+    /// 返回当前调用已获授的权限集合。
+    pub fn access(&self) -> &RpcAccess {
+        &self.access
     }
 }
 

--- a/server/src/rpc/context.rs
+++ b/server/src/rpc/context.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use super::{RpcAccess, RpcError, RpcResult};
+use super::{RpcAccess, RpcCancellationToken, RpcDeadline, RpcError, RpcResult};
 
 const MAX_REQUEST_ID_LENGTH: usize = 128;
 
@@ -82,11 +82,13 @@ impl RpcTransport {
 }
 
 /// RPC 方法执行时可安全使用的请求元数据。
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct RpcContext {
     request_id: RpcRequestId,
     transport: RpcTransport,
     access: RpcAccess,
+    cancellation: RpcCancellationToken,
+    deadline: Option<RpcDeadline>,
 }
 
 impl RpcContext {
@@ -96,6 +98,8 @@ impl RpcContext {
             request_id,
             transport,
             access: RpcAccess::deny_all(),
+            cancellation: RpcCancellationToken::new(),
+            deadline: None,
         }
     }
 
@@ -104,6 +108,18 @@ impl RpcContext {
     /// 未调用此方法的上下文不会拥有任何方法权限，调度器将拒绝受保护的 RPC 方法。
     pub fn with_access(mut self, access: RpcAccess) -> Self {
         self.access = access;
+        self
+    }
+
+    /// 附加由传输适配器或任务协调器持有的取消令牌。
+    pub fn with_cancellation(mut self, cancellation: RpcCancellationToken) -> Self {
+        self.cancellation = cancellation;
+        self
+    }
+
+    /// 为本次调用设置单调时钟截止时间。
+    pub fn with_deadline(mut self, deadline: RpcDeadline) -> Self {
+        self.deadline = Some(deadline);
         self
     }
 
@@ -121,12 +137,33 @@ impl RpcContext {
     pub fn access(&self) -> &RpcAccess {
         &self.access
     }
+
+    /// 返回当前调用的协作式取消令牌。
+    pub fn cancellation(&self) -> &RpcCancellationToken {
+        &self.cancellation
+    }
+
+    /// 检查调用是否仍可继续执行。
+    ///
+    /// 适用于长时间运行的方法在副作用发生前、每个分页/循环迭代以及等待外部依赖后进行
+    /// 协作式检查。
+    pub fn check_active(&self) -> RpcResult<()> {
+        if self.cancellation.is_cancelled() {
+            return Err(RpcError::cancelled());
+        }
+
+        if self.deadline.is_some_and(RpcDeadline::has_expired) {
+            return Err(RpcError::deadline_exceeded("the requested operation"));
+        }
+
+        Ok(())
+    }
 }
 
 /// 传输适配器传给 RPC 方法的已解析请求。
 ///
 /// 参数由该类型拥有，调用方法时会被消费，从而避免为跨异步边界保留请求数据而额外克隆。
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct RpcRequest<T> {
     context: RpcContext,
     params: T,

--- a/server/src/rpc/contract.rs
+++ b/server/src/rpc/contract.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 
 use crate::observability;
 
-use super::{RpcContext, RpcRequest, RpcResult};
+use super::{RpcContext, RpcMethodName, RpcRequest, RpcResult};
 
 /// 一个传输无关的 RPC 应用服务方法。
 ///
@@ -12,7 +12,7 @@ use super::{RpcContext, RpcRequest, RpcResult};
 /// 参数反序列化、授权、协议错误映射和事件推送；方法实现只编排领域端口。
 pub trait RpcMethod {
     /// 稳定的方法名，供日志和适配器注册表使用。
-    const NAME: &'static str;
+    const NAME: RpcMethodName;
 
     /// 已完成传输反序列化的输入类型。
     type Request: Send;
@@ -39,7 +39,7 @@ where
         Ok(response) => Ok(response),
         Err(error) => {
             let error = error.with_request_id(context.request_id().clone());
-            observability::rpc_method_failed(M::NAME, &context, &error);
+            observability::rpc_method_failed(M::NAME.as_str(), &context, &error);
             Err(error)
         }
     }
@@ -53,7 +53,7 @@ mod tests {
     struct EchoMethod;
 
     impl RpcMethod for EchoMethod {
-        const NAME: &'static str = "test.echo";
+        const NAME: RpcMethodName = RpcMethodName::new("test.echo");
 
         type Request = String;
         type Response = String;
@@ -71,7 +71,7 @@ mod tests {
     struct FailingMethod;
 
     impl RpcMethod for FailingMethod {
-        const NAME: &'static str = "test.fail";
+        const NAME: RpcMethodName = RpcMethodName::new("test.fail");
 
         type Request = ();
         type Response = ();

--- a/server/src/rpc/contract.rs
+++ b/server/src/rpc/contract.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 
 use crate::observability;
 
-use super::{RpcContext, RpcMethodName, RpcRequest, RpcResult};
+use super::{RpcContext, RpcError, RpcMethodName, RpcPermission, RpcRequest, RpcResult};
 
 /// 一个传输无关的 RPC 应用服务方法。
 ///
@@ -13,6 +13,8 @@ use super::{RpcContext, RpcMethodName, RpcRequest, RpcResult};
 pub trait RpcMethod {
     /// 稳定的方法名，供日志和适配器注册表使用。
     const NAME: RpcMethodName;
+    /// 执行该方法所需的权限；`None` 仅适用于显式公开的只读方法。
+    const REQUIRED_PERMISSION: Option<RpcPermission>;
 
     /// 已完成传输反序列化的输入类型。
     type Request: Send;
@@ -35,6 +37,14 @@ where
     M: RpcMethod + Sync,
 {
     let (context, params) = request.into_parts();
+    if let Some(permission) = M::REQUIRED_PERMISSION {
+        if !context.access().allows(permission) {
+            let error = RpcError::permission_denied().with_request_id(context.request_id().clone());
+            observability::rpc_method_failed(M::NAME.as_str(), &context, &error);
+            return Err(error);
+        }
+    }
+
     match method.call(&context, params).await {
         Ok(response) => Ok(response),
         Err(error) => {
@@ -54,6 +64,7 @@ mod tests {
 
     impl RpcMethod for EchoMethod {
         const NAME: RpcMethodName = RpcMethodName::new("test.echo");
+        const REQUIRED_PERMISSION: Option<RpcPermission> = None;
 
         type Request = String;
         type Response = String;
@@ -72,6 +83,7 @@ mod tests {
 
     impl RpcMethod for FailingMethod {
         const NAME: RpcMethodName = RpcMethodName::new("test.fail");
+        const REQUIRED_PERMISSION: Option<RpcPermission> = None;
 
         type Request = ();
         type Response = ();

--- a/server/src/rpc/contract.rs
+++ b/server/src/rpc/contract.rs
@@ -1,0 +1,113 @@
+//! RPC 方法调用契约和统一调度器。
+
+use std::future::Future;
+
+use crate::observability;
+
+use super::{RpcContext, RpcRequest, RpcResult};
+
+/// 一个传输无关的 RPC 应用服务方法。
+///
+/// 方法借用服务实例、消费已解析参数，并只返回 [`RpcResult`]。Tauri 与 Axum 适配器负责
+/// 参数反序列化、授权、协议错误映射和事件推送；方法实现只编排领域端口。
+pub trait RpcMethod {
+    /// 稳定的方法名，供日志和适配器注册表使用。
+    const NAME: &'static str;
+
+    /// 已完成传输反序列化的输入类型。
+    type Request: Send;
+    /// 可由传输适配器序列化的输出类型。
+    type Response: Send;
+
+    /// 执行方法。
+    fn call(
+        &self,
+        context: &RpcContext,
+        request: Self::Request,
+    ) -> impl Future<Output = RpcResult<Self::Response>> + Send;
+}
+
+/// 调度一个 RPC 方法并为失败结果补充关联标识和结构化追踪事件。
+///
+/// 不记录请求参数、响应正文或错误消息，避免凭据、命令正文和文件路径进入公共事件流。
+pub async fn dispatch<M>(method: &M, request: RpcRequest<M::Request>) -> RpcResult<M::Response>
+where
+    M: RpcMethod + Sync,
+{
+    let (context, params) = request.into_parts();
+    match method.call(&context, params).await {
+        Ok(response) => Ok(response),
+        Err(error) => {
+            let error = error.with_request_id(context.request_id().clone());
+            observability::rpc_method_failed(M::NAME, &context, &error);
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::{RpcError, RpcErrorCode, RpcRequestId, RpcTransport};
+
+    struct EchoMethod;
+
+    impl RpcMethod for EchoMethod {
+        const NAME: &'static str = "test.echo";
+
+        type Request = String;
+        type Response = String;
+
+        fn call(
+            &self,
+            context: &RpcContext,
+            request: Self::Request,
+        ) -> impl Future<Output = RpcResult<Self::Response>> + Send {
+            let request_id = context.request_id().to_string();
+            async move { Ok(format!("{request_id}:{request}")) }
+        }
+    }
+
+    struct FailingMethod;
+
+    impl RpcMethod for FailingMethod {
+        const NAME: &'static str = "test.fail";
+
+        type Request = ();
+        type Response = ();
+
+        fn call(
+            &self,
+            _context: &RpcContext,
+            _request: Self::Request,
+        ) -> impl Future<Output = RpcResult<Self::Response>> + Send {
+            async { Err(RpcError::unavailable("test dependency")) }
+        }
+    }
+
+    fn request<T>(params: T) -> RpcRequest<T> {
+        let request_id = RpcRequestId::new("rpc-test-42").expect("request id should be valid");
+        let context = RpcContext::new(request_id, RpcTransport::Internal);
+        RpcRequest::new(context, params)
+    }
+
+    #[tokio::test]
+    async fn dispatch_passes_owned_request_data_to_the_method() {
+        let response = dispatch(&EchoMethod, request("payload".to_string()))
+            .await
+            .expect("method should succeed");
+
+        assert_eq!(response, "rpc-test-42:payload");
+    }
+
+    #[tokio::test]
+    async fn dispatch_attaches_the_request_id_to_safe_failures() {
+        let error = dispatch(&FailingMethod, request(()))
+            .await
+            .expect_err("method should fail");
+
+        assert_eq!(error.code(), RpcErrorCode::Unavailable);
+        assert_eq!(error.request_id().map(RpcRequestId::as_str), Some("rpc-test-42"));
+        assert!(error.is_retryable());
+    }
+}

--- a/server/src/rpc/contract.rs
+++ b/server/src/rpc/contract.rs
@@ -4,7 +4,9 @@ use std::future::Future;
 
 use crate::observability;
 
-use super::{RpcContext, RpcError, RpcMethodName, RpcPermission, RpcRequest, RpcResult};
+use super::{
+    RpcContext, RpcError, RpcMethodName, RpcPermission, RpcRequest, RpcResponse, RpcResult,
+};
 
 /// 一个传输无关的 RPC 应用服务方法。
 ///
@@ -32,7 +34,10 @@ pub trait RpcMethod {
 /// 调度一个 RPC 方法并为失败结果补充关联标识和结构化追踪事件。
 ///
 /// 不记录请求参数、响应正文或错误消息，避免凭据、命令正文和文件路径进入公共事件流。
-pub async fn dispatch<M>(method: &M, request: RpcRequest<M::Request>) -> RpcResult<M::Response>
+pub async fn dispatch<M>(
+    method: &M,
+    request: RpcRequest<M::Request>,
+) -> RpcResult<RpcResponse<M::Response>>
 where
     M: RpcMethod + Sync,
 {
@@ -46,7 +51,7 @@ where
     }
 
     match method.call(&context, params).await {
-        Ok(response) => Ok(response),
+        Ok(response) => Ok(RpcResponse::new(context.request_id().clone(), response)),
         Err(error) => {
             let error = error.with_request_id(context.request_id().clone());
             observability::rpc_method_failed(M::NAME.as_str(), &context, &error);
@@ -109,7 +114,8 @@ mod tests {
             .await
             .expect("method should succeed");
 
-        assert_eq!(response, "rpc-test-42:payload");
+        assert_eq!(response.request_id().as_str(), "rpc-test-42");
+        assert_eq!(response.data(), "rpc-test-42:payload");
     }
 
     #[tokio::test]

--- a/server/src/rpc/contract.rs
+++ b/server/src/rpc/contract.rs
@@ -42,28 +42,40 @@ where
     M: RpcMethod + Sync,
 {
     let (context, params) = request.into_parts();
+    if let Err(error) = context.check_active() {
+        return fail(&context, M::NAME, error);
+    }
+
     if let Some(permission) = M::REQUIRED_PERMISSION {
         if !context.access().allows(permission) {
-            let error = RpcError::permission_denied().with_request_id(context.request_id().clone());
-            observability::rpc_method_failed(M::NAME.as_str(), &context, &error);
-            return Err(error);
+            return fail(&context, M::NAME, RpcError::permission_denied());
         }
     }
 
     match method.call(&context, params).await {
-        Ok(response) => Ok(RpcResponse::new(context.request_id().clone(), response)),
-        Err(error) => {
-            let error = error.with_request_id(context.request_id().clone());
-            observability::rpc_method_failed(M::NAME.as_str(), &context, &error);
-            Err(error)
-        }
+        Ok(response) => match context.check_active() {
+            Ok(()) => Ok(RpcResponse::new(context.request_id().clone(), response)),
+            Err(error) => fail(&context, M::NAME, error),
+        },
+        Err(error) => fail(&context, M::NAME, error),
     }
+}
+
+fn fail<T>(context: &RpcContext, method: RpcMethodName, error: RpcError) -> RpcResult<T> {
+    let error = error.with_request_id(context.request_id().clone());
+    observability::rpc_method_failed(method.as_str(), context, &error);
+    Err(error)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rpc::{RpcError, RpcErrorCode, RpcRequestId, RpcTransport};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    use crate::rpc::{
+        RpcCancellationToken, RpcDeadline, RpcError, RpcErrorCode, RpcRequestId, RpcTransport,
+    };
 
     struct EchoMethod;
 
@@ -102,6 +114,27 @@ mod tests {
         }
     }
 
+    struct CountingMethod {
+        calls: AtomicUsize,
+    }
+
+    impl RpcMethod for CountingMethod {
+        const NAME: RpcMethodName = RpcMethodName::new("test.count");
+        const REQUIRED_PERMISSION: Option<RpcPermission> = None;
+
+        type Request = ();
+        type Response = ();
+
+        fn call(
+            &self,
+            _context: &RpcContext,
+            _request: Self::Request,
+        ) -> impl Future<Output = RpcResult<Self::Response>> + Send {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            async { Ok(()) }
+        }
+    }
+
     fn request<T>(params: T) -> RpcRequest<T> {
         let request_id = RpcRequestId::new("rpc-test-42").expect("request id should be valid");
         let context = RpcContext::new(request_id, RpcTransport::Internal);
@@ -127,5 +160,37 @@ mod tests {
         assert_eq!(error.code(), RpcErrorCode::Unavailable);
         assert_eq!(error.request_id().map(RpcRequestId::as_str), Some("rpc-test-42"));
         assert!(error.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn rejects_a_cancelled_request_before_invoking_the_method() {
+        let cancellation = RpcCancellationToken::new();
+        cancellation.cancel();
+        let request_id = RpcRequestId::new("cancelled-42").expect("request id should be valid");
+        let context =
+            RpcContext::new(request_id, RpcTransport::Internal).with_cancellation(cancellation);
+        let method = CountingMethod { calls: AtomicUsize::new(0) };
+
+        let error = dispatch(&method, RpcRequest::new(context, ()))
+            .await
+            .expect_err("cancelled request must fail");
+
+        assert_eq!(error.code(), RpcErrorCode::Cancelled);
+        assert_eq!(method.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn rejects_an_expired_request_before_invoking_the_method() {
+        let request_id = RpcRequestId::new("deadline-42").expect("request id should be valid");
+        let deadline = RpcDeadline::at(Instant::now() - Duration::from_secs(1));
+        let context = RpcContext::new(request_id, RpcTransport::Internal).with_deadline(deadline);
+        let method = CountingMethod { calls: AtomicUsize::new(0) };
+
+        let error = dispatch(&method, RpcRequest::new(context, ()))
+            .await
+            .expect_err("expired request must fail");
+
+        assert_eq!(error.code(), RpcErrorCode::DeadlineExceeded);
+        assert_eq!(method.calls.load(Ordering::Relaxed), 0);
     }
 }

--- a/server/src/rpc/error.rs
+++ b/server/src/rpc/error.rs
@@ -1,0 +1,173 @@
+//! RPC 的稳定错误契约。
+
+use serde::Serialize;
+
+use super::RpcRequestId;
+
+/// RPC 方法返回的统一结果类型。
+pub type RpcResult<T> = Result<T, RpcError>;
+
+/// 供 Tauri、HTTP 和其他传输一致映射的错误类别。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcErrorCode {
+    /// 调用参数不符合方法契约。
+    InvalidArgument,
+    /// 请求的资源不存在。
+    NotFound,
+    /// 当前状态不允许执行该操作。
+    Conflict,
+    /// 调用方未获授执行该操作的权限。
+    PermissionDenied,
+    /// 依赖暂时不可用，可以由调用方重试。
+    Unavailable,
+    /// 调用超过适配器或应用服务声明的截止时间。
+    DeadlineExceeded,
+    /// 未分类的服务端失败，不暴露内部错误文本。
+    Internal,
+}
+
+impl RpcErrorCode {
+    /// 返回稳定的机器可读错误代码。
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidArgument => "invalid_argument",
+            Self::NotFound => "not_found",
+            Self::Conflict => "conflict",
+            Self::PermissionDenied => "permission_denied",
+            Self::Unavailable => "unavailable",
+            Self::DeadlineExceeded => "deadline_exceeded",
+            Self::Internal => "internal",
+        }
+    }
+
+    /// 指示传输适配器是否可以向调用方建议重试。
+    pub const fn is_retryable(self) -> bool {
+        matches!(self, Self::Unavailable | Self::DeadlineExceeded)
+    }
+}
+
+/// 可安全返回给 RPC 调用方的错误。
+///
+/// 不保存底层错误对象或未脱敏参数。方法实现应先将底层错误记录到受控日志，再映射为本
+/// 类型，防止路径、凭据或供应商错误文本越过传输边界。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct RpcError {
+    code: RpcErrorCode,
+    message: String,
+    retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_id: Option<RpcRequestId>,
+}
+
+impl RpcError {
+    /// 构建参数无效错误。
+    pub fn invalid_argument(field: &'static str, reason: &'static str) -> Self {
+        Self::new(RpcErrorCode::InvalidArgument, format!("Invalid '{field}': {reason}."))
+    }
+
+    /// 构建资源不存在错误。
+    pub fn not_found(resource: &'static str) -> Self {
+        Self::new(RpcErrorCode::NotFound, format!("The requested {resource} was not found."))
+    }
+
+    /// 构建状态冲突错误。
+    pub fn conflict(operation: &'static str) -> Self {
+        Self::new(RpcErrorCode::Conflict, format!("The current state does not allow {operation}."))
+    }
+
+    /// 构建拒绝访问错误。
+    pub fn permission_denied() -> Self {
+        Self::new(
+            RpcErrorCode::PermissionDenied,
+            "The caller is not permitted to perform this operation.".to_string(),
+        )
+    }
+
+    /// 构建可重试的依赖不可用错误。
+    pub fn unavailable(dependency: &'static str) -> Self {
+        Self::new(
+            RpcErrorCode::Unavailable,
+            format!("The {dependency} is temporarily unavailable. Please retry."),
+        )
+    }
+
+    /// 构建可重试的截止时间错误。
+    pub fn deadline_exceeded(operation: &'static str) -> Self {
+        Self::new(
+            RpcErrorCode::DeadlineExceeded,
+            format!("The {operation} did not complete before its deadline. Please retry."),
+        )
+    }
+
+    /// 构建不泄露内部实现细节的服务端错误。
+    pub fn internal(operation: &'static str) -> Self {
+        Self::new(
+            RpcErrorCode::Internal,
+            format!("The server could not complete {operation}. Inspect server logs with the request ID."),
+        )
+    }
+
+    fn new(code: RpcErrorCode, message: String) -> Self {
+        Self {
+            code,
+            message,
+            retryable: code.is_retryable(),
+            request_id: None,
+        }
+    }
+
+    /// 返回稳定的错误代码。
+    pub const fn code(&self) -> RpcErrorCode {
+        self.code
+    }
+
+    /// 返回可安全展示给调用方的错误文本。
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// 返回调用方是否可重试该操作。
+    pub const fn is_retryable(&self) -> bool {
+        self.retryable
+    }
+
+    /// 返回调度器附加的请求关联标识。
+    pub fn request_id(&self) -> Option<&RpcRequestId> {
+        self.request_id.as_ref()
+    }
+
+    pub(crate) fn with_request_id(mut self, request_id: RpcRequestId) -> Self {
+        self.request_id = Some(request_id);
+        self
+    }
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RpcError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_error_does_not_expose_a_cause() {
+        let error = RpcError::internal("the requested operation");
+
+        assert_eq!(error.code(), RpcErrorCode::Internal);
+        assert!(!error.message().contains("database password"));
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn retryable_codes_are_marked_for_adapters() {
+        assert!(RpcError::unavailable("test dependency").is_retryable());
+        assert!(RpcError::deadline_exceeded("test operation").is_retryable());
+        assert!(!RpcError::permission_denied().is_retryable());
+    }
+}

--- a/server/src/rpc/error.rs
+++ b/server/src/rpc/error.rs
@@ -23,6 +23,8 @@ pub enum RpcErrorCode {
     Unavailable,
     /// 调用超过适配器或应用服务声明的截止时间。
     DeadlineExceeded,
+    /// 调用方或任务协调器取消了执行。
+    Cancelled,
     /// 未分类的服务端失败，不暴露内部错误文本。
     Internal,
 }
@@ -37,6 +39,7 @@ impl RpcErrorCode {
             Self::PermissionDenied => "permission_denied",
             Self::Unavailable => "unavailable",
             Self::DeadlineExceeded => "deadline_exceeded",
+            Self::Cancelled => "cancelled",
             Self::Internal => "internal",
         }
     }
@@ -99,6 +102,11 @@ impl RpcError {
             RpcErrorCode::DeadlineExceeded,
             format!("The {operation} did not complete before its deadline. Please retry."),
         )
+    }
+
+    /// 构建调用被取消错误。
+    pub fn cancelled() -> Self {
+        Self::new(RpcErrorCode::Cancelled, "The requested operation was cancelled.".to_string())
     }
 
     /// 构建不泄露内部实现细节的服务端错误。

--- a/server/src/rpc/error.rs
+++ b/server/src/rpc/error.rs
@@ -52,6 +52,7 @@ impl RpcErrorCode {
 /// 不保存底层错误对象或未脱敏参数。方法实现应先将底层错误记录到受控日志，再映射为本
 /// 类型，防止路径、凭据或供应商错误文本越过传输边界。
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcError {
     code: RpcErrorCode,
     message: String,
@@ -169,5 +170,15 @@ mod tests {
         assert!(RpcError::unavailable("test dependency").is_retryable());
         assert!(RpcError::deadline_exceeded("test operation").is_retryable());
         assert!(!RpcError::permission_denied().is_retryable());
+    }
+
+    #[test]
+    fn serializes_the_request_id_with_camel_case() {
+        let request_id = RpcRequestId::new("error-42").expect("request id should be valid");
+        let error = RpcError::permission_denied().with_request_id(request_id);
+        let value = serde_json::to_value(error).expect("error should serialize");
+
+        assert_eq!(value["requestId"], "error-42");
+        assert!(value.get("request_id").is_none());
     }
 }

--- a/server/src/rpc/lifecycle.rs
+++ b/server/src/rpc/lifecycle.rs
@@ -1,0 +1,69 @@
+//! RPC 调用的协作式取消与截止时间控制。
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// 可由传输适配器或任务协调器取消的调用令牌。
+///
+/// 取消是协作式的：它不会强制终止线程、future 或子进程。RPC 调度器会在方法调用前后
+/// 检查该令牌；耗时方法应在自己的循环和 I/O 边界调用 [`crate::rpc::RpcContext::check_active`]。
+#[derive(Clone, Debug, Default)]
+pub struct RpcCancellationToken(Arc<AtomicBool>);
+
+impl RpcCancellationToken {
+    /// 创建尚未取消的令牌。
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 请求取消当前调用。
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// 判断调用是否已被请求取消。
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// 单调时钟上的 RPC 调用截止时间。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RpcDeadline(Instant);
+
+impl RpcDeadline {
+    /// 使用调用方已计算的单调时钟时间点创建截止时间。
+    pub const fn at(instant: Instant) -> Self {
+        Self(instant)
+    }
+
+    /// 判断是否已经超过截止时间。
+    pub fn has_expired(self) -> bool {
+        Instant::now() >= self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn cancellation_is_visible_to_all_token_clones() {
+        let token = RpcCancellationToken::new();
+        let observer = token.clone();
+
+        token.cancel();
+
+        assert!(observer.is_cancelled());
+    }
+
+    #[test]
+    fn recognizes_an_elapsed_deadline() {
+        let deadline = RpcDeadline::at(Instant::now() - Duration::from_secs(1));
+
+        assert!(deadline.has_expired());
+    }
+}

--- a/server/src/rpc/method_name.rs
+++ b/server/src/rpc/method_name.rs
@@ -1,0 +1,125 @@
+//! RPC 方法的稳定标识和 HTTP 路径派生规则。
+
+use std::fmt;
+
+const HTTP_RPC_PREFIX: &str = "/api/rpc";
+
+/// 传输无关的 RPC 方法标识。
+///
+/// 标识固定使用小写点分的 `domain.resource.action` 形式，例如
+/// `server.console.send`。Rust 实现仍可使用 idiomatic 的模块、类型和函数命名；前端
+/// 适配器则可直接以此标识组织调用，并由 [`Self::http_path`] 获得一致的 Axum 路径。
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RpcMethodName(&'static str);
+
+impl RpcMethodName {
+    /// 使用编译期校验的静态方法标识创建名称。
+    ///
+    /// 每个段必须以小写 ASCII 字母开头，后续只能包含小写 ASCII 字母或数字；段之间仅
+    /// 能用一个 `.` 分隔。这使标识可以无歧义映射为 HTTP 路径。
+    pub const fn new(value: &'static str) -> Self {
+        assert!(Self::is_valid(value), "invalid RPC method name");
+        Self(value)
+    }
+
+    /// 判断动态获得的标识是否符合公共命名规则。
+    pub const fn is_valid(value: &str) -> bool {
+        let bytes = value.as_bytes();
+        if bytes.is_empty() {
+            return false;
+        }
+
+        let mut index = 0;
+        let mut needs_segment_start = true;
+        while index < bytes.len() {
+            let byte = bytes[index];
+            if byte == b'.' {
+                if needs_segment_start {
+                    return false;
+                }
+                needs_segment_start = true;
+            } else if needs_segment_start {
+                if !is_ascii_lowercase_letter(byte) {
+                    return false;
+                }
+                needs_segment_start = false;
+            } else if !is_ascii_lowercase_letter(byte) && !is_ascii_digit(byte) {
+                return false;
+            }
+            index += 1;
+        }
+
+        !needs_segment_start
+    }
+
+    /// 返回稳定的传输无关方法标识。
+    pub const fn as_str(self) -> &'static str {
+        self.0
+    }
+
+    /// 派生 Axum 应注册的 POST 路径。
+    ///
+    /// HTTP 只承载 RPC 方法，不混入旧的动态 `/api/{command}` 表。请求和响应 JSON 字段
+    /// 的 camelCase 规则由未来的 Axum/Tauri 适配器 DTO 负责。
+    pub fn http_path(self) -> String {
+        let mut path = String::with_capacity(HTTP_RPC_PREFIX.len() + self.0.len() + 1);
+        path.push_str(HTTP_RPC_PREFIX);
+        path.push('/');
+        for character in self.0.chars() {
+            path.push(if character == '.' { '/' } else { character });
+        }
+        path
+    }
+}
+
+impl fmt::Debug for RpcMethodName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("RpcMethodName")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl fmt::Display for RpcMethodName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
+}
+
+const fn is_ascii_lowercase_letter(byte: u8) -> bool {
+    byte >= b'a' && byte <= b'z'
+}
+
+const fn is_ascii_digit(byte: u8) -> bool {
+    byte >= b'0' && byte <= b'9'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_a_stable_http_path_from_the_canonical_name() {
+        let method = RpcMethodName::new("server.console.send");
+
+        assert_eq!(method.as_str(), "server.console.send");
+        assert_eq!(method.http_path(), "/api/rpc/server/console/send");
+    }
+
+    #[test]
+    fn accepts_lowercase_dotted_domain_resource_action_names() {
+        assert!(RpcMethodName::is_valid("server.instance.create"));
+        assert!(RpcMethodName::is_valid("plugin.v2.enable"));
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_transport_unsafe_names() {
+        assert!(!RpcMethodName::is_valid(""));
+        assert!(!RpcMethodName::is_valid("server..send"));
+        assert!(!RpcMethodName::is_valid("server.console."));
+        assert!(!RpcMethodName::is_valid("server.console.send-command"));
+        assert!(!RpcMethodName::is_valid("Server.console.send"));
+        assert!(!RpcMethodName::is_valid("server.2console.send"));
+    }
+}

--- a/server/src/rpc/methods/server/console_command.rs
+++ b/server/src/rpc/methods/server/console_command.rs
@@ -1,0 +1,240 @@
+//! 服务器控制台命令 RPC 方法。
+
+use std::fmt;
+use std::future::Future;
+
+use crate::observability;
+use crate::rpc::service::{ConsoleCommandService, ConsoleCommandServiceError};
+use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcResult};
+
+const MAX_INSTANCE_ID_LENGTH: usize = 128;
+const MAX_COMMAND_CHAR_COUNT: usize = 32_767;
+
+/// 经过边界校验的单行服务器控制台命令。
+///
+/// 命令正文可能包含密码、令牌或玩家输入，因此该类型不会派生 `Debug` 或 `Clone`。
+pub struct ConsoleCommandRequest {
+    instance_id: String,
+    command: String,
+}
+
+impl ConsoleCommandRequest {
+    /// 构建受约束的控制台命令请求。
+    ///
+    /// 只接受单行、无控制字符的命令，避免一条 RPC 请求被扩展为多次终端写入。实例 ID 仅
+    /// 允许日志安全字符，避免未经验证的标识进入追踪字段。
+    pub fn new(instance_id: impl Into<String>, command: impl Into<String>) -> RpcResult<Self> {
+        let instance_id = instance_id.into();
+        validate_instance_id(&instance_id)?;
+
+        let command = command.into();
+        validate_command(&command)?;
+
+        Ok(Self { instance_id, command })
+    }
+
+    /// 返回已经校验的服务器实例标识。
+    pub fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+
+    /// 返回已经校验的单行控制台命令。
+    pub fn command(&self) -> &str {
+        &self.command
+    }
+
+    /// 返回命令的 Unicode 字符数量，供脱敏可观测性使用。
+    pub fn command_char_count(&self) -> usize {
+        self.command.chars().count()
+    }
+}
+
+impl fmt::Debug for ConsoleCommandRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConsoleCommandRequest")
+            .field("instance_id", &self.instance_id)
+            .field("command_char_count", &self.command_char_count())
+            .finish()
+    }
+}
+
+/// 将已验证请求交给受管服务器控制台的 RPC 方法。
+pub struct SendConsoleCommand<S> {
+    service: S,
+}
+
+impl<S> SendConsoleCommand<S> {
+    /// 使用宿主提供的受管控制台能力创建方法实例。
+    pub const fn new(service: S) -> Self {
+        Self { service }
+    }
+}
+
+impl<S> RpcMethod for SendConsoleCommand<S>
+where
+    S: ConsoleCommandService,
+{
+    const NAME: &'static str = "server.console.send";
+
+    type Request = ConsoleCommandRequest;
+    type Response = ();
+
+    fn call(
+        &self,
+        _context: &RpcContext,
+        request: Self::Request,
+    ) -> impl Future<Output = RpcResult<Self::Response>> + Send {
+        let service = &self.service;
+        async move {
+            let result = service
+                .send_console_command(request.instance_id(), request.command())
+                .map_err(map_service_error);
+            observability::console_command_dispatched(
+                request.instance_id(),
+                request.command_char_count(),
+                result.is_ok(),
+            );
+            result
+        }
+    }
+}
+
+fn validate_instance_id(instance_id: &str) -> RpcResult<()> {
+    if instance_id.is_empty() || instance_id.len() > MAX_INSTANCE_ID_LENGTH {
+        return Err(RpcError::invalid_argument(
+            "instance_id",
+            "must contain between 1 and 128 characters",
+        ));
+    }
+
+    if !instance_id
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(RpcError::invalid_argument(
+            "instance_id",
+            "may contain only ASCII letters, digits, hyphens, and underscores",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_command(command: &str) -> RpcResult<()> {
+    if command.trim().is_empty() {
+        return Err(RpcError::invalid_argument("command", "must contain a non-whitespace command"));
+    }
+
+    if command.chars().count() > MAX_COMMAND_CHAR_COUNT {
+        return Err(RpcError::invalid_argument("command", "exceeds the 32767-character limit"));
+    }
+
+    if command.chars().any(|character| character.is_control()) {
+        return Err(RpcError::invalid_argument(
+            "command",
+            "must be a single line without control characters",
+        ));
+    }
+
+    Ok(())
+}
+
+fn map_service_error(error: ConsoleCommandServiceError) -> RpcError {
+    match error {
+        ConsoleCommandServiceError::InstanceNotFound => RpcError::not_found("server instance"),
+        ConsoleCommandServiceError::InputUnavailable => {
+            RpcError::conflict("sending console commands to this server")
+        }
+        ConsoleCommandServiceError::DeliveryFailed => RpcError::unavailable("server console"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::rpc::{dispatch, RpcContext, RpcErrorCode, RpcRequest, RpcRequestId, RpcTransport};
+
+    struct RecordingConsoleService {
+        requests: Mutex<Vec<(String, String)>>,
+        failure: Option<ConsoleCommandServiceError>,
+    }
+
+    impl ConsoleCommandService for RecordingConsoleService {
+        fn send_console_command(
+            &self,
+            instance_id: &str,
+            command: &str,
+        ) -> Result<(), ConsoleCommandServiceError> {
+            self.requests
+                .lock()
+                .expect("test request log lock should not be poisoned")
+                .push((instance_id.into(), command.into()));
+            self.failure.map_or(Ok(()), Err)
+        }
+    }
+
+    fn rpc_request(params: ConsoleCommandRequest) -> RpcRequest<ConsoleCommandRequest> {
+        let request_id = RpcRequestId::new("console-rpc-42").expect("request id should be valid");
+        let context = RpcContext::new(request_id, RpcTransport::Internal);
+        RpcRequest::new(context, params)
+    }
+
+    #[test]
+    fn rejects_multiline_commands_before_a_service_can_receive_them() {
+        let error = ConsoleCommandRequest::new("server-42", "say first\nstop")
+            .expect_err("multiline command must be rejected");
+
+        assert_eq!(error.code(), RpcErrorCode::InvalidArgument);
+    }
+
+    #[test]
+    fn debug_output_does_not_include_command_contents() {
+        let request = ConsoleCommandRequest::new("server-42", "login secret-token")
+            .expect("request should be valid");
+
+        assert!(!format!("{request:?}").contains("secret-token"));
+    }
+
+    #[tokio::test]
+    async fn dispatches_the_validated_command_once() {
+        let method = SendConsoleCommand::new(RecordingConsoleService {
+            requests: Mutex::new(Vec::new()),
+            failure: None,
+        });
+        let params =
+            ConsoleCommandRequest::new("server-42", "say hello").expect("request should be valid");
+
+        dispatch(&method, rpc_request(params))
+            .await
+            .expect("command should be delivered");
+
+        assert_eq!(
+            method
+                .service
+                .requests
+                .into_inner()
+                .expect("test request log lock should not be poisoned"),
+            vec![("server-42".into(), "say hello".into())]
+        );
+    }
+
+    #[tokio::test]
+    async fn maps_unverified_console_input_to_a_conflict() {
+        let method = SendConsoleCommand::new(RecordingConsoleService {
+            requests: Mutex::new(Vec::new()),
+            failure: Some(ConsoleCommandServiceError::InputUnavailable),
+        });
+        let params =
+            ConsoleCommandRequest::new("server-42", "stop").expect("request should be valid");
+
+        let error = dispatch(&method, rpc_request(params))
+            .await
+            .expect_err("unverified console input must be rejected");
+
+        assert_eq!(error.code(), RpcErrorCode::Conflict);
+        assert_eq!(error.request_id().map(RpcRequestId::as_str), Some("console-rpc-42"));
+    }
+}

--- a/server/src/rpc/methods/server/console_command.rs
+++ b/server/src/rpc/methods/server/console_command.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 
 use crate::observability;
 use crate::rpc::service::{ConsoleCommandService, ConsoleCommandServiceError};
-use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcResult};
+use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcMethodName, RpcResult};
 
 const MAX_INSTANCE_ID_LENGTH: usize = 128;
 const MAX_COMMAND_CHAR_COUNT: usize = 32_767;
@@ -75,7 +75,7 @@ impl<S> RpcMethod for SendConsoleCommand<S>
 where
     S: ConsoleCommandService,
 {
-    const NAME: &'static str = "server.console.send";
+    const NAME: RpcMethodName = RpcMethodName::new("server.console.send");
 
     type Request = ConsoleCommandRequest;
     type Response = ();

--- a/server/src/rpc/methods/server/console_command.rs
+++ b/server/src/rpc/methods/server/console_command.rs
@@ -5,10 +5,13 @@ use std::future::Future;
 
 use crate::observability;
 use crate::rpc::service::{ConsoleCommandService, ConsoleCommandServiceError};
-use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcMethodName, RpcResult};
+use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcMethodName, RpcPermission, RpcResult};
 
 const MAX_INSTANCE_ID_LENGTH: usize = 128;
 const MAX_COMMAND_CHAR_COUNT: usize = 32_767;
+
+/// 向受管服务器控制台写入命令所需的 RPC 权限。
+pub const PERMISSION_SERVER_CONSOLE_SEND: RpcPermission = RpcPermission::new("server.console.send");
 
 /// 经过边界校验的单行服务器控制台命令。
 ///
@@ -76,6 +79,7 @@ where
     S: ConsoleCommandService,
 {
     const NAME: RpcMethodName = RpcMethodName::new("server.console.send");
+    const REQUIRED_PERMISSION: Option<RpcPermission> = Some(PERMISSION_SERVER_CONSOLE_SEND);
 
     type Request = ConsoleCommandRequest;
     type Response = ();
@@ -155,7 +159,9 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
-    use crate::rpc::{dispatch, RpcContext, RpcErrorCode, RpcRequest, RpcRequestId, RpcTransport};
+    use crate::rpc::{
+        dispatch, RpcAccess, RpcContext, RpcErrorCode, RpcRequest, RpcRequestId, RpcTransport,
+    };
 
     struct RecordingConsoleService {
         requests: Mutex<Vec<(String, String)>>,
@@ -177,6 +183,15 @@ mod tests {
     }
 
     fn rpc_request(params: ConsoleCommandRequest) -> RpcRequest<ConsoleCommandRequest> {
+        let request_id = RpcRequestId::new("console-rpc-42").expect("request id should be valid");
+        let context = RpcContext::new(request_id, RpcTransport::Internal)
+            .with_access(RpcAccess::allow([PERMISSION_SERVER_CONSOLE_SEND]));
+        RpcRequest::new(context, params)
+    }
+
+    fn unprivileged_rpc_request(
+        params: ConsoleCommandRequest,
+    ) -> RpcRequest<ConsoleCommandRequest> {
         let request_id = RpcRequestId::new("console-rpc-42").expect("request id should be valid");
         let context = RpcContext::new(request_id, RpcTransport::Internal);
         RpcRequest::new(context, params)
@@ -236,5 +251,27 @@ mod tests {
 
         assert_eq!(error.code(), RpcErrorCode::Conflict);
         assert_eq!(error.request_id().map(RpcRequestId::as_str), Some("console-rpc-42"));
+    }
+
+    #[tokio::test]
+    async fn rejects_an_unprivileged_call_before_the_service_is_invoked() {
+        let method = SendConsoleCommand::new(RecordingConsoleService {
+            requests: Mutex::new(Vec::new()),
+            failure: None,
+        });
+        let params =
+            ConsoleCommandRequest::new("server-42", "stop").expect("request should be valid");
+
+        let error = dispatch(&method, unprivileged_rpc_request(params))
+            .await
+            .expect_err("missing permission must be rejected");
+
+        assert_eq!(error.code(), RpcErrorCode::PermissionDenied);
+        assert!(method
+            .service
+            .requests
+            .lock()
+            .expect("test request log lock should not be poisoned")
+            .is_empty());
     }
 }

--- a/server/src/rpc/methods/server/mod.rs
+++ b/server/src/rpc/methods/server/mod.rs
@@ -1,5 +1,7 @@
 //! 服务器实例管理方法。
 
 mod console;
+mod console_command;
 
 pub use console::dispatch_console_command;
+pub use console_command::{ConsoleCommandRequest, SendConsoleCommand};

--- a/server/src/rpc/methods/server/mod.rs
+++ b/server/src/rpc/methods/server/mod.rs
@@ -4,4 +4,6 @@ mod console;
 mod console_command;
 
 pub use console::dispatch_console_command;
-pub use console_command::{ConsoleCommandRequest, SendConsoleCommand};
+pub use console_command::{
+    ConsoleCommandRequest, SendConsoleCommand, PERMISSION_SERVER_CONSOLE_SEND,
+};

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -3,6 +3,7 @@
 //! 传输适配器负责将 Tauri、HTTP 或其他请求转换为此模块的方法调用；此处不依赖
 //! 任一具体传输协议。
 
+mod access;
 mod context;
 mod contract;
 mod error;
@@ -11,6 +12,7 @@ mod method_name;
 pub mod methods;
 pub mod service;
 
+pub use access::{RpcAccess, RpcPermission};
 pub use context::{RpcContext, RpcRequest, RpcRequestId, RpcTransport};
 pub use contract::{dispatch, RpcMethod};
 pub use error::{RpcError, RpcErrorCode, RpcResult};

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -7,6 +7,7 @@ mod access;
 mod context;
 mod contract;
 mod error;
+mod lifecycle;
 mod method_name;
 mod response;
 
@@ -17,5 +18,6 @@ pub use access::{RpcAccess, RpcPermission};
 pub use context::{RpcContext, RpcRequest, RpcRequestId, RpcTransport};
 pub use contract::{dispatch, RpcMethod};
 pub use error::{RpcError, RpcErrorCode, RpcResult};
+pub use lifecycle::{RpcCancellationToken, RpcDeadline};
 pub use method_name::RpcMethodName;
 pub use response::RpcResponse;

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -6,6 +6,7 @@
 mod context;
 mod contract;
 mod error;
+mod method_name;
 
 pub mod methods;
 pub mod service;
@@ -13,3 +14,4 @@ pub mod service;
 pub use context::{RpcContext, RpcRequest, RpcRequestId, RpcTransport};
 pub use contract::{dispatch, RpcMethod};
 pub use error::{RpcError, RpcErrorCode, RpcResult};
+pub use method_name::RpcMethodName;

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -8,6 +8,7 @@ mod context;
 mod contract;
 mod error;
 mod method_name;
+mod response;
 
 pub mod methods;
 pub mod service;
@@ -17,3 +18,4 @@ pub use context::{RpcContext, RpcRequest, RpcRequestId, RpcTransport};
 pub use contract::{dispatch, RpcMethod};
 pub use error::{RpcError, RpcErrorCode, RpcResult};
 pub use method_name::RpcMethodName;
+pub use response::RpcResponse;

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -3,5 +3,13 @@
 //! 传输适配器负责将 Tauri、HTTP 或其他请求转换为此模块的方法调用；此处不依赖
 //! 任一具体传输协议。
 
+mod context;
+mod contract;
+mod error;
+
 pub mod methods;
 pub mod service;
+
+pub use context::{RpcContext, RpcRequest, RpcRequestId, RpcTransport};
+pub use contract::{dispatch, RpcMethod};
+pub use error::{RpcError, RpcErrorCode, RpcResult};

--- a/server/src/rpc/response.rs
+++ b/server/src/rpc/response.rs
@@ -1,0 +1,55 @@
+//! RPC 成功响应的传输无关包络。
+
+use serde::Serialize;
+
+use super::RpcRequestId;
+
+/// 由统一调度器返回的成功响应。
+///
+/// `requestId` 与失败响应中的关联标识使用相同来源。适配器可以直接序列化该结构，或在
+/// 保持旧兼容接口时仅取出 [`Self::into_data`]；RPC 方法本身不需要了解任何传输包络。
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcResponse<T> {
+    request_id: RpcRequestId,
+    data: T,
+}
+
+impl<T> RpcResponse<T> {
+    pub(crate) fn new(request_id: RpcRequestId, data: T) -> Self {
+        Self { request_id, data }
+    }
+
+    /// 返回本次调用的关联标识。
+    pub fn request_id(&self) -> &RpcRequestId {
+        &self.request_id
+    }
+
+    /// 借用 RPC 方法返回的数据。
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// 取出 RPC 方法返回的数据，供兼容适配器使用。
+    pub fn into_data(self) -> T {
+        self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn serializes_the_request_id_with_camel_case() {
+        let request_id = RpcRequestId::new("response-42").expect("request id should be valid");
+        let response = RpcResponse::new(request_id, json!({ "serverName": "Lantern" }));
+        let value = serde_json::to_value(response).expect("response should serialize");
+
+        assert_eq!(value["requestId"], "response-42");
+        assert_eq!(value["data"]["serverName"], "Lantern");
+        assert!(value.get("request_id").is_none());
+    }
+}

--- a/server/src/rpc/service/console.rs
+++ b/server/src/rpc/service/console.rs
@@ -1,0 +1,29 @@
+//! 服务器控制台输入的宿主能力端口。
+
+/// 由受管服务器运行时返回的控制台输入失败类别。
+///
+/// 宿主实现必须在向任何子进程写入前验证该实例的 stdin 确实属于受管服务端进程。脚本、
+/// shell 或自定义启动包装进程的 stdin 必须返回 [`Self::InputUnavailable`]，而不能被视为
+/// 可写控制台。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConsoleCommandServiceError {
+    /// 指定的服务器实例不存在。
+    InstanceNotFound,
+    /// 实例未运行，或其 stdin 不属于已验证的服务端进程。
+    InputUnavailable,
+    /// 已验证的服务端控制台暂时无法接收输入。
+    DeliveryFailed,
+}
+
+/// 向已验证服务器控制台发送单行命令的宿主能力。
+///
+/// 该端口不接受 Tauri、HTTP 或插件运行时类型。实现必须保证错误不会携带命令正文、凭据
+/// 或主机路径；底层失败详情应仅写入受控的宿主日志。
+pub trait ConsoleCommandService: Send + Sync {
+    /// 向指定实例的受管服务端进程发送一条已验证命令。
+    fn send_console_command(
+        &self,
+        instance_id: &str,
+        command: &str,
+    ) -> Result<(), ConsoleCommandServiceError>;
+}

--- a/server/src/rpc/service/mod.rs
+++ b/server/src/rpc/service/mod.rs
@@ -2,8 +2,10 @@
 
 use std::fmt::Display;
 
+mod console;
 mod runtime;
 
+pub use console::{ConsoleCommandService, ConsoleCommandServiceError};
 pub use runtime::ServerRuntime;
 
 /// 由宿主实现的运行中实例控制台写入能力。


### PR DESCRIPTION
完成 RPC 基础框架搭建。

适配器和具体领域接入后续单独推进。

## Summary by Sourcery

引入一个与传输层无关的 RPC 框架，提供结构化上下文、错误处理、权限控制和可观测性，并基于该基础设施暴露一个用于服务器控制台命令的 RPC 方法。

New Features:
- 添加核心 RPC 抽象层，包括方法契约、上下文、请求/响应封装、权限控制、生命周期控制以及错误模型。
- 暴露一个 `server.console.send` RPC 方法和相应权限，用于向受管服务器实例发送已验证的单行控制台命令。
- 定义宿主侧的控制台命令服务端口和错误类型，用于集成服务器控制台 I/O 实现。

Enhancements:
- 扩展服务器可观测性，新增结构化的 `rpc_method_failed` 事件，用于记录失败的 RPC 调用，同时不记录敏感负载数据。

Build:
- 在 server crate 中添加 serde 和 tokio 开发依赖，以支持 RPC 负载序列化和异步测试。

Tests:
- 添加单元测试和异步测试，覆盖 RPC 命名与 HTTP 路径推导、请求上下文校验、生命周期行为、错误序列化、分发行为，以及控制台命令 RPC 的校验与鉴权路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a transport-agnostic RPC framework with structured context, error handling, permissions, and observability, and expose a server console command method over this infrastructure.

New Features:
- Add a core RPC abstraction layer including method contract, context, request/response envelope, permissions, lifecycle controls, and error model.
- Expose a `server.console.send` RPC method and permission for sending validated single-line console commands to managed server instances.
- Define a host-side console command service port and error types for integrating server console I/O implementations.

Enhancements:
- Extend server observability with a structured `rpc_method_failed` event for failed RPC calls, without logging sensitive payloads.

Build:
- Add serde and tokio dev-dependencies to support RPC payload serialization and async tests in the server crate.

Tests:
- Add unit and async tests covering RPC naming and HTTP path derivation, request context validation, lifecycle behavior, error serialization, dispatch behavior, and console command RPC validation and authorization paths.

</details>