### PR TITLE
feat(server): 实现 REST API 端点注册——方法声明 HTTP 方法/路径/权限，一行宏注册

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,9 +11,9 @@ path = "src/lib.rs"
 axum = "0.8"
 sealantern-core = { path = "../crates/core" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tracing = "0.1"
 
 [dev-dependencies]
-serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }

--- a/server/src/rpc/axum.rs
+++ b/server/src/rpc/axum.rs
@@ -6,14 +6,13 @@ use std::sync::Arc;
 use axum::{
     http::{header::HeaderName, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
-    Json, Router,
+    Json,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::observability;
 
-use super::service::ConsoleCommandService;
 use super::{
     dispatch, RpcAccess, RpcContext, RpcError, RpcErrorCode, RpcMethod, RpcRequest, RpcRequestId,
     RpcResult, RpcTransport,
@@ -50,25 +49,6 @@ impl<A: Send + Sync + 'static> Clone for AxumRpcState<A> {
             access_resolver: Arc::clone(&self.access_resolver),
         }
     }
-}
-
-/// 组装当前所有已实现 RPC 方法的 Axum 路由。
-///
-/// 调用方可将返回的路由嵌套进更大的 Axum 应用，认证实现则通过
-/// [`HttpRpcAccessResolver`] 注入，避免 HTTP 传输默认获得写入服务器控制台的权限。
-pub fn build_router<S, A>(console_service: S, access_resolver: A) -> Router
-where
-    S: ConsoleCommandService + 'static,
-    A: HttpRpcAccessResolver,
-{
-    let mut router = Router::new();
-    crate::rpc_route!(
-        router,
-        crate::rpc::methods::server::SendConsoleCommand::new(console_service)
-    );
-    router.with_state(AxumRpcState {
-        access_resolver: Arc::new(access_resolver),
-    })
 }
 
 /// Axum 专用的 RPC 方法契约，扩展传输无关的 [`RpcMethod`]。
@@ -303,6 +283,7 @@ mod tests {
     use axum::{
         body::{to_bytes, Body},
         http::Request,
+        Router,
     };
     use serde_json::Value;
     use tower::ServiceExt;
@@ -329,16 +310,6 @@ mod tests {
                 .expect("recording service lock")
                 .push((instance_id.into(), command.into()));
             Ok(())
-        }
-    }
-
-    impl ConsoleCommandService for Arc<RecordingConsoleService> {
-        fn send_console_command(
-            &self,
-            instance_id: &str,
-            command: &str,
-        ) -> Result<(), ConsoleCommandServiceError> {
-            self.as_ref().send_console_command(instance_id, command)
         }
     }
 
@@ -370,12 +341,12 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_a_valid_http_request_through_the_rpc_method() {
-        let service = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let svc = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
         let state = AxumRpcState {
             access_resolver: Arc::new(AllowConsoleSend),
         };
         let mut router = Router::new();
-        rpc_route!(router, SendConsoleCommand::new(service));
+        rpc_route!(router, SendConsoleCommand::new(svc.clone()));
         let app = router.with_state(state);
         let response = app
             .oneshot(request(r#"{"instanceId":"alpha","command":"say hello"}"#))
@@ -390,14 +361,18 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["requestId"], "http-test-42");
         assert!(body["data"].is_null());
+        assert_eq!(
+            *svc.commands.lock().expect("recording service lock"),
+            vec![("alpha".into(), "say hello".into())]
+        );
     }
 
     #[tokio::test]
     async fn rejects_an_unprivileged_request_without_calling_the_service() {
-        let service = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let svc = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
         let state = AxumRpcState { access_resolver: Arc::new(DenyAll) };
         let mut router = Router::new();
-        rpc_route!(router, SendConsoleCommand::new(service));
+        rpc_route!(router, SendConsoleCommand::new(svc.clone()));
         let app = router.with_state(state);
 
         let response = app
@@ -412,16 +387,21 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["code"], "permission_denied");
         assert_eq!(body["requestId"], "http-test-42");
+        assert!(svc
+            .commands
+            .lock()
+            .expect("recording service lock")
+            .is_empty());
     }
 
     #[tokio::test]
     async fn maps_invalid_json_to_the_rpc_error_envelope() {
-        let service = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let svc = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
         let state = AxumRpcState {
             access_resolver: Arc::new(AllowConsoleSend),
         };
         let mut router = Router::new();
-        rpc_route!(router, SendConsoleCommand::new(service));
+        rpc_route!(router, SendConsoleCommand::new(svc.clone()));
         let app = router.with_state(state);
         let response = app
             .oneshot(request("not json"))
@@ -435,6 +415,11 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["code"], "invalid_argument");
         assert_eq!(body["requestId"], "http-test-42");
+        assert!(svc
+            .commands
+            .lock()
+            .expect("recording service lock")
+            .is_empty());
     }
 
     #[test]
@@ -446,13 +431,10 @@ mod tests {
 
     #[tokio::test]
     async fn build_router_dispatches_requests_through_the_public_entry() {
-        let service = RecordingConsoleService { commands: Mutex::new(Vec::new()) };
-        // 使用 build_router 公开入口，验证路由可正确响应 HTTP 请求
-        let app =
-            build_router::<RecordingConsoleService, AllowConsoleSend>(service, AllowConsoleSend);
+        let svc = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let services = crate::rpc::service::RpcServices::new(svc.clone());
+        let app = crate::rpc::router::build_router(services, AllowConsoleSend);
 
-        // 显式验证 Router 实现了 Service，调用 oneshot 前明确 body 类型
-        use tower::ServiceExt as _;
         let response = app
             .oneshot(request(r#"{"instanceId":"beta","command":"list"}"#))
             .await
@@ -466,12 +448,17 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["requestId"], "http-test-42");
         assert!(body["data"].is_null());
+        assert_eq!(
+            *svc.commands.lock().expect("recording service lock"),
+            vec![("beta".into(), "list".into())]
+        );
     }
 
     #[tokio::test]
     async fn build_router_rejects_unprivileged_requests() {
-        let service = RecordingConsoleService { commands: Mutex::new(Vec::new()) };
-        let app = build_router::<RecordingConsoleService, DenyAll>(service, DenyAll);
+        let svc = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let services = crate::rpc::service::RpcServices::new(svc.clone());
+        let app = crate::rpc::router::build_router(services, DenyAll);
 
         let response = app
             .oneshot(request(r#"{"instanceId":"alpha","command":"stop"}"#))
@@ -485,13 +472,18 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["code"], "permission_denied");
         assert_eq!(body["requestId"], "http-test-42");
+        assert!(svc
+            .commands
+            .lock()
+            .expect("recording service lock")
+            .is_empty());
     }
 
     #[tokio::test]
     async fn build_router_rejects_invalid_json() {
-        let service = RecordingConsoleService { commands: Mutex::new(Vec::new()) };
-        let app =
-            build_router::<RecordingConsoleService, AllowConsoleSend>(service, AllowConsoleSend);
+        let svc = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let services = crate::rpc::service::RpcServices::new(svc.clone());
+        let app = crate::rpc::router::build_router(services, AllowConsoleSend);
 
         let response = app
             .oneshot(request("not json"))

--- a/server/src/rpc/axum.rs
+++ b/server/src/rpc/axum.rs
@@ -4,26 +4,29 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use axum::{
-    extract::{rejection::JsonRejection, State},
     http::{header::HeaderName, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
-    routing::post,
     Json, Router,
 };
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use crate::observability;
 
+use super::service::ConsoleCommandService;
 use super::{
-    dispatch,
-    methods::server::{ConsoleCommandRequest, SendConsoleCommand},
-    service::ConsoleCommandService,
-    RpcAccess, RpcContext, RpcError, RpcErrorCode, RpcMethod, RpcRequest, RpcRequestId, RpcResult,
-    RpcTransport,
+    dispatch, RpcAccess, RpcContext, RpcError, RpcErrorCode, RpcMethod, RpcRequest, RpcRequestId,
+    RpcResult, RpcTransport,
 };
 
 const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
 static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// 所有 RPC 方法共享的 Axum HTTP 路径前缀。
+///
+/// 方法标识 `server.console.send` 通过 [`RpcAxumMethod::http_path`] 默认实现映射为
+/// `/api/rpc/server/console/send`。
+const HTTP_RPC_PREFIX: &str = "/api/rpc";
 
 /// 由 HTTP 宿主实现的认证与授权端口。
 ///
@@ -34,68 +37,169 @@ pub trait HttpRpcAccessResolver: Send + Sync + 'static {
     fn resolve(&self, headers: &HeaderMap) -> RpcResult<RpcAccess>;
 }
 
-/// 组装现有服务器控制台 RPC 的 Axum 路由。
+/// Axum RPC 状态。
 ///
-/// 该函数只注册已实现的稳定 RPC 方法。调用方可将返回的路由嵌套进更大的 Axum 应用，认证
-/// 实现则通过 [`HttpRpcAccessResolver`] 注入，避免 HTTP 传输默认获得写入服务器控制台的权限。
-pub fn router<S, A>(console_service: S, access_resolver: A) -> Router
-where
-    S: ConsoleCommandService + 'static,
-    A: HttpRpcAccessResolver,
-{
-    let path = SendConsoleCommand::<S>::NAME.http_path();
-    let state = AxumRpcState {
-        console_command: Arc::new(SendConsoleCommand::new(console_service)),
-        access_resolver: Arc::new(access_resolver),
-    };
-
-    Router::new()
-        .route(&path, post(send_console_command::<S, A>))
-        .with_state(state)
+/// 只持有认证解析器，方法实例由 `rpc_route!` 宏捕获。
+pub struct AxumRpcState<A: Send + Sync + 'static> {
+    pub access_resolver: Arc<A>,
 }
 
-struct AxumRpcState<S, A> {
-    console_command: Arc<SendConsoleCommand<S>>,
-    access_resolver: Arc<A>,
-}
-
-impl<S, A> Clone for AxumRpcState<S, A> {
+impl<A: Send + Sync + 'static> Clone for AxumRpcState<A> {
     fn clone(&self) -> Self {
         Self {
-            console_command: Arc::clone(&self.console_command),
             access_resolver: Arc::clone(&self.access_resolver),
         }
     }
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct SendConsoleCommandPayload {
-    instance_id: String,
-    command: String,
-}
-
-async fn send_console_command<S, A>(
-    State(state): State<AxumRpcState<S, A>>,
-    headers: HeaderMap,
-    payload: Result<Json<SendConsoleCommandPayload>, JsonRejection>,
-) -> Response
+/// 组装当前所有已实现 RPC 方法的 Axum 路由。
+///
+/// 调用方可将返回的路由嵌套进更大的 Axum 应用，认证实现则通过
+/// [`HttpRpcAccessResolver`] 注入，避免 HTTP 传输默认获得写入服务器控制台的权限。
+pub fn build_router<S, A>(console_service: S, access_resolver: A) -> Router
 where
     S: ConsoleCommandService + 'static,
     A: HttpRpcAccessResolver,
 {
-    let request_id = match request_id(&headers) {
+    let mut router = Router::new();
+    crate::rpc_route!(
+        router,
+        crate::rpc::methods::server::SendConsoleCommand::new(console_service)
+    );
+    router.with_state(AxumRpcState {
+        access_resolver: Arc::new(access_resolver),
+    })
+}
+
+/// Axum 专用的 RPC 方法契约，扩展传输无关的 [`RpcMethod`]。
+///
+/// 将 HTTP 相关配置（方法、路径）保留在适配器层，不污染契约层。实现者只需声明
+/// [`HTTP_METHOD`] 和 [`RpcMethod::NAME`]，HTTP 路径由 [`http_path`] 默认实现从方法
+/// 标识自动派生。
+///
+/// [`HTTP_METHOD`]: Self::HTTP_METHOD
+/// [`http_path`]: Self::http_path
+pub trait RpcAxumMethod: RpcMethod {
+    /// HTTP 方法，影响 axum 路由注册方式。
+    const HTTP_METHOD: RpcHttpMethod;
+
+    /// 派生 Axum 应注册的 HTTP 路径。
+    ///
+    /// 默认实现将方法标识中的 `.` 映射为路径 `/`，并拼接 [`HTTP_RPC_PREFIX`] 前缀。
+    /// 例如标识 `server.console.send` 会派生出 `/api/rpc/server/console/send`。
+    ///
+    /// 实现者可重写此方法以提供自定义路径，但必须保持以 `/` 开头。
+    ///
+    /// # 默认实现示例
+    ///
+    /// ```ignore
+    /// // 通常在 rpc_route! 宏内部调用；也可在测试中直接使用：
+    /// let path = <SendConsoleCommand<_> as RpcAxumMethod>::http_path();
+    /// assert_eq!(path, "/api/rpc/server/console/send");
+    /// ```
+    fn http_path() -> String {
+        let name = Self::NAME.as_str();
+        let mut path = String::with_capacity(HTTP_RPC_PREFIX.len() + name.len() + 1);
+        path.push_str(HTTP_RPC_PREFIX);
+        path.push('/');
+        for character in name.chars() {
+            path.push(if character == '.' { '/' } else { character });
+        }
+        path
+    }
+}
+
+/// HTTP 方法，对应 axum 路由的 HTTP 方法。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpcHttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+/// 通过方法实例推导关联常量（路径、HTTP 方法）。
+///
+/// 仅在 `rpc_route!` 宏中被调用。
+pub(crate) fn rpc_method_info<M: RpcAxumMethod>(_method: &Arc<M>) -> (String, RpcHttpMethod) {
+    (M::http_path(), M::HTTP_METHOD)
+}
+
+/// 注册 RPC 方法到 Axum 路由。
+///
+/// 自动处理路径派生、HTTP 方法映射、鉴权、JSON 反序列化和响应序列化。
+///
+/// # 示例
+///
+/// ```ignore
+/// let mut router = Router::new();
+/// rpc_route!(router, SendConsoleCommand::new(service));
+/// ```
+#[macro_export]
+macro_rules! rpc_route {
+    ($router:ident, $method:expr) => {{
+        let method: std::sync::Arc<_> = std::sync::Arc::new($method);
+        let (__rpc_path, __rpc_method) = $crate::rpc::axum::rpc_method_info(&method);
+
+        let __rpc_handler =
+            move |state: axum::extract::State<$crate::rpc::axum::AxumRpcState<_>>,
+                  headers: axum::http::HeaderMap,
+                  payload: Result<
+                axum::Json<serde_json::Value>,
+                axum::extract::rejection::JsonRejection,
+            >| {
+                let method = std::sync::Arc::clone(&method);
+                async move {
+                    $crate::rpc::axum::handle_rpc(method.as_ref(), &state, &headers, payload).await
+                }
+            };
+
+        match __rpc_method {
+            $crate::rpc::axum::RpcHttpMethod::Get => {
+                $router = $router.route(&__rpc_path, axum::routing::get(__rpc_handler));
+            }
+            $crate::rpc::axum::RpcHttpMethod::Post => {
+                $router = $router.route(&__rpc_path, axum::routing::post(__rpc_handler));
+            }
+            $crate::rpc::axum::RpcHttpMethod::Put => {
+                $router = $router.route(&__rpc_path, axum::routing::put(__rpc_handler));
+            }
+            $crate::rpc::axum::RpcHttpMethod::Patch => {
+                $router = $router.route(&__rpc_path, axum::routing::patch(__rpc_handler));
+            }
+            $crate::rpc::axum::RpcHttpMethod::Delete => {
+                $router = $router.route(&__rpc_path, axum::routing::delete(__rpc_handler));
+            }
+        }
+    }};
+}
+
+/// 通用 RPC handler，处理鉴权、反序列化、调度和响应。
+pub(crate) async fn handle_rpc<M, A>(
+    method: &M,
+    state: &AxumRpcState<A>,
+    headers: &HeaderMap,
+    payload: Result<Json<serde_json::Value>, axum::extract::rejection::JsonRejection>,
+) -> Response
+where
+    M: RpcMethod + Sync,
+    M::Request: DeserializeOwned,
+    M::Response: Serialize,
+    A: HttpRpcAccessResolver + Send + Sync + 'static,
+{
+    let request_id = match request_id(headers) {
         Ok(request_id) => request_id,
         Err((request_id, error)) => return reject(request_id, "invalid_request_id", error),
     };
 
-    let access = match state.access_resolver.resolve(&headers) {
+    let access = match state.access_resolver.resolve(headers) {
         Ok(access) => access,
         Err(error) => return reject(request_id, "authorization_rejected", error),
     };
 
-    let payload = match payload {
-        Ok(Json(payload)) => payload,
+    let value = match payload {
+        Ok(Json(value)) => value,
         Err(_) => {
             return reject(
                 request_id,
@@ -105,17 +209,20 @@ where
         }
     };
 
-    let params = match ConsoleCommandRequest::new(payload.instance_id, payload.command) {
+    let params: M::Request = match serde_json::from_value(value) {
         Ok(params) => params,
-        Err(error) => return reject(request_id, "invalid_params", error),
+        Err(_) => {
+            return reject(
+                request_id,
+                "invalid_params",
+                RpcError::invalid_argument("request", "failed to parse request body"),
+            );
+        }
     };
 
     let context = RpcContext::new(request_id, RpcTransport::Http).with_access(access);
-    match dispatch(state.console_command.as_ref(), RpcRequest::new(context, params)).await {
-        Ok(response) => {
-            let request_id = response.request_id().clone();
-            respond(StatusCode::OK, &request_id, response)
-        }
+    match dispatch(method, RpcRequest::new(context, params)).await {
+        Ok(response) => respond(StatusCode::OK, response.request_id(), &response),
         Err(error) => rpc_error_response(error),
     }
 }
@@ -166,10 +273,7 @@ fn rpc_error_response(error: RpcError) -> Response {
     respond(status, &request_id, error)
 }
 
-fn respond<T>(status: StatusCode, request_id: &RpcRequestId, body: T) -> Response
-where
-    T: serde::Serialize,
-{
+fn respond<T: Serialize>(status: StatusCode, request_id: &RpcRequestId, body: T) -> Response {
     let mut response = (status, Json(body)).into_response();
     response.headers_mut().insert(
         REQUEST_ID_HEADER,
@@ -194,26 +298,27 @@ const fn status_for(code: RpcErrorCode) -> StatusCode {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
 
     use axum::{
         body::{to_bytes, Body},
-        http::{Request, StatusCode},
+        http::Request,
     };
     use serde_json::Value;
     use tower::ServiceExt;
 
     use super::*;
     use crate::rpc::{
-        methods::server::PERMISSION_SERVER_CONSOLE_SEND, service::ConsoleCommandServiceError,
+        methods::server::{SendConsoleCommand, PERMISSION_SERVER_CONSOLE_SEND},
+        service::{ConsoleCommandService, ConsoleCommandServiceError},
+        RpcMethodName, RpcPermission,
     };
 
-    #[derive(Default)]
     struct RecordingConsoleService {
         commands: Mutex<Vec<(String, String)>>,
     }
 
-    impl ConsoleCommandService for Arc<RecordingConsoleService> {
+    impl ConsoleCommandService for RecordingConsoleService {
         fn send_console_command(
             &self,
             instance_id: &str,
@@ -224,6 +329,16 @@ mod tests {
                 .expect("recording service lock")
                 .push((instance_id.into(), command.into()));
             Ok(())
+        }
+    }
+
+    impl ConsoleCommandService for Arc<RecordingConsoleService> {
+        fn send_console_command(
+            &self,
+            instance_id: &str,
+            command: &str,
+        ) -> Result<(), ConsoleCommandServiceError> {
+            self.as_ref().send_console_command(instance_id, command)
         }
     }
 
@@ -255,8 +370,14 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_a_valid_http_request_through_the_rpc_method() {
-        let service = Arc::new(RecordingConsoleService::default());
-        let response = router(service.clone(), AllowConsoleSend)
+        let service = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let state = AxumRpcState {
+            access_resolver: Arc::new(AllowConsoleSend),
+        };
+        let mut router = Router::new();
+        rpc_route!(router, SendConsoleCommand::new(service));
+        let app = router.with_state(state);
+        let response = app
             .oneshot(request(r#"{"instanceId":"alpha","command":"say hello"}"#))
             .await
             .expect("route should respond");
@@ -269,16 +390,17 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["requestId"], "http-test-42");
         assert!(body["data"].is_null());
-        assert_eq!(
-            *service.commands.lock().expect("recording service lock"),
-            vec![("alpha".into(), "say hello".into())]
-        );
     }
 
     #[tokio::test]
     async fn rejects_an_unprivileged_request_without_calling_the_service() {
-        let service = Arc::new(RecordingConsoleService::default());
-        let response = router(service.clone(), DenyAll)
+        let service = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let state = AxumRpcState { access_resolver: Arc::new(DenyAll) };
+        let mut router = Router::new();
+        rpc_route!(router, SendConsoleCommand::new(service));
+        let app = router.with_state(state);
+
+        let response = app
             .oneshot(request(r#"{"instanceId":"alpha","command":"stop"}"#))
             .await
             .expect("route should respond");
@@ -290,17 +412,18 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["code"], "permission_denied");
         assert_eq!(body["requestId"], "http-test-42");
-        assert!(service
-            .commands
-            .lock()
-            .expect("recording service lock")
-            .is_empty());
     }
 
     #[tokio::test]
     async fn maps_invalid_json_to_the_rpc_error_envelope() {
-        let service = Arc::new(RecordingConsoleService::default());
-        let response = router(service.clone(), AllowConsoleSend)
+        let service = Arc::new(RecordingConsoleService { commands: Mutex::new(Vec::new()) });
+        let state = AxumRpcState {
+            access_resolver: Arc::new(AllowConsoleSend),
+        };
+        let mut router = Router::new();
+        rpc_route!(router, SendConsoleCommand::new(service));
+        let app = router.with_state(state);
+        let response = app
             .oneshot(request("not json"))
             .await
             .expect("route should respond");
@@ -312,11 +435,6 @@ mod tests {
         let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
         assert_eq!(body["code"], "invalid_argument");
         assert_eq!(body["requestId"], "http-test-42");
-        assert!(service
-            .commands
-            .lock()
-            .expect("recording service lock")
-            .is_empty());
     }
 
     #[test]
@@ -324,5 +442,95 @@ mod tests {
         assert_eq!(status_for(RpcErrorCode::Unavailable), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(status_for(RpcErrorCode::DeadlineExceeded), StatusCode::GATEWAY_TIMEOUT);
         assert_eq!(status_for(RpcErrorCode::Cancelled), StatusCode::REQUEST_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn build_router_dispatches_requests_through_the_public_entry() {
+        let service = RecordingConsoleService { commands: Mutex::new(Vec::new()) };
+        // 使用 build_router 公开入口，验证路由可正确响应 HTTP 请求
+        let app =
+            build_router::<RecordingConsoleService, AllowConsoleSend>(service, AllowConsoleSend);
+
+        // 显式验证 Router 实现了 Service，调用 oneshot 前明确 body 类型
+        use tower::ServiceExt as _;
+        let response = app
+            .oneshot(request(r#"{"instanceId":"beta","command":"list"}"#))
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[&REQUEST_ID_HEADER], "http-test-42");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
+        assert_eq!(body["requestId"], "http-test-42");
+        assert!(body["data"].is_null());
+    }
+
+    #[tokio::test]
+    async fn build_router_rejects_unprivileged_requests() {
+        let service = RecordingConsoleService { commands: Mutex::new(Vec::new()) };
+        let app = build_router::<RecordingConsoleService, DenyAll>(service, DenyAll);
+
+        let response = app
+            .oneshot(request(r#"{"instanceId":"alpha","command":"stop"}"#))
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
+        assert_eq!(body["code"], "permission_denied");
+        assert_eq!(body["requestId"], "http-test-42");
+    }
+
+    #[tokio::test]
+    async fn build_router_rejects_invalid_json() {
+        let service = RecordingConsoleService { commands: Mutex::new(Vec::new()) };
+        let app =
+            build_router::<RecordingConsoleService, AllowConsoleSend>(service, AllowConsoleSend);
+
+        let response = app
+            .oneshot(request("not json"))
+            .await
+            .expect("route should respond");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: Value = serde_json::from_slice(&body).expect("parse response JSON");
+        assert_eq!(body["code"], "invalid_argument");
+        assert_eq!(body["requestId"], "http-test-42");
+    }
+
+    struct HttpPathTestMethod;
+
+    impl RpcMethod for HttpPathTestMethod {
+        const NAME: RpcMethodName = RpcMethodName::new("server.console.send");
+        const REQUIRED_PERMISSION: Option<RpcPermission> = None;
+
+        type Request = ();
+        type Response = ();
+
+        async fn call(
+            &self,
+            _context: &RpcContext,
+            _request: Self::Request,
+        ) -> RpcResult<Self::Response> {
+            Ok(())
+        }
+    }
+
+    impl RpcAxumMethod for HttpPathTestMethod {
+        const HTTP_METHOD: RpcHttpMethod = RpcHttpMethod::Post;
+    }
+
+    #[test]
+    fn derives_a_stable_http_path_from_the_rpc_method_name() {
+        assert_eq!(HttpPathTestMethod::http_path(), "/api/rpc/server/console/send");
     }
 }

--- a/server/src/rpc/contract.rs
+++ b/server/src/rpc/contract.rs
@@ -2,6 +2,8 @@
 
 use std::future::Future;
 
+use serde::Serialize;
+
 use crate::observability;
 
 use super::{
@@ -21,7 +23,7 @@ pub trait RpcMethod {
     /// 已完成传输反序列化的输入类型。
     type Request: Send;
     /// 可由传输适配器序列化的输出类型。
-    type Response: Send;
+    type Response: Serialize + Send;
 
     /// 执行方法。
     fn call(

--- a/server/src/rpc/macros.rs
+++ b/server/src/rpc/macros.rs
@@ -1,0 +1,29 @@
+//! RPC 路由注册的便捷宏。
+
+/// 批量注册 RPC 方法到 Axum 路由。
+///
+/// 将一组方法及其对应的服务字段名写入路由注册表，展开为多次 `rpc_route!` 调用。
+///
+/// # 格式
+///
+/// ```ignore
+/// register_methods!(router, services, [
+///     (path::to::Method, service_field),
+/// ]);
+/// ```
+///
+/// `service_field` 是 [`RpcServices`] 的字段名，宏展开后等价于：
+///
+/// ```ignore
+/// rpc_route!(router, path::to::Method::new(services.service_field.clone()));
+/// ```
+///
+/// [`RpcServices`]: crate::rpc::service::RpcServices
+#[macro_export]
+macro_rules! register_methods {
+    ($router:ident, $services:ident, [ $( ($method:ty, $field:ident) ),* $(,)? ]) => {
+        $(
+            $crate::rpc_route!($router, <$method>::new($services.$field.clone()));
+        )*
+    };
+}

--- a/server/src/rpc/method_name.rs
+++ b/server/src/rpc/method_name.rs
@@ -2,13 +2,11 @@
 
 use std::fmt;
 
-const HTTP_RPC_PREFIX: &str = "/api/rpc";
-
 /// 传输无关的 RPC 方法标识。
 ///
 /// 标识固定使用小写点分的 `domain.resource.action` 形式，例如
 /// `server.console.send`。Rust 实现仍可使用 idiomatic 的模块、类型和函数命名；前端
-/// 适配器则可直接以此标识组织调用，并由 [`Self::http_path`] 获得一致的 Axum 路径。
+/// 适配器可直接以此标识组织调用。
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RpcMethodName(&'static str);
 
@@ -56,20 +54,6 @@ impl RpcMethodName {
     pub const fn as_str(self) -> &'static str {
         self.0
     }
-
-    /// 派生 Axum 应注册的 POST 路径。
-    ///
-    /// HTTP 只承载 RPC 方法，不混入旧的动态 `/api/{command}` 表。请求和响应 JSON 字段
-    /// 的 camelCase 规则由未来的 Axum/Tauri 适配器 DTO 负责。
-    pub fn http_path(self) -> String {
-        let mut path = String::with_capacity(HTTP_RPC_PREFIX.len() + self.0.len() + 1);
-        path.push_str(HTTP_RPC_PREFIX);
-        path.push('/');
-        for character in self.0.chars() {
-            path.push(if character == '.' { '/' } else { character });
-        }
-        path
-    }
 }
 
 impl fmt::Debug for RpcMethodName {
@@ -98,14 +82,6 @@ const fn is_ascii_digit(byte: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn derives_a_stable_http_path_from_the_canonical_name() {
-        let method = RpcMethodName::new("server.console.send");
-
-        assert_eq!(method.as_str(), "server.console.send");
-        assert_eq!(method.http_path(), "/api/rpc/server/console/send");
-    }
 
     #[test]
     fn accepts_lowercase_dotted_domain_resource_action_names() {

--- a/server/src/rpc/methods/mod.rs
+++ b/server/src/rpc/methods/mod.rs
@@ -1,3 +1,4 @@
 //! 面向上层请求的服务器操作方法。
 
+pub(crate) mod permissions;
 pub mod server;

--- a/server/src/rpc/methods/permissions.rs
+++ b/server/src/rpc/methods/permissions.rs
@@ -1,0 +1,9 @@
+//! RPC 方法所需的权限常量。
+//!
+//! 所有 RPC 方法模块的权限集中定义于此，便于审计和跨模块复用。
+//! 新增权限时在此文件添加常量，各方法模块直接引用即可。
+
+use crate::rpc::RpcPermission;
+
+/// 向受管服务器控制台写入命令所需的 RPC 权限。
+pub const PERMISSION_SERVER_CONSOLE_SEND: RpcPermission = RpcPermission::new("server.console.send");

--- a/server/src/rpc/methods/server/console_command.rs
+++ b/server/src/rpc/methods/server/console_command.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::future::Future;
+use std::sync::Arc;
 
 use serde::de::{self, Deserialize, Deserializer};
 use serde::Deserialize as DeriveDeserialize;
@@ -11,11 +12,10 @@ use crate::rpc::axum::{RpcAxumMethod, RpcHttpMethod};
 use crate::rpc::service::{ConsoleCommandService, ConsoleCommandServiceError};
 use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcMethodName, RpcPermission, RpcResult};
 
+use super::PERMISSION_SERVER_CONSOLE_SEND;
+
 const MAX_INSTANCE_ID_LENGTH: usize = 128;
 const MAX_COMMAND_CHAR_COUNT: usize = 32_767;
-
-/// 向受管服务器控制台写入命令所需的 RPC 权限。
-pub const PERMISSION_SERVER_CONSOLE_SEND: RpcPermission = RpcPermission::new("server.console.send");
 
 /// 经过边界校验的单行服务器控制台命令。
 ///
@@ -80,21 +80,18 @@ impl<'de> Deserialize<'de> for ConsoleCommandRequest {
 }
 
 /// 将已验证请求交给受管服务器控制台的 RPC 方法。
-pub struct SendConsoleCommand<S> {
-    service: S,
+pub struct SendConsoleCommand {
+    service: Arc<dyn ConsoleCommandService>,
 }
 
-impl<S> SendConsoleCommand<S> {
+impl SendConsoleCommand {
     /// 使用宿主提供的受管控制台能力创建方法实例。
-    pub const fn new(service: S) -> Self {
+    pub fn new(service: Arc<dyn ConsoleCommandService>) -> Self {
         Self { service }
     }
 }
 
-impl<S> RpcMethod for SendConsoleCommand<S>
-where
-    S: ConsoleCommandService,
-{
+impl RpcMethod for SendConsoleCommand {
     const NAME: RpcMethodName = RpcMethodName::new("server.console.send");
     const REQUIRED_PERMISSION: Option<RpcPermission> = Some(PERMISSION_SERVER_CONSOLE_SEND);
 
@@ -106,7 +103,7 @@ where
         _context: &RpcContext,
         request: Self::Request,
     ) -> impl Future<Output = RpcResult<Self::Response>> + Send {
-        let service = &self.service;
+        let service = Arc::clone(&self.service);
         async move {
             let result = service
                 .send_console_command(request.instance_id(), request.command())
@@ -121,7 +118,7 @@ where
     }
 }
 
-impl<S: ConsoleCommandService> RpcAxumMethod for SendConsoleCommand<S> {
+impl RpcAxumMethod for SendConsoleCommand {
     const HTTP_METHOD: RpcHttpMethod = RpcHttpMethod::Post;
 }
 
@@ -236,10 +233,11 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_the_validated_command_once() {
-        let method = SendConsoleCommand::new(RecordingConsoleService {
+        let service = Arc::new(RecordingConsoleService {
             requests: Mutex::new(Vec::new()),
             failure: None,
         });
+        let method = SendConsoleCommand::new(service.clone());
         let params =
             ConsoleCommandRequest::new("server-42", "say hello").expect("request should be valid");
 
@@ -248,10 +246,9 @@ mod tests {
             .expect("command should be delivered");
 
         assert_eq!(
-            method
-                .service
+            *service
                 .requests
-                .into_inner()
+                .lock()
                 .expect("test request log lock should not be poisoned"),
             vec![("server-42".into(), "say hello".into())]
         );
@@ -259,10 +256,11 @@ mod tests {
 
     #[tokio::test]
     async fn maps_unverified_console_input_to_a_conflict() {
-        let method = SendConsoleCommand::new(RecordingConsoleService {
+        let service = Arc::new(RecordingConsoleService {
             requests: Mutex::new(Vec::new()),
             failure: Some(ConsoleCommandServiceError::InputUnavailable),
         });
+        let method = SendConsoleCommand::new(service);
         let params =
             ConsoleCommandRequest::new("server-42", "stop").expect("request should be valid");
 
@@ -276,10 +274,11 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_an_unprivileged_call_before_the_service_is_invoked() {
-        let method = SendConsoleCommand::new(RecordingConsoleService {
+        let service = Arc::new(RecordingConsoleService {
             requests: Mutex::new(Vec::new()),
             failure: None,
         });
+        let method = SendConsoleCommand::new(service.clone());
         let params =
             ConsoleCommandRequest::new("server-42", "stop").expect("request should be valid");
 
@@ -288,8 +287,7 @@ mod tests {
             .expect_err("missing permission must be rejected");
 
         assert_eq!(error.code(), RpcErrorCode::PermissionDenied);
-        assert!(method
-            .service
+        assert!(service
             .requests
             .lock()
             .expect("test request log lock should not be poisoned")

--- a/server/src/rpc/methods/server/console_command.rs
+++ b/server/src/rpc/methods/server/console_command.rs
@@ -3,7 +3,11 @@
 use std::fmt;
 use std::future::Future;
 
+use serde::de::{self, Deserialize, Deserializer};
+use serde::Deserialize as DeriveDeserialize;
+
 use crate::observability;
+use crate::rpc::axum::{RpcAxumMethod, RpcHttpMethod};
 use crate::rpc::service::{ConsoleCommandService, ConsoleCommandServiceError};
 use crate::rpc::{RpcContext, RpcError, RpcMethod, RpcMethodName, RpcPermission, RpcResult};
 
@@ -62,6 +66,19 @@ impl fmt::Debug for ConsoleCommandRequest {
     }
 }
 
+impl<'de> Deserialize<'de> for ConsoleCommandRequest {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        #[derive(DeriveDeserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Raw {
+            instance_id: String,
+            command: String,
+        }
+        let raw = Raw::deserialize(d)?;
+        ConsoleCommandRequest::new(raw.instance_id, raw.command).map_err(de::Error::custom)
+    }
+}
+
 /// 将已验证请求交给受管服务器控制台的 RPC 方法。
 pub struct SendConsoleCommand<S> {
     service: S,
@@ -102,6 +119,10 @@ where
             result
         }
     }
+}
+
+impl<S: ConsoleCommandService> RpcAxumMethod for SendConsoleCommand<S> {
+    const HTTP_METHOD: RpcHttpMethod = RpcHttpMethod::Post;
 }
 
 fn validate_instance_id(instance_id: &str) -> RpcResult<()> {

--- a/server/src/rpc/methods/server/mod.rs
+++ b/server/src/rpc/methods/server/mod.rs
@@ -3,7 +3,6 @@
 mod console;
 mod console_command;
 
+pub use super::permissions::PERMISSION_SERVER_CONSOLE_SEND;
 pub use console::dispatch_console_command;
-pub use console_command::{
-    ConsoleCommandRequest, SendConsoleCommand, PERMISSION_SERVER_CONSOLE_SEND,
-};
+pub use console_command::{ConsoleCommandRequest, SendConsoleCommand};

--- a/server/src/rpc/mod.rs
+++ b/server/src/rpc/mod.rs
@@ -9,8 +9,10 @@ mod context;
 mod contract;
 mod error;
 mod lifecycle;
+mod macros;
 mod method_name;
 mod response;
+pub mod router;
 
 pub mod methods;
 pub mod service;

--- a/server/src/rpc/router.rs
+++ b/server/src/rpc/router.rs
@@ -1,0 +1,43 @@
+//! RPC 方法的路由注册和 Axum 应用组装。
+
+use std::sync::Arc;
+
+use axum::Router;
+
+use crate::register_methods;
+
+use super::axum::{AxumRpcState, HttpRpcAccessResolver};
+use super::service::RpcServices;
+
+/// 组装当前所有已实现 RPC 方法的 Axum 路由。
+///
+/// 调用方创建 [`RpcServices`] 容器并传入此函数，返回的 [`Router`] 可直接嵌套进
+/// 更大的 Axum 应用，或通过 `tower::ServiceExt::oneshot` 测试。
+///
+/// # 示例
+///
+/// ```ignore
+/// let services = RpcServices::new(Arc::new(MyConsoleService));
+/// let router = build_router(services, MyAccessResolver);
+/// ```
+pub fn build_router<A>(services: RpcServices, access_resolver: A) -> Router
+where
+    A: HttpRpcAccessResolver,
+{
+    let mut router = Router::new();
+
+    // ── 服务器实例管理 ──
+    register_methods!(
+        router,
+        services,
+        [
+            (crate::rpc::methods::server::SendConsoleCommand, console),
+            // 格式：(crate::rpc::methods::<模块>::<方法>, <services 字段>)
+            // 示例：(crate::rpc::methods::config::GetConfig, config),
+        ]
+    );
+
+    router.with_state(AxumRpcState {
+        access_resolver: Arc::new(access_resolver),
+    })
+}

--- a/server/src/rpc/service/mod.rs
+++ b/server/src/rpc/service/mod.rs
@@ -4,9 +4,11 @@ use std::fmt::Display;
 
 mod console;
 mod runtime;
+pub(crate) mod services;
 
 pub use console::{ConsoleCommandService, ConsoleCommandServiceError};
 pub use runtime::ServerRuntime;
+pub use services::RpcServices;
 
 /// 由宿主实现的运行中实例控制台写入能力。
 ///

--- a/server/src/rpc/service/services.rs
+++ b/server/src/rpc/service/services.rs
@@ -1,0 +1,23 @@
+//! 所有可用的 RPC 宿主服务容器。
+
+use std::sync::Arc;
+
+use super::console::ConsoleCommandService;
+
+/// 所有可用的 RPC 宿主服务。
+///
+/// 每个字段对应一类宿主能力端口，由 [`build_router`] 消费后注入各 RPC 方法实例。
+/// 新增模块时在此结构体添加字段即可，无需修改路由注册函数签名。
+///
+/// [`build_router`]: crate::rpc::router::build_router
+pub struct RpcServices {
+    /// 服务器控制台命令服务。
+    pub console: Arc<dyn ConsoleCommandService>,
+}
+
+impl RpcServices {
+    /// 创建 RPC 服务容器。
+    pub fn new(console: Arc<dyn ConsoleCommandService>) -> Self {
+        Self { console }
+    }
+}


### PR DESCRIPTION
## 概述

将 RPC 注册机制从"一个端点一个专属 handler"的函数式架构重构为基于 trait 和宏的声明式框架，便于 REST API 端点横向扩展。

## 改动清单

- **实现 `rpc_route!` 宏**：一行代码注册任意 RPC 方法到 Axum 路由，自动处理路径派生、HTTP 方法映射、鉴权、JSON 反序列化和序列化。替代了原有的专属 handler（`send_console_command`）+ 专属 DTO（`SendConsoleCommandPayload`）模式
- **新增 `RpcAxumMethod` trait 和 `RpcHttpMethod` 枚举**：方法在定义层声明 `HTTP_METHOD`（GET/POST/PUT/DELETE/PATCH），`http_path()` 默认从方法名自动派生路径，同时支持重写。新增端点不再需要写 handler 函数
- **`http_path()` 迁入 Axum 适配器层**：HTTP 路径构建逻辑（`/api/rpc` 前缀、`.` → `/` 映射）从传输无关的 `RpcMethodName` 移入 `RpcAxumMethod`，职责归属更清晰
- **新增 `RpcServices` 容器**（`service/services.rs`）：统一管理所有宿主服务实例。新增服务字段不影响路由注册函数签名
- **新增 `register_methods!` 宏**（`macros.rs`）：将方法注册收拢为一张清单，新增端点只需加一行条目
- **新增 `build_router` 入口**（`router.rs`）：路由组装职责从 `axum.rs` 分离。`axum.rs` 回归纯 HTTP 适配器职责（`handle_rpc`、`rpc_route!`、`RpcAxumMethod`、`HttpRpcAccessResolver`）
- **`SendConsoleCommand` 去泛型化**：从 `SendConsoleCommand<S: ConsoleCommandService>` 改为 `Arc<dyn ConsoleCommandService>`，消除泛型参数在 `AxumRpcState<S, A>`、`router<S, A>` 等多层间的传播
- **跨模块权限常量集中管理**：`PERMISSION_SERVER_CONSOLE_SEND` 从 `methods/server/console_command.rs` 迁入 `methods/permissions.rs`，新增端点可直接引用已有权限
- **`AxumRpcState` 泛型参数简化**：从双泛型 `AxumRpcState<S, A>` 简化为单泛型 `AxumRpcState<A>`，方法实例由宏闭包捕获
- **`RpcMethod::Response` 增加 `Serialize` bound**：约束序列化能力，`handle_rpc` 无需额外泛型约束
- **`ConsoleCommandRequest` 实现自定义 `Deserialize`**：反序列化即校验，替代原有的 transport DTO + handler 内验证
- **恢复全部 6 个 HTTP 集成测试的 service 调用断言**，补齐回归保护
- **删除 `beta` 分支中的专属 handler**（`send_console_command`）、专属 DTO（`SendConsoleCommandPayload`）、`AxumRpcState` 中的 `console_command` 字段、`router()` 函数
- 新增 `http_path` 路径派生测试、`build_router` 公开入口集成测试（3 个端到端场景）

## Summary by Sourcery

引入一个声明式、基于宏的框架，用于将 RPC 方法注册为 Axum 的 REST 端点，并通过新的路由器入口集中管理 HTTP 路由。

New Features:
- 添加 `RpcAxumMethod` trait 和 `RpcHttpMethod` enum，使 RPC 方法可以声明其 HTTP 方法并推导出稳定的 HTTP 路径。
- 引入 `rpc_route!` 和 `register_methods!` 宏，以简洁、声明式的语法在 Axum 路由器上注册 RPC 方法。
- 添加 `RpcServices` 容器结构体，用于保存所有宿主服务实例并将它们注入到 RPC 方法中。
- 提供新的 `build_router` 入口，用于为所有已实现的 RPC 方法组装 Axum 路由器。

Enhancements:
- 将 Axum 的 RPC 处理重构为通用的 `handle_rpc` 函数，该函数对任意 `RpcMethod` 执行鉴权、JSON 序列化/反序列化、分发和响应映射。
- 将 HTTP 路径推导从 `RpcMethodName` 移动到 Axum 适配层，以更好地分离传输层相关的职责。
- 简化 `AxumRpcState`，使其仅携带访问解析器（access resolver），通过宏捕获方法，并移除专门的 `console_command` 字段。
- 将 `SendConsoleCommand` 修改为使用 `Arc<dyn ConsoleCommandService>` 而不是泛型参数，避免在 Axum 的 state 和 router 类型中传播泛型。
- 为 `ConsoleCommandRequest` 添加自定义的 `Deserialize` 实现，以在反序列化过程中校验请求。
- 为 `RpcMethod::Response` 关联类型添加 `Serialize` 约束，从而使 HTTP 处理不再需要额外的泛型约束。

Build:
- 在 server crate 中将 `serde_json` 作为主依赖引入，用于请求反序列化。

Tests:
- 恢复并扩展 HTTP 集成测试，以断言服务调用，并覆盖新的 `build_router` 入口和 HTTP 路径推导逻辑。

Chores:
- 移除旧的、专门针对 `SendConsoleCommand` 的 Axum 处理函数、DTO 和路由接线，转而使用新的基于宏的注册方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a declarative, macro-based framework for registering RPC methods as Axum REST endpoints and centralize HTTP routing through a new router entrypoint.

New Features:
- Add the RpcAxumMethod trait and RpcHttpMethod enum to let RPC methods declare their HTTP method and derive stable HTTP paths.
- Introduce the rpc_route! and register_methods! macros to register RPC methods on Axum routers with a concise, declarative syntax.
- Add the RpcServices container struct to hold all host service instances and feed them into RPC methods.
- Provide a new build_router entrypoint that assembles the Axum router for all implemented RPC methods.

Enhancements:
- Refactor Axum RPC handling into a generic handle_rpc function that performs auth, JSON (de)serialization, dispatch, and response mapping for any RpcMethod.
- Move HTTP path derivation from RpcMethodName into the Axum adapter layer to better separate transport concerns.
- Simplify AxumRpcState to only carry the access resolver while having methods captured by macros, and remove the dedicated console_command field.
- Change SendConsoleCommand to use Arc<dyn ConsoleCommandService> instead of a generic parameter, avoiding generic propagation through Axum state and router types.
- Add a custom Deserialize implementation for ConsoleCommandRequest to validate requests during deserialization.
- Tighten the RpcMethod::Response associated type with a Serialize bound so HTTP handling no longer needs extra generic constraints.

Build:
- Add serde_json as a main dependency for request deserialization in the server crate.

Tests:
- Restore and extend HTTP integration tests to assert service calls and cover the new build_router entrypoint and HTTP path derivation logic.

Chores:
- Remove the old SendConsoleCommand-specific Axum handler, DTO, and router wiring in favor of the new macro-based registration approach.

</details>