### PR TITLE
feat: 接入 Axum RPC 适配器

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6049,10 +6049,12 @@ dependencies = [
 name = "sealantern-server"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "sealantern-core",
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-only"
 path = "src/lib.rs"
 
 [dependencies]
+axum = "0.8"
 sealantern-core = { path = "../crates/core" }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
@@ -15,3 +16,4 @@ tracing = "0.1"
 [dev-dependencies]
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
+tower = { version = "0.5", features = ["util"] }

--- a/server/src/observability.rs
+++ b/server/src/observability.rs
@@ -5,6 +5,8 @@ pub const SERVER_TARGET: &str = "sealantern.server";
 pub const EVENT_CONSOLE_COMMAND_DISPATCHED: &str = "console_command_dispatched";
 /// Event: RPC 方法调用失败。
 pub const EVENT_RPC_METHOD_FAILED: &str = "rpc_method_failed";
+/// Event: HTTP 适配器在调度前拒绝请求。
+pub const EVENT_RPC_HTTP_REQUEST_REJECTED: &str = "rpc_http_request_rejected";
 
 /// 记录控制台命令的处理结果，不记录命令正文或执行错误。
 pub fn console_command_dispatched(instance_id: &str, command_char_count: usize, succeeded: bool) {
@@ -44,5 +46,17 @@ pub fn rpc_method_failed(
         error_code = error.code().as_str(),
         retryable = error.is_retryable(),
         "rpc method failed"
+    );
+}
+
+/// 记录 HTTP 适配器拒绝的请求，不记录请求头、请求正文或认证材料。
+pub fn rpc_http_request_rejected(request_id: &str, reason: &'static str, error_code: &str) {
+    tracing::warn!(
+        target: SERVER_TARGET,
+        event_name = EVENT_RPC_HTTP_REQUEST_REJECTED,
+        request_id,
+        reason,
+        error_code,
+        "rpc HTTP request rejected"
     );
 }

--- a/server/src/rpc/axum.rs
+++ b/server/src/rpc/axum.rs
@@ -1,0 +1,328 @@
+//! Axum HTTP 到 RPC 契约的传输适配器。
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::{
+    extract::{rejection::JsonRejection, State},
+    http::{header::HeaderName, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde::Deserialize;
+
+use crate::observability;
+
+use super::{
+    dispatch,
+    methods::server::{ConsoleCommandRequest, SendConsoleCommand},
+    service::ConsoleCommandService,
+    RpcAccess, RpcContext, RpcError, RpcErrorCode, RpcMethod, RpcRequest, RpcRequestId, RpcResult,
+    RpcTransport,
+};
+
+const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// 由 HTTP 宿主实现的认证与授权端口。
+///
+/// 适配器不自行信任任意 HTTP 请求。宿主必须根据已经验证的身份材料返回权限集合，或返回
+/// 一个可安全公开的 [`RpcError`]。请求头的原始内容不得进入 RPC 日志或错误响应。
+pub trait HttpRpcAccessResolver: Send + Sync + 'static {
+    /// 解析当前 HTTP 请求所获授的 RPC 权限。
+    fn resolve(&self, headers: &HeaderMap) -> RpcResult<RpcAccess>;
+}
+
+/// 组装现有服务器控制台 RPC 的 Axum 路由。
+///
+/// 该函数只注册已实现的稳定 RPC 方法。调用方可将返回的路由嵌套进更大的 Axum 应用，认证
+/// 实现则通过 [`HttpRpcAccessResolver`] 注入，避免 HTTP 传输默认获得写入服务器控制台的权限。
+pub fn router<S, A>(console_service: S, access_resolver: A) -> Router
+where
+    S: ConsoleCommandService + 'static,
+    A: HttpRpcAccessResolver,
+{
+    let path = SendConsoleCommand::<S>::NAME.http_path();
+    let state = AxumRpcState {
+        console_command: Arc::new(SendConsoleCommand::new(console_service)),
+        access_resolver: Arc::new(access_resolver),
+    };
+
+    Router::new()
+        .route(&path, post(send_console_command::<S, A>))
+        .with_state(state)
+}
+
+struct AxumRpcState<S, A> {
+    console_command: Arc<SendConsoleCommand<S>>,
+    access_resolver: Arc<A>,
+}
+
+impl<S, A> Clone for AxumRpcState<S, A> {
+    fn clone(&self) -> Self {
+        Self {
+            console_command: Arc::clone(&self.console_command),
+            access_resolver: Arc::clone(&self.access_resolver),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SendConsoleCommandPayload {
+    instance_id: String,
+    command: String,
+}
+
+async fn send_console_command<S, A>(
+    State(state): State<AxumRpcState<S, A>>,
+    headers: HeaderMap,
+    payload: Result<Json<SendConsoleCommandPayload>, JsonRejection>,
+) -> Response
+where
+    S: ConsoleCommandService + 'static,
+    A: HttpRpcAccessResolver,
+{
+    let request_id = match request_id(&headers) {
+        Ok(request_id) => request_id,
+        Err((request_id, error)) => return reject(request_id, "invalid_request_id", error),
+    };
+
+    let access = match state.access_resolver.resolve(&headers) {
+        Ok(access) => access,
+        Err(error) => return reject(request_id, "authorization_rejected", error),
+    };
+
+    let payload = match payload {
+        Ok(Json(payload)) => payload,
+        Err(_) => {
+            return reject(
+                request_id,
+                "invalid_json",
+                RpcError::invalid_argument("request", "must be a valid JSON object"),
+            );
+        }
+    };
+
+    let params = match ConsoleCommandRequest::new(payload.instance_id, payload.command) {
+        Ok(params) => params,
+        Err(error) => return reject(request_id, "invalid_params", error),
+    };
+
+    let context = RpcContext::new(request_id, RpcTransport::Http).with_access(access);
+    match dispatch(state.console_command.as_ref(), RpcRequest::new(context, params)).await {
+        Ok(response) => {
+            let request_id = response.request_id().clone();
+            respond(StatusCode::OK, &request_id, response)
+        }
+        Err(error) => rpc_error_response(error),
+    }
+}
+
+fn request_id(headers: &HeaderMap) -> Result<RpcRequestId, (RpcRequestId, RpcError)> {
+    let generated = generated_request_id();
+    let Some(value) = headers.get(&REQUEST_ID_HEADER) else {
+        return Ok(generated);
+    };
+
+    let value = match value.to_str() {
+        Ok(value) => value,
+        Err(_) => {
+            return Err((
+                generated,
+                RpcError::invalid_argument("x-request-id", "must be valid ASCII"),
+            ));
+        }
+    };
+
+    RpcRequestId::new(value).map_err(|error| (generated, error))
+}
+
+fn generated_request_id() -> RpcRequestId {
+    let sequence = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    RpcRequestId::new(format!("http-{sequence}")).expect("generated request ID must be valid")
+}
+
+fn reject(request_id: RpcRequestId, reason: &'static str, error: RpcError) -> Response {
+    let error = error.with_request_id(request_id);
+    observability::rpc_http_request_rejected(
+        error
+            .request_id()
+            .expect("rejection must have a request ID")
+            .as_str(),
+        reason,
+        error.code().as_str(),
+    );
+    rpc_error_response(error)
+}
+
+fn rpc_error_response(error: RpcError) -> Response {
+    let status = status_for(error.code());
+    let request_id = error
+        .request_id()
+        .expect("all Axum RPC errors must have a request ID")
+        .clone();
+    respond(status, &request_id, error)
+}
+
+fn respond<T>(status: StatusCode, request_id: &RpcRequestId, body: T) -> Response
+where
+    T: serde::Serialize,
+{
+    let mut response = (status, Json(body)).into_response();
+    response.headers_mut().insert(
+        REQUEST_ID_HEADER,
+        HeaderValue::from_str(request_id.as_str())
+            .expect("validated request ID must be a header value"),
+    );
+    response
+}
+
+const fn status_for(code: RpcErrorCode) -> StatusCode {
+    match code {
+        RpcErrorCode::InvalidArgument => StatusCode::BAD_REQUEST,
+        RpcErrorCode::NotFound => StatusCode::NOT_FOUND,
+        RpcErrorCode::Conflict => StatusCode::CONFLICT,
+        RpcErrorCode::PermissionDenied => StatusCode::FORBIDDEN,
+        RpcErrorCode::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        RpcErrorCode::DeadlineExceeded => StatusCode::GATEWAY_TIMEOUT,
+        RpcErrorCode::Cancelled => StatusCode::REQUEST_TIMEOUT,
+        RpcErrorCode::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::rpc::{
+        methods::server::PERMISSION_SERVER_CONSOLE_SEND, service::ConsoleCommandServiceError,
+    };
+
+    #[derive(Default)]
+    struct RecordingConsoleService {
+        commands: Mutex<Vec<(String, String)>>,
+    }
+
+    impl ConsoleCommandService for Arc<RecordingConsoleService> {
+        fn send_console_command(
+            &self,
+            instance_id: &str,
+            command: &str,
+        ) -> Result<(), ConsoleCommandServiceError> {
+            self.commands
+                .lock()
+                .expect("recording service lock")
+                .push((instance_id.into(), command.into()));
+            Ok(())
+        }
+    }
+
+    struct AllowConsoleSend;
+
+    impl HttpRpcAccessResolver for AllowConsoleSend {
+        fn resolve(&self, _headers: &HeaderMap) -> RpcResult<RpcAccess> {
+            Ok(RpcAccess::allow([PERMISSION_SERVER_CONSOLE_SEND]))
+        }
+    }
+
+    struct DenyAll;
+
+    impl HttpRpcAccessResolver for DenyAll {
+        fn resolve(&self, _headers: &HeaderMap) -> RpcResult<RpcAccess> {
+            Ok(RpcAccess::deny_all())
+        }
+    }
+
+    fn request(body: &'static str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/rpc/server/console/send")
+            .header("content-type", "application/json")
+            .header("x-request-id", "http-test-42")
+            .body(Body::from(body))
+            .expect("build HTTP request")
+    }
+
+    #[tokio::test]
+    async fn dispatches_a_valid_http_request_through_the_rpc_method() {
+        let service = Arc::new(RecordingConsoleService::default());
+        let response = router(service.clone(), AllowConsoleSend)
+            .oneshot(request(r#"{"instanceId":"alpha","command":"say hello"}"#))
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[&REQUEST_ID_HEADER], "http-test-42");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
+        assert_eq!(body["requestId"], "http-test-42");
+        assert!(body["data"].is_null());
+        assert_eq!(
+            *service.commands.lock().expect("recording service lock"),
+            vec![("alpha".into(), "say hello".into())]
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_an_unprivileged_request_without_calling_the_service() {
+        let service = Arc::new(RecordingConsoleService::default());
+        let response = router(service.clone(), DenyAll)
+            .oneshot(request(r#"{"instanceId":"alpha","command":"stop"}"#))
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
+        assert_eq!(body["code"], "permission_denied");
+        assert_eq!(body["requestId"], "http-test-42");
+        assert!(service
+            .commands
+            .lock()
+            .expect("recording service lock")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn maps_invalid_json_to_the_rpc_error_envelope() {
+        let service = Arc::new(RecordingConsoleService::default());
+        let response = router(service.clone(), AllowConsoleSend)
+            .oneshot(request("not json"))
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
+        assert_eq!(body["code"], "invalid_argument");
+        assert_eq!(body["requestId"], "http-test-42");
+        assert!(service
+            .commands
+            .lock()
+            .expect("recording service lock")
+            .is_empty());
+    }
+
+    #[test]
+    fn maps_rpc_errors_to_stable_http_statuses() {
+        assert_eq!(status_for(RpcErrorCode::Unavailable), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_for(RpcErrorCode::DeadlineExceeded), StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(status_for(RpcErrorCode::Cancelled), StatusCode::REQUEST_TIMEOUT);
+    }
+}

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -4,6 +4,7 @@
 //! 任一具体传输协议。
 
 mod access;
+pub mod axum;
 mod context;
 mod contract;
 mod error;


### PR DESCRIPTION
新增 Axum 到 RPC 的控制台命令适配器。\n\n统一处理请求标识、授权结果与 HTTP 错误响应。\n\n未修改 Tauri 对接。

## Summary by Sourcery

引入一个基于 Axum 的 HTTP 适配器，用于现有的 RPC 控制台命令端点，实现结构化的请求标识、授权处理以及 HTTP 错误映射。

新特性：
- 添加 Axum RPC 适配器和路由器，通过 HTTP 暴露服务器控制台命令方法。
- 定义 `HttpRpcAccessResolver` 接口，便于宿主基于 HTTP 头信息接入经过认证的 RPC 访问控制。

增强：
- 为在分发前被拒绝的 HTTP RPC 请求添加可观测性日志，包括拒绝原因和错误码。
- 将 RPC 错误码映射为稳定的 HTTP 状态码响应，并通过头信息和响应体传播请求标识符。

构建：
- 在服务器 crate 中添加 Axum 和 Tower 依赖，以支持基于 HTTP 的 RPC 路由。

测试：
- 添加集成风格的测试，用于覆盖以下场景：成功分发、授权拒绝、无效 JSON 处理，以及 Axum RPC 适配器的错误到 HTTP 状态码的映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an Axum-based HTTP adapter for the existing RPC console command endpoint, with structured request identification, authorization handling, and HTTP error mapping.

New Features:
- Add an Axum RPC adapter and router to expose the server console command method over HTTP.
- Define an HttpRpcAccessResolver interface for hosts to plug in authenticated RPC access control based on HTTP headers.

Enhancements:
- Add observability logging for HTTP RPC requests rejected before dispatch, including reason and error code.
- Map RPC error codes to stable HTTP status responses and propagate request identifiers via headers and response body.

Build:
- Add Axum and Tower dependencies to the server crate to support HTTP-based RPC routing.

Tests:
- Add integration-style tests covering successful dispatch, authorization rejection, invalid JSON handling, and error-to-HTTP-status mapping for the Axum RPC adapter.

</details>