### PR TITLE
ci: 分模块拆分CI测试

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -219,7 +219,7 @@ jobs:
           workspaces: ". -> target"
 
       - name: 运行测试
-        run: cargo test -p sea-lantern-lib
+        run: cargo test --lib -p sea-lantern
 
   frontend:
     name: 前端检查 (Node)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: "代码质量检查"
 on:
   pull_request:
   push:
-    branches: [main, dev]
+    branches: [main]
 
 concurrency:
   group: check-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
+      backend-core: ${{ steps.filter.outputs['backend-core'] }}
+      backend-infra: ${{ steps.filter.outputs['backend-infra'] }}
+      backend-extra: ${{ steps.filter.outputs['backend-extra'] }}
+      backend-server: ${{ steps.filter.outputs['backend-server'] }}
+      backend-tauri: ${{ steps.filter.outputs['backend-tauri'] }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +28,43 @@ jobs:
         with:
           filters: |
             backend:
+              - 'crates/**'
+              - 'server/**'
+              - 'src-tauri/**'
+              - '.cargo/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rustfmt.toml'
+              - '.github/workflows/check.yml'
+            backend-core:
+              - 'crates/core/**'
+              - '.cargo/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rustfmt.toml'
+              - '.github/workflows/check.yml'
+            backend-infra:
+              - 'crates/infra/**'
+              - '.cargo/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rustfmt.toml'
+              - '.github/workflows/check.yml'
+            backend-extra:
+              - 'crates/extra/**'
+              - '.cargo/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rustfmt.toml'
+              - '.github/workflows/check.yml'
+            backend-server:
+              - 'server/**'
+              - '.cargo/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rustfmt.toml'
+              - '.github/workflows/check.yml'
+            backend-tauri:
               - 'src-tauri/**'
               - '.cargo/**'
               - 'Cargo.toml'
@@ -41,11 +83,12 @@ jobs:
               - '.oxfmtrc.json'
               - '.github/workflows/check.yml'
 
-  backend:
-    name: 后端检查 (Rust)
+  backend-lint:
+    name: 后端代码规范 (fmt + clippy)
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: 检出代码
         uses: actions/checkout@v4
@@ -78,14 +121,105 @@ jobs:
       - name: 检查代码格式 (Rust)
         run: cargo fmt --all -- --check
 
-      - name: 编译检查 (Rust)
-        run: cargo check --workspace
-
       - name: 运行 Clippy 检查
         run: cargo clippy --workspace -- -D warnings
 
-      - name: 运行后端测试
-        run: cargo test --workspace
+  backend-test-core:
+    name: 后端测试（core）
+    needs: [changes, backend-lint]
+    if: ${{ needs.changes.outputs['backend-core'] == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Rust 工具链
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: 缓存 Rust 编译产物
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: 运行测试
+        run: cargo test -p sealantern-core
+
+  backend-test-infra:
+    name: 后端测试（infra）
+    needs: [changes, backend-lint]
+    if: ${{ needs.changes.outputs['backend-infra'] == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Rust 工具链
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: 缓存 Rust 编译产物
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: 运行测试
+        run: cargo test -p sealantern-infra --all-features
+
+  backend-test-server:
+    name: 后端测试（server）
+    needs: [changes, backend-lint]
+    if: ${{ needs.changes.outputs['backend-server'] == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Rust 工具链
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: 缓存 Rust 编译产物
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: 运行测试
+        run: cargo test -p sealantern-server
+
+  backend-test-tauri:
+    name: 后端测试（tauri）
+    needs: [changes, backend-lint]
+    if: ${{ needs.changes.outputs['backend-tauri'] == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装系统依赖
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf nasm
+
+      - name: 安装 Rust 工具链
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: 缓存 Rust 编译产物
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: 运行测试
+        run: cargo test -p sea-lantern-lib
 
   frontend:
     name: 前端检查 (Node)
@@ -120,3 +254,4 @@ jobs:
 
       - name: 运行格式化并检查前端 Lint
         run: pnpm run fmt:check && pnpm run lint
+


### PR DESCRIPTION
- 拆分测试逻辑
- 调整"代码质量检查"在push时的分支检测逻辑

## Summary by Sourcery

将后端 CI 检查拆分为独立的 lint 和按模块划分的测试任务，并调整代码质量工作流的触发方式。

新功能：
- 在 CI 工作流中为各个后端模块（core、infra、extra、server、tauri）引入变更检测输出。
- 为 core、infra、server 和 tauri crate 添加独立的后端测试任务，每个任务运行针对性的 `cargo test`。

增强：
- 重命名并聚焦后端工作流任务，使其专注于代码格式化和 clippy lint，将编译和测试拆分到专门的任务中。
- 为后端测试任务配置超时时间和缓存，以提升 CI 的稳定性和性能。
- 在 CI 中安装运行 tauri 相关后端测试所需的系统依赖。

CI：
- 将代码质量检查工作流的 push 触发限制为仅在 `main` 分支上生效。
- 扩展变更检测任务中的路径过滤规则，以更好地识别与后端相关的修改，并驱动更模块化的测试执行。

测试：
- 运行按模块划分的 Rust 测试套件，而不是单一的工作区整体测试，使 CI 覆盖范围与后端模块边界保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split backend CI checks into separate lint and per-module test jobs and adjust code quality workflow triggers.

New Features:
- Introduce change detection outputs for individual backend modules (core, infra, extra, server, tauri) in the CI workflow.
- Add separate backend test jobs for core, infra, server, and tauri crates, each running targeted cargo tests.

Enhancements:
- Rename and focus the backend workflow job on formatting and clippy linting, separating compilation and tests into dedicated jobs.
- Configure timeouts and caching for backend test jobs to improve CI reliability and performance.
- Install required system dependencies for running tauri-related backend tests in CI.

CI:
- Restrict the code quality check workflow push trigger to the main branch only.
- Expand path filters in the changes job to better detect backend-related modifications and drive modular test execution.

Tests:
- Run module-specific Rust test suites instead of a monolithic workspace test to align CI coverage with backend module boundaries.

</details>