### PR TITLE
fix: CI误报成功的问题

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -242,12 +242,12 @@ jobs:
       - name: 汇总后端检查状态
         run: |
           failed=""
-          if [[ "${{ needs.backend-lint.result }}" == "failure" ]]; then failed="$failed lint"; fi
-          if [[ "${{ needs.backend-test-core.result }}" == "failure" ]]; then failed="$failed core"; fi
-          if [[ "${{ needs.backend-test-infra.result }}" == "failure" ]]; then failed="$failed infra"; fi
-          if [[ "${{ needs.backend-test-server.result }}" == "failure" ]]; then failed="$failed server"; fi
-          if [[ "${{ needs.backend-test-extra.result }}" == "failure" ]]; then failed="$failed extra"; fi
-          if [[ "${{ needs.backend-test-tauri.result }}" == "failure" ]]; then failed="$failed tauri"; fi
+          if [[ "${{ needs.backend-lint.result }}" != "success" && "${{ needs.backend-lint.result }}" != "skipped" ]]; then failed="$failed lint"; fi
+          if [[ "${{ needs.backend-test-core.result }}" != "success" && "${{ needs.backend-test-core.result }}" != "skipped" ]]; then failed="$failed core"; fi
+          if [[ "${{ needs.backend-test-infra.result }}" != "success" && "${{ needs.backend-test-infra.result }}" != "skipped" ]]; then failed="$failed infra"; fi
+          if [[ "${{ needs.backend-test-server.result }}" != "success" && "${{ needs.backend-test-server.result }}" != "skipped" ]]; then failed="$failed server"; fi
+          if [[ "${{ needs.backend-test-extra.result }}" != "success" && "${{ needs.backend-test-extra.result }}" != "skipped" ]]; then failed="$failed extra"; fi
+          if [[ "${{ needs.backend-test-tauri.result }}" != "success" && "${{ needs.backend-test-tauri.result }}" != "skipped" ]]; then failed="$failed tauri"; fi
           if [[ -n "$failed" ]]; then
             echo "::error ::后端检查失败，以下模块未通过：$failed"
             exit 1


### PR DESCRIPTION
- 修复了部分情况下，测试失败，但总结用的CI被误报为成功的问题

## Summary by Sourcery

Bug Fixes:
- 修复 CI 摘要逻辑：当后端测试或代码检查（lint）任务以非成功状态结束（但不是显式失败）时，可能仍会错误地报告为成功。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix CI summary logic that could report success when backend tests or lint jobs ended in non-success states other than explicit failures.

</details>