### PR TITLE
fix: 恢复 Unix core 进程测试

### DIFF
--- a/crates/core/src/process/daemon.rs
+++ b/crates/core/src/process/daemon.rs
@@ -302,7 +302,6 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> io::Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(dead_code)]
     use super::*;
 
     #[cfg(unix)]
@@ -320,7 +319,6 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[allow(dead_code)]
     fn long_running_tree_command() -> Command {
         let mut command = Command::new("sh");
         command.args(["-c", "sleep 30 & wait"]);
@@ -328,16 +326,12 @@ mod tests {
     }
 
     #[cfg(windows)]
-    #[allow(dead_code)]
     fn long_running_tree_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
-    // ## 仅限于 Windows：该模块的测试涉及子进程创建与管理，在 Linux CI 上会因进程管理问题卡住超时。
-    // ## Windows 上 taskkill 工作正常，故保留。若需在 Linux 上运行，需先修复 terminate_tree 的信号发送逻辑。
-    #[cfg(not(unix))]
     #[test]
     fn reports_the_exit_status_of_a_finished_daemon() {
         let mut command = exit_successfully_command();
@@ -347,7 +341,6 @@ mod tests {
         assert!(daemon.poll().expect("poll test process").is_some());
     }
 
-    #[cfg(not(unix))]
     #[test]
     fn reports_an_abnormal_sign_for_an_exited_daemon() {
         let mut command = exit_successfully_command();
@@ -364,9 +357,6 @@ mod tests {
         ));
     }
 
-    // ## 仅限于 Windows：该测试在 Linux CI 上会因 terminate_tree 无法正确终止进程树而卡住超时。
-    // ## Windows 上 taskkill 工作正常，故保留。
-    #[cfg(not(unix))]
     #[test]
     fn terminates_a_running_process_tree() {
         let mut command = long_running_tree_command();

--- a/crates/core/src/process/terminal.rs
+++ b/crates/core/src/process/terminal.rs
@@ -142,9 +142,7 @@ impl std::error::Error for TerminalWriteError {
     }
 }
 
-// ## 仅限于 Windows：该模块的测试涉及子进程 pipe 通信，在 Linux CI 上会因进程管理问题卡住超时。
-// ## Windows 上 taskkill 工作正常，故保留。若需在 Linux 上运行，需先修复 terminate_tree 的信号发送逻辑。
-#[cfg(all(test, not(unix)))]
+#[cfg(test)]
 mod tests {
     use std::io::Read;
     use std::process::{Command, Stdio};

--- a/crates/core/src/server/status.rs
+++ b/crates/core/src/server/status.rs
@@ -32,7 +32,6 @@ impl ServerStatus {
 
 #[cfg(test)]
 mod tests {
-    #![allow(dead_code, unused_imports)]
     use std::process::Command;
 
     use super::{ServerProcessState, ServerStatus};
@@ -53,7 +52,6 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[allow(dead_code)]
     fn long_running_command() -> Command {
         let mut command = Command::new("sh");
         command.args(["-c", "sleep 30"]);
@@ -61,16 +59,12 @@ mod tests {
     }
 
     #[cfg(windows)]
-    #[allow(dead_code)]
     fn long_running_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
-    // ## 仅限于 Windows：该模块的测试涉及子进程创建与管理，在 Linux CI 上会因进程管理问题卡住超时。
-    // ## Windows 上 taskkill 工作正常，故保留。若需在 Linux 上运行，需先修复 terminate_tree 的信号发送逻辑。
-    #[cfg(not(unix))]
     #[test]
     fn wraps_a_running_daemon() {
         let mut command = long_running_command();
@@ -86,8 +80,6 @@ mod tests {
             .expect("terminate test process tree");
     }
 
-    // ## 仅限于 Windows：同上，该测试也涉及子进程创建，在 Linux CI 上会卡住。
-    #[cfg(not(unix))]
     #[test]
     fn wraps_a_finished_daemon_exit_status() {
         let mut command = exit_successfully_command();


### PR DESCRIPTION
恢复 Unix 平台的 core 进程与终端测试覆盖。

## Summary by Sourcery

在简化测试配置属性的同时，恢复 Unix 平台下核心守护进程和终端进程测试的覆盖率。

Tests:
- 通过移除针对 Unix 的测试排除属性，重新启用 Unix 上的守护进程和服务器状态测试。
- 通过将测试配置扩展到所有平台，在 Unix 上启用终端进程测试。
- 清理进程管理测试中未使用的测试允许属性以及与平台相关的注释。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore Unix platform coverage for core daemon and terminal process tests while simplifying test configuration attributes.

Tests:
- Re-enable daemon and server status tests on Unix by removing Unix-specific test exclusion attributes.
- Enable terminal process tests on Unix by broadening test configuration to all platforms.
- Clean up unused test allow attributes and platform-specific comments around process management tests.

</details>