### PR TITLE
refactor(infra): 迁移path.rs部分职责到location.rs,优化代码质量

### DIFF
--- a/crates/extra/src/config/mod.rs
+++ b/crates/extra/src/config/mod.rs
@@ -8,7 +8,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-pub use sealantern_infra::fs::{get_app_data_dir, get_or_create_app_data_dir};
+pub use sealantern_infra::platform::{get_app_data_dir, get_or_create_app_data_dir};
 
 /// 应用程序主配置
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/infra/src/archive/unzip.rs
+++ b/crates/infra/src/archive/unzip.rs
@@ -113,15 +113,15 @@ fn extract_zip_inner(
         let relative = safe_entry_path(archive_path, &entry_name)?;
 
         if entry.is_dir() {
-            ensure_directory(&root, relative.as_path(), destination)?;
+            ensure_directory(&root, &relative, destination)?;
             summary.directories += 1;
             continue;
         }
 
-        ensure_parent_dirs(&root, relative.as_path(), destination)?;
-        let output_path = destination.join(relative.as_path());
+        ensure_parent_dirs(&root, &relative, destination)?;
+        let output_path = destination.join(&relative);
         let mut output = root
-            .open_with(relative.as_path(), OpenOptions::new().write(true).create_new(true))
+            .open_with(&relative, OpenOptions::new().write(true).create_new(true))
             .map_err(|error| ArchiveError::io("create ZIP entry file", &output_path, error))?;
         let copied = copy_entry_with_limits(
             &mut entry,

--- a/crates/infra/src/archive/zipper.rs
+++ b/crates/infra/src/archive/zipper.rs
@@ -115,7 +115,7 @@ fn write_archive(
             .read_dir(if directory.as_os_str().is_empty() {
                 Path::new(".")
             } else {
-                directory.as_path()
+                &directory
             })
             .map_err(|error| {
                 ArchiveError::io("read ZIP source directory", source_path.join(&directory), error)

--- a/crates/infra/src/fs/atomic.rs
+++ b/crates/infra/src/fs/atomic.rs
@@ -43,19 +43,16 @@ pub(crate) fn write_atomic_in(
     path: &SafeRelativePath,
     contents: &[u8],
 ) -> Result<(), FsError> {
-    let parent = path.as_path().parent().unwrap_or_else(|| Path::new(""));
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
     if !parent.as_os_str().is_empty() {
         root.create_dir_all(parent)
             .map_err(|error| FsError::io("create cache directory", path.as_path(), error))?;
     }
 
-    let file_name = path
-        .as_path()
-        .file_name()
-        .ok_or_else(|| FsError::InvalidPath {
-            path: path.as_path().to_path_buf(),
-            reason: "destination has no file name",
-        })?;
+    let file_name = path.file_name().ok_or_else(|| FsError::InvalidPath {
+        path: path.to_path_buf(),
+        reason: "destination has no file name",
+    })?;
     let temporary = parent.join(format!(".{}.{}.tmp", file_name.to_string_lossy(), Uuid::new_v4()));
 
     let write_result = (|| {
@@ -68,10 +65,9 @@ pub(crate) fn write_atomic_in(
             .map_err(|error| FsError::io("write cache temporary file", &temporary, error))?;
         file.sync_all()
             .map_err(|error| FsError::io("sync cache temporary file", &temporary, error))?;
-        root.rename(&temporary, root, path.as_path())
-            .map_err(|error| {
-                FsError::io("atomically replace cache entry", path.as_path(), error)
-            })?;
+        root.rename(&temporary, root, path).map_err(|error| {
+            FsError::io("atomically replace cache entry", path.as_path(), error)
+        })?;
         Ok(())
     })();
     if write_result.is_err() {

--- a/crates/infra/src/fs/cache.rs
+++ b/crates/infra/src/fs/cache.rs
@@ -50,7 +50,7 @@ impl FileCache {
         let root = Arc::clone(&self.root);
         let key = SafeRelativePath::parse(key)?;
         let bytes = bytes.to_vec();
-        let path = self.root_path.join(key.as_path());
+        let path = self.root_path.join(&key);
         let result =
             run_blocking("write cache entry", move || write_atomic_in(&root, &key, &bytes)).await;
         trace_cache_result("write cache entry", &path, &result);
@@ -65,7 +65,7 @@ impl FileCache {
     ) -> Result<Option<Vec<u8>>, FsError> {
         let root = Arc::clone(&self.root);
         let key = SafeRelativePath::parse(key)?;
-        let path = self.root_path.join(key.as_path());
+        let path = self.root_path.join(&key);
         let result =
             run_blocking("read cache entry", move || read_optional(&root, &key, limit)).await;
         trace_cache_result("read cache entry", &path, &result);
@@ -81,9 +81,9 @@ impl FileCache {
     ) -> Result<Option<Vec<u8>>, FsError> {
         let root = Arc::clone(&self.root);
         let key = SafeRelativePath::parse(key)?;
-        let path = self.root_path.join(key.as_path());
+        let path = self.root_path.join(&key);
         let result = run_blocking("read fresh cache entry", move || {
-            let metadata = match root.symlink_metadata(key.as_path()) {
+            let metadata = match root.symlink_metadata(&key) {
                 Ok(metadata) => metadata,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
                 Err(error) => {
@@ -92,7 +92,7 @@ impl FileCache {
             };
             if metadata.file_type().is_symlink() {
                 return Err(FsError::InvalidPath {
-                    path: key.as_path().to_path_buf(),
+                    path: key.to_path_buf(),
                     reason: "cache entry must not be a symbolic link",
                 });
             }
@@ -147,26 +147,26 @@ fn read_optional(
     key: &SafeRelativePath,
     limit: DataLimit,
 ) -> Result<Option<Vec<u8>>, FsError> {
-    let metadata = match root.symlink_metadata(key.as_path()) {
+    let metadata = match root.symlink_metadata(&key) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(FsError::io("read cache entry metadata", key.as_path(), error)),
     };
     if metadata.file_type().is_symlink() {
         return Err(FsError::InvalidPath {
-            path: key.as_path().to_path_buf(),
+            path: key.to_path_buf(),
             reason: "cache entry must not be a symbolic link",
         });
     }
     if !metadata.file_type().is_file() {
         return Err(FsError::InvalidPath {
-            path: key.as_path().to_path_buf(),
+            path: key.to_path_buf(),
             reason: "cache entry is not a regular file",
         });
     }
 
     let file = root
-        .open(key.as_path())
+        .open(&key)
         .map_err(|error| FsError::io("open cache entry", key.as_path(), error))?;
     let mut reader = file.take((limit.max_bytes() as u64).saturating_add(1));
     let mut bytes = Vec::new();
@@ -175,7 +175,7 @@ fn read_optional(
         .map_err(|error| FsError::io("read cache entry", key.as_path(), error))?;
     if bytes.len() > limit.max_bytes() {
         return Err(FsError::DataLimitExceeded {
-            path: key.as_path().to_path_buf(),
+            path: key.to_path_buf(),
             limit: limit.max_bytes(),
             observed_at_least: bytes.len(),
         });

--- a/crates/infra/src/fs/cache.rs
+++ b/crates/infra/src/fs/cache.rs
@@ -147,7 +147,7 @@ fn read_optional(
     key: &SafeRelativePath,
     limit: DataLimit,
 ) -> Result<Option<Vec<u8>>, FsError> {
-    let metadata = match root.symlink_metadata(&key) {
+    let metadata = match root.symlink_metadata(key) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(FsError::io("read cache entry metadata", key.as_path(), error)),
@@ -166,7 +166,7 @@ fn read_optional(
     }
 
     let file = root
-        .open(&key)
+        .open(key)
         .map_err(|error| FsError::io("open cache entry", key.as_path(), error))?;
     let mut reader = file.take((limit.max_bytes() as u64).saturating_add(1));
     let mut bytes = Vec::new();

--- a/crates/infra/src/fs/mod.rs
+++ b/crates/infra/src/fs/mod.rs
@@ -1,4 +1,4 @@
-//! 文件系统基础设施原语。
+//! 文件系统基础组件。
 //!
 //! 该模块有意将策略与基础设施层分离。它
 //! 提供安全的路径处理、有界读取、原子写入、持久化
@@ -26,7 +26,7 @@ pub use error::FsError;
 pub use hash::{sha256_file, sha256_hex};
 pub use lock::FileLock;
 pub use metadata::{describe, file_size, FileMetadata};
-pub use path::{get_app_data_dir, get_or_create_app_data_dir, SafeRelativePath};
+pub use path::SafeRelativePath;
 pub use persist::{
     read_json, read_toml, read_yaml, write_json_atomic, write_toml_atomic, write_yaml_atomic,
 };

--- a/crates/infra/src/fs/path.rs
+++ b/crates/infra/src/fs/path.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use std::path::{Component, Path, PathBuf};
 
 use super::FsError;
@@ -32,152 +33,22 @@ impl SafeRelativePath {
 
 impl AsRef<Path> for SafeRelativePath {
     fn as_ref(&self) -> &Path {
-        self.as_path()
+        &self.0
+    }
+}
+
+/// 允许直接调用 `Path` 的方法（如 `parent()`、`join()`、`file_name()`），
+/// 无需手动写 `.as_path()`。
+impl Deref for SafeRelativePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.0
     }
 }
 
 fn invalid(path: &Path, reason: &'static str) -> FsError {
     FsError::InvalidPath { path: path.to_path_buf(), reason }
-}
-
-/// 检查是否为 MSI 安装（程序安装在 Program Files 目录）
-#[cfg(target_os = "windows")]
-fn is_msi_installation() -> bool {
-    // 检查可执行文件是否在 Program Files 目录
-    if let Ok(exe_path) = std::env::current_exe() {
-        if let Some(parent) = exe_path.parent() {
-            let exe_str = parent.to_string_lossy().to_lowercase();
-            // 检查路径是否包含 Program Files
-            if exe_str.contains(r"\program files\") {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// 获取应用程序数据目录
-///
-/// 根据不同平台和安装方式返回合适的存储路径：
-/// - Docker 环境：./data
-/// - Windows MSI 安装：%AppData%\SeaLantern
-/// - Windows 便携版：程序所在目录
-/// - macOS: ~/Library/Application Support/SeaLantern
-/// - Linux: ~/.local/share/sea-lantern
-///
-/// 这个函数确保 MSI 安装的应用将数据存储在用户目录而非安装目录
-pub fn get_app_data_dir() -> PathBuf {
-    // Docker 环境检测 - 优先返回容器内数据目录
-    let is_docker = std::path::Path::new("/.dockerenv").exists();
-    eprintln!("[DEBUG] path.rs: /.dockerenv exists = {}", is_docker);
-    if is_docker {
-        let docker_path = PathBuf::from("./data");
-        eprintln!("[DEBUG] path.rs: Docker mode, returning path: {:?}", docker_path);
-        return docker_path;
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        // Windows: 检查是否为 MSI 安装
-        if is_msi_installation() {
-            // MSI 安装：使用 %AppData%
-            if let Some(data_dir) = dirs::data_dir() {
-                eprintln!(
-                    "[DEBUG] path.rs: Windows MSI mode, returning path: {:?}",
-                    data_dir.join("SeaLantern")
-                );
-                return data_dir.join("SeaLantern");
-            }
-            // 回退到主目录
-            if let Some(home_dir) = dirs::home_dir() {
-                eprintln!(
-                    "[DEBUG] path.rs: Windows fallback to home, returning path: {:?}",
-                    home_dir.join(".sea-lantern")
-                );
-                return home_dir.join(".sea-lantern");
-            }
-        }
-        // 便携版或其他安装：使用程序所在目录
-        if let Ok(exe_path) = std::env::current_exe() {
-            if let Some(exe_dir) = exe_path.parent() {
-                eprintln!("[DEBUG] path.rs: Windows portable mode, returning path: {:?}", exe_dir);
-                return exe_dir.to_path_buf();
-            }
-        }
-        // 最后的回退方案
-        if let Some(home_dir) = dirs::home_dir() {
-            eprintln!(
-                "[DEBUG] path.rs: Windows final fallback, returning path: {:?}",
-                home_dir.join(".sea-lantern")
-            );
-            return home_dir.join(".sea-lantern");
-        }
-        eprintln!("[DEBUG] path.rs: Windows ultimate fallback, returning path: .");
-        PathBuf::from(".")
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        // macOS: ~/Library/Application Support/SeaLantern
-        if let Some(data_dir) = dirs::data_dir() {
-            eprintln!(
-                "[DEBUG] path.rs: macOS mode, returning path: {:?}",
-                data_dir.join("SeaLantern")
-            );
-            return data_dir.join("SeaLantern");
-        }
-        if let Some(home_dir) = dirs::home_dir() {
-            eprintln!(
-                "[DEBUG] path.rs: macOS fallback, returning path: {:?}",
-                home_dir
-                    .join("Library")
-                    .join("Application Support")
-                    .join("SeaLantern")
-            );
-            return home_dir
-                .join("Library")
-                .join("Application Support")
-                .join("SeaLantern");
-        }
-        eprintln!("[DEBUG] path.rs: macOS ultimate fallback, returning path: .");
-        PathBuf::from(".")
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        // Linux: ~/.local/share/sea-lantern
-        if let Some(data_dir) = dirs::data_dir() {
-            eprintln!(
-                "[DEBUG] path.rs: Linux mode, returning path: {:?}",
-                data_dir.join("sea-lantern")
-            );
-            return data_dir.join("sea-lantern");
-        }
-        if let Some(home_dir) = dirs::home_dir() {
-            eprintln!(
-                "[DEBUG] path.rs: Linux fallback, returning path: {:?}",
-                home_dir.join(".sea-lantern")
-            );
-            return home_dir.join(".sea-lantern");
-        }
-        eprintln!("[DEBUG] path.rs: Linux ultimate fallback, returning path: .");
-        PathBuf::from(".")
-    }
-}
-
-/// 获取应用数据目录的字符串表示，如果目录不存在则创建
-pub fn get_or_create_app_data_dir() -> String {
-    let data_dir = get_app_data_dir();
-    eprintln!("[DEBUG] path.rs: get_or_create_app_data_dir called, path: {:?}", data_dir);
-    // 创建目录（如果不存在）
-    if let Err(e) = std::fs::create_dir_all(&data_dir) {
-        eprintln!("警告：无法创建数据目录：{}", e);
-    } else {
-        eprintln!("[DEBUG] path.rs: Directory created/verified successfully");
-    }
-    let result = data_dir.to_string_lossy().to_string();
-    eprintln!("[DEBUG] path.rs: Returning data dir string: {}", result);
-    result
 }
 
 #[cfg(test)]
@@ -199,21 +70,5 @@ mod tests {
         for path in ["../secret", "/etc/passwd", "folder\\\\file", "."] {
             assert!(SafeRelativePath::parse(path).is_err(), "{path} should be rejected");
         }
-    }
-
-    #[test]
-    fn test_get_app_data_dir_not_empty() {
-        let dir = get_app_data_dir();
-        assert!(!dir.as_path().as_os_str().is_empty());
-    }
-
-    #[test]
-    fn test_get_or_create_app_data_dir() {
-        let dir_str = get_or_create_app_data_dir();
-        assert!(!dir_str.is_empty());
-        // 验证目录存在
-        let path = PathBuf::from(&dir_str);
-        assert!(path.exists());
-        assert!(path.is_dir());
     }
 }

--- a/crates/infra/src/observability.rs
+++ b/crates/infra/src/observability.rs
@@ -44,6 +44,20 @@ pub fn platform_operation_failed(operation: &str, error: &dyn Display) {
     );
 }
 
+/// Event: 应用数据目录创建失败。
+pub const EVENT_APP_DATA_DIR_CREATE_FAILED: &str = "app_data_dir_create_failed";
+
+/// 记录应用数据目录创建失败，不暴露完整目录结构。
+pub fn app_data_dir_create_failed(path: &std::path::Path, error: &dyn Display) {
+    tracing::warn!(
+        target: PLATFORM_TARGET,
+        event_name = EVENT_APP_DATA_DIR_CREATE_FAILED,
+        path = %path.display(),
+        error = %error,
+        "application data directory creation failed"
+    );
+}
+
 // -- 文件系统层 --
 
 /// 文件系统基础设施模块的 tracing 目标。

--- a/crates/infra/src/platform/locations.rs
+++ b/crates/infra/src/platform/locations.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use crate::observability;
 
 /// 标准安装的应用目录名（macOS 和 Windows MSI 安装使用）。
+#[cfg(target_os = "windows")]
 const APP_DIR_NAME: &str = "SeaLantern";
 
 /// Linux 平台的应用目录名（遵循 XDG 规范使用小写）。

--- a/crates/infra/src/platform/locations.rs
+++ b/crates/infra/src/platform/locations.rs
@@ -1,0 +1,136 @@
+//! 跨平台的应用程序目录位置策略。
+//!
+//! 本模块决定"应用程序的数据、缓存、配置等文件应该存放在哪里"——这是平台感知问题，
+//! 不是数据持久化问题。`persistence` 等消费者通过本模块获取目录路径，不自行推导
+//! 路径规则。
+//!
+//! 路径优先级因平台而异（Docker → MSI → 便携版 → 标准目录），各平台内部的
+//! fallback 链通过 `Option::or_else` 表达，优先级由调用顺序决定。
+
+use std::path::PathBuf;
+
+use crate::observability;
+
+/// 标准安装的应用目录名（macOS 和 Windows MSI 安装使用）。
+const APP_DIR_NAME: &str = "SeaLantern";
+
+/// Linux 平台的应用目录名（遵循 XDG 规范使用小写）。
+#[cfg(target_os = "linux")]
+const APP_DIR_NAME_LOWERCASE: &str = "sea-lantern";
+
+/// 回退方案使用的隐藏目录名（Linux `$HOME` 回退、Windows 非 MSI 最终回退）。
+const APP_DIR_HIDDEN: &str = ".sea-lantern";
+
+/// Docker 容器内的数据目录。
+const APP_DOCKER_DATA_DIR: &str = "./data";
+
+/// 检查是否为 MSI 安装（程序安装在 Program Files 目录）。
+#[cfg(target_os = "windows")]
+fn is_msi_installation() -> bool {
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(parent) = exe_path.parent() {
+            let exe_str = parent.to_string_lossy().to_lowercase();
+            if exe_str.contains(r"\program files\") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// 获取应用程序数据目录。
+///
+/// 根据不同平台和运行环境返回合适的存储路径：
+/// - Docker：`./data`
+/// - Windows MSI 安装：`%APPDATA%\SeaLantern`
+/// - Windows 便携版：程序所在目录
+/// - macOS：`~/Library/Application Support/SeaLantern`
+/// - Linux：`~/.local/share/sea-lantern`
+pub fn get_app_data_dir() -> PathBuf {
+    if std::path::Path::new("/.dockerenv").exists() {
+        return PathBuf::from(APP_DOCKER_DATA_DIR);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if is_msi_installation() {
+            if let Some(dir) = dirs::data_dir()
+                .map(|d| d.join(APP_DIR_NAME))
+                .or_else(|| dirs::home_dir().map(|h| h.join(APP_DIR_HIDDEN)))
+            {
+                return dir;
+            }
+        }
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+            .or_else(|| dirs::home_dir().map(|h| h.join(APP_DIR_HIDDEN)))
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        dirs::data_dir()
+            .map(|d| d.join(APP_DIR_NAME))
+            .or_else(|| {
+                dirs::home_dir().map(|h| {
+                    h.join("Library")
+                        .join("Application Support")
+                        .join(APP_DIR_NAME)
+                })
+            })
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        dirs::data_dir()
+            .map(|d| d.join(APP_DIR_NAME_LOWERCASE))
+            .or_else(|| dirs::home_dir().map(|h| h.join(APP_DIR_HIDDEN)))
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+}
+
+/// 获取应用数据目录，如果不存在则创建。
+///
+/// 如果目录创建失败，仅记录警告不阻断流程——调用方仍可拿到路径自行处理。
+pub fn get_or_create_app_data_dir() -> String {
+    let data_dir = get_app_data_dir();
+    if let Err(e) = std::fs::create_dir_all(&data_dir) {
+        observability::app_data_dir_create_failed(&data_dir, &e);
+    }
+    data_dir.to_string_lossy().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_data_dir_is_not_empty() {
+        let dir = get_app_data_dir();
+        assert!(!dir.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn test_app_data_dir_ends_with_app_name() {
+        let dir = get_app_data_dir();
+        let file_name = dir.file_name().expect("path should have a file name");
+        let name = file_name.to_string_lossy();
+
+        // 预期路径末端包含应用目录名（SeaLantern / sea-lantern / .sea-lantern）。
+        // Windows 便携版返回 exe 所在目录，不一定以应用名结尾，跳过。
+        if cfg!(not(target_os = "windows")) {
+            assert!(
+                name.contains("SeaLantern") || name.contains("sea-lantern"),
+                "expected app directory name in path, got: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_or_create_app_data_dir_returns_non_empty() {
+        let dir_str = get_or_create_app_data_dir();
+        assert!(!dir_str.is_empty());
+    }
+}

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -1,12 +1,13 @@
 //! 跨平台的系统级基础设施。
 //!
-//! 此模块只封装可移植的系统交互原语。应用策略、配置持久化和 UI 授权流程
+//! 此模块只封装可移植的系统交互基础组件。应用策略、配置持久化和 UI 授权流程
 //! 由上层负责；尤其是 CA 证书仅供 HTTP 客户端使用，不会修改操作系统信任库。
 
 mod certificate;
 mod elevation;
 mod environment;
 mod error;
+mod locations;
 mod system;
 
 pub use certificate::{
@@ -15,4 +16,5 @@ pub use certificate::{
 pub use elevation::{is_elevated, request_elevation, ElevationLaunch};
 pub use environment::{Environment, EnvironmentError};
 pub use error::PlatformError;
+pub use locations::{get_app_data_dir, get_or_create_app_data_dir};
 pub use system::{collect_system_info, SystemInfo};

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -28,7 +28,7 @@ fn is_msi_installation() -> bool {
 ///
 /// 根据不同平台和安装方式返回合适的存储路径：
 /// - Docker 环境：./data
-/// - Windows MSI 安装：%AppData%\Sea Lantern
+/// - Windows MSI 安装：%AppData%\SeaLantern
 /// - Windows 便携版：程序所在目录
 /// - macOS: ~/Library/Application Support/Sea Lantern
 /// - Linux: ~/.local/share/sea-lantern


### PR DESCRIPTION
- `SafeRelativePath` 实现 `Deref<Target = Path>`，允许直接调用 `parent()`、`join()`、`file_name()` 等 Path 方法，无需手动 `.as_path()`；保留显式 `as_path()` 方法向后兼容
- `AsRef<Path>` 实现改为直接引用 `&self.0`，消除间接调用
- 清理 15+ 处 `.as_path()` 冗余调用：
  - `atomic.rs`：`path.as_path().parent()` → `path.parent()`
  - `cache.rs`：`key.as_path()` 作为 `join`/`symlink_metadata`/`open` 参数 → `&key`
  - `unzip.rs`、`zipper.rs`：传参简化为 `&relative`、`&directory`
  - `cache.rs`、`atomic.rs`：`as_path().to_path_buf()` → `to_path_buf()`
- 迁移 `path.rs` 至 `location.rs` ， 重命名 `platform/path.rs` → `platform/locations.rs`， 解决与 `fs/path.rs` 命名重复问题（`path` 管路径安全，`locations` 管位置策略）
- 新增 `platform::locations` 模块文档 + 3 个单元测试
- 新增 `observability::app_data_dir_create_failed` 事件， `locations::get_or_create_app_data_dir` 改用标准事件记录

---
## Summary by Sourcery

将应用数据目录的处理重构为按平台划分的专用位置，并简化在文件系统和归档代码中使用 SafeRelativePath 的方式。

新功能：
- 暴露 `platform::locations` 模块，提供跨平台的应用数据目录策略。
- 为创建应用数据目录失败情况添加可观测事件和辅助方法。

改进：
- 让 `SafeRelativePath` 解引用为 `Path`，并简化其 `AsRef<Path>` 实现，以去除多余的 `as_path()` 调用。
- 更新文件系统、缓存、原子写入、解压和压缩相关代码，使其在路径操作中直接使用 `SafeRelativePath`。
- 重命名并重组与路径相关的模块，将安全路径处理与平台位置策略分离，并相应调整对外的重新导出。

文档：
- 为 `platform::locations` 添加模块级文档，并调整现有文件系统和平台模块文档以反映新的结构。

测试：
- 为 `platform::locations` 中应用数据目录行为添加单元测试，并为 `get_or_create_app_data_dir` 返回非空路径的行为添加测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor application data directory handling into platform-specific locations and simplify SafeRelativePath usage across filesystem and archive code.

New Features:
- Expose platform::locations module providing cross-platform application data directory strategies.
- Add observability event and helper for failed application data directory creation.

Enhancements:
- Make SafeRelativePath deref to Path and streamline its AsRef<Path> implementation to remove redundant as_path() calls.
- Update filesystem, cache, atomic write, unzip, and zipper code to use SafeRelativePath directly for path operations.
- Rename and reorganize path-related modules to separate safe path handling from platform location strategy, and adjust public re-exports accordingly.

Documentation:
- Add module-level documentation for platform::locations and adjust existing filesystem and platform module docs to reflect the new structure.

Tests:
- Add unit tests for platform::locations app data directory behavior and for get_or_create_app_data_dir returning non-empty paths.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将应用数据目录的处理重构为按平台划分的专用位置，并简化在文件系统和归档代码中使用 SafeRelativePath 的方式。

新功能：
- 暴露 `platform::locations` 模块，提供跨平台的应用数据目录策略。
- 为创建应用数据目录失败情况添加可观测事件和辅助方法。

改进：
- 让 `SafeRelativePath` 解引用为 `Path`，并简化其 `AsRef<Path>` 实现，以去除多余的 `as_path()` 调用。
- 更新文件系统、缓存、原子写入、解压和压缩相关代码，使其在路径操作中直接使用 `SafeRelativePath`。
- 重命名并重组与路径相关的模块，将安全路径处理与平台位置策略分离，并相应调整对外的重新导出。

文档：
- 为 `platform::locations` 添加模块级文档，并调整现有文件系统和平台模块文档以反映新的结构。

测试：
- 为 `platform::locations` 中应用数据目录行为添加单元测试，并为 `get_or_create_app_data_dir` 返回非空路径的行为添加测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor application data directory handling into platform-specific locations and simplify SafeRelativePath usage across filesystem and archive code.

New Features:
- Expose platform::locations module providing cross-platform application data directory strategies.
- Add observability event and helper for failed application data directory creation.

Enhancements:
- Make SafeRelativePath deref to Path and streamline its AsRef<Path> implementation to remove redundant as_path() calls.
- Update filesystem, cache, atomic write, unzip, and zipper code to use SafeRelativePath directly for path operations.
- Rename and reorganize path-related modules to separate safe path handling from platform location strategy, and adjust public re-exports accordingly.

Documentation:
- Add module-level documentation for platform::locations and adjust existing filesystem and platform module docs to reflect the new structure.

Tests:
- Add unit tests for platform::locations app data directory behavior and for get_or_create_app_data_dir returning non-empty paths.

</details>

</details>

## Summary by Sourcery

通过引入以平台为中心的 `locations` 模块，并简化在文件系统和归档代码中对 `SafeRelativePath` 的使用，重构路径处理和应用数据目录策略。

新特性：
- 暴露 `platform::locations` API，用于在各个平台上解析并创建应用数据目录。
- 为应用数据目录创建失败新增专用的可观测性事件。

增强改进：
- 让 `SafeRelativePath` 实现对 `Path` 的解引用，并简化其 `AsRef` 实现，从而在文件系统、缓存、原子 IO、解压（unzip）和压缩（zipper）逻辑中去除多余的 `as_path()` 调用。
- 通过将应用数据目录逻辑从 `fs::path` 移动到 `platform::locations`，并相应更新公开的再导出，将安全路径处理与平台位置策略分离。

文档：
- 为 `platform::locations` 添加模块级文档，并调整文件系统和平台模块文档以反映新的职责划分。

测试：
- 为 `platform::locations` 添加单元测试，覆盖应用数据目录结构以及 `get_or_create_app_data_dir` 行为，同时移除旧的基于 `fs::path` 的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor path handling and application data directory strategy by introducing a platform-focused locations module and simplifying SafeRelativePath usage across filesystem and archive code.

New Features:
- Expose platform::locations APIs for resolving and creating application data directories across platforms.
- Add a dedicated observability event for failed application data directory creation.

Enhancements:
- Make SafeRelativePath deref to Path and streamline its AsRef implementation to remove redundant as_path() usage in filesystem, cache, atomic IO, unzip, and zipper logic.
- Separate safe path handling from platform location strategy by moving app data directory logic from fs::path to platform::locations and updating public re-exports accordingly.

Documentation:
- Add module-level documentation for platform::locations and adjust filesystem and platform module docs to reflect the new responsibilities.

Tests:
- Add unit tests for platform::locations covering app data directory shape and get_or_create_app_data_dir behavior while removing old fs::path-based tests.

</details>