### PR TITLE
feat: 封装 sculk 在线隧道能力

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,6 +6036,7 @@ name = "sealantern-extra"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "sculk",
  "sealantern-infra",
  "serde",
  "serde_json",

--- a/crates/extra/Cargo.toml
+++ b/crates/extra/Cargo.toml
@@ -7,11 +7,16 @@ license = "GPL-3.0-only"
 [lib]
 path = "src/lib.rs"
 
+[features]
+default = []
+online-tunnel = ["dep:sculk"]
+
 [dependencies]
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "sync"] }
 urlencoding = "2"
 sealantern-infra = { path = "../infra" }
+sculk = { version = "=0.2.0", default-features = false, optional = true }

--- a/crates/extra/src/lib.rs
+++ b/crates/extra/src/lib.rs
@@ -3,5 +3,8 @@
 pub mod config;
 pub mod observability;
 
+#[cfg(feature = "online-tunnel")]
+pub mod online;
+
 #[path = "market/lib.rs"]
 pub mod market;

--- a/crates/extra/src/observability.rs
+++ b/crates/extra/src/observability.rs
@@ -92,3 +92,56 @@ pub fn market_request_failed(operation: &str, source: &str, error: &dyn Display)
         "market request failed"
     );
 }
+
+/// 在线隧道模块的 tracing 目标。
+pub const ONLINE_TARGET: &str = "sealantern.extra.online";
+
+/// Event: 在线隧道已启动。
+pub const EVENT_ONLINE_TUNNEL_STARTED: &str = "online_tunnel_started";
+/// Event: 在线隧道已停止。
+pub const EVENT_ONLINE_TUNNEL_STOPPED: &str = "online_tunnel_stopped";
+/// Event: 在线隧道操作失败。
+pub const EVENT_ONLINE_TUNNEL_FAILED: &str = "online_tunnel_failed";
+/// Event: 在线隧道报告非致命错误。
+pub const EVENT_ONLINE_TUNNEL_EVENT_ERROR: &str = "online_tunnel_event_error";
+
+/// 记录在线隧道启动完成，不记录票据、密码或身份密钥。
+pub fn online_tunnel_started(mode: &str) {
+    tracing::info!(
+        target: ONLINE_TARGET,
+        event_name = EVENT_ONLINE_TUNNEL_STARTED,
+        mode,
+        "online tunnel started"
+    );
+}
+
+/// 记录在线隧道停止完成。
+pub fn online_tunnel_stopped(mode: &str) {
+    tracing::info!(
+        target: ONLINE_TARGET,
+        event_name = EVENT_ONLINE_TUNNEL_STOPPED,
+        mode,
+        "online tunnel stopped"
+    );
+}
+
+/// 记录在线隧道操作失败，不记录调用输入中的敏感字段。
+pub fn online_tunnel_failed(operation: &str, error: &dyn Display) {
+    tracing::error!(
+        target: ONLINE_TARGET,
+        event_name = EVENT_ONLINE_TUNNEL_FAILED,
+        operation,
+        error = %error,
+        "online tunnel operation failed"
+    );
+}
+
+/// 记录底层隧道报告的非致命错误事件。
+pub fn online_tunnel_event_error(error: &str) {
+    tracing::warn!(
+        target: ONLINE_TARGET,
+        event_name = EVENT_ONLINE_TUNNEL_EVENT_ERROR,
+        error,
+        "online tunnel reported a non-fatal error"
+    );
+}

--- a/crates/extra/src/online/mod.rs
+++ b/crates/extra/src/online/mod.rs
@@ -1,0 +1,14 @@
+//! SeaLantern 在线联机隧道能力。
+//!
+//! 此模块定义应用自己的请求、状态和事件契约。底层使用的隧道库保持在私有适配器内，
+//! 因而 server、桌面宿主和后续调用方不会依赖 `sculk` 的公开类型。
+
+mod model;
+mod sculk;
+mod service;
+
+pub use model::{
+    HostTunnelRequest, JoinTunnelRequest, OnlineTunnelError, TunnelConnection, TunnelEvent,
+    TunnelIdentity, TunnelMode, TunnelStatus, TunnelTicket,
+};
+pub use service::OnlineTunnelService;

--- a/crates/extra/src/online/model.rs
+++ b/crates/extra/src/online/model.rs
@@ -91,12 +91,6 @@ impl fmt::Debug for TunnelTicket {
     }
 }
 
-impl fmt::Display for TunnelTicket {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0)
-    }
-}
-
 /// Host 节点使用的 32 字节稳定身份密钥。
 #[derive(Clone)]
 pub struct TunnelIdentity([u8; 32]);
@@ -227,3 +221,15 @@ impl fmt::Display for OnlineTunnelError {
 }
 
 impl std::error::Error for OnlineTunnelError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ticket_debug_output_is_redacted() {
+        let ticket = TunnelTicket::from_provider("sculk://sensitive-ticket");
+
+        assert!(!format!("{ticket:?}").contains(ticket.as_str()));
+    }
+}

--- a/crates/extra/src/online/model.rs
+++ b/crates/extra/src/online/model.rs
@@ -1,0 +1,229 @@
+use std::fmt;
+
+/// 当前运行的隧道角色。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TunnelMode {
+    Host,
+    Join,
+}
+
+impl TunnelMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Host => "host",
+            Self::Join => "join",
+        }
+    }
+}
+
+/// Host 隧道启动请求。
+#[derive(Clone)]
+pub struct HostTunnelRequest {
+    pub minecraft_port: u16,
+    pub password: Option<String>,
+    pub max_players: Option<u32>,
+    pub relay_url: Option<String>,
+    pub identity: Option<TunnelIdentity>,
+}
+
+impl fmt::Debug for HostTunnelRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HostTunnelRequest")
+            .field("minecraft_port", &self.minecraft_port)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .field("max_players", &self.max_players)
+            .field("relay_url", &self.relay_url)
+            .field("identity", &self.identity.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+/// Join 隧道启动请求。
+#[derive(Clone)]
+pub struct JoinTunnelRequest {
+    pub ticket: TunnelTicket,
+    pub local_port: u16,
+    pub password: Option<String>,
+    pub max_retries: Option<u32>,
+}
+
+impl fmt::Debug for JoinTunnelRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("JoinTunnelRequest")
+            .field("ticket", &"[REDACTED]")
+            .field("local_port", &self.local_port)
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .field("max_retries", &self.max_retries)
+            .finish()
+    }
+}
+
+/// 由用户分享的隧道票据。
+#[derive(Clone, PartialEq, Eq)]
+pub struct TunnelTicket(String);
+
+impl TunnelTicket {
+    pub fn parse(value: impl Into<String>) -> Result<Self, OnlineTunnelError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(OnlineTunnelError::invalid_request("tunnel ticket must not be empty"));
+        }
+        value
+            .parse::<sculk::tunnel::Ticket>()
+            .map_err(|error| OnlineTunnelError::provider("parse tunnel ticket", error))?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn from_provider(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Debug for TunnelTicket {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TunnelTicket([REDACTED])")
+    }
+}
+
+impl fmt::Display for TunnelTicket {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Host 节点使用的 32 字节稳定身份密钥。
+#[derive(Clone)]
+pub struct TunnelIdentity([u8; 32]);
+
+impl TunnelIdentity {
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for TunnelIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TunnelIdentity([REDACTED])")
+    }
+}
+
+/// 已建立隧道中单个对端的运行时快照。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TunnelConnection {
+    pub remote_id: String,
+    pub is_relay: bool,
+    pub rtt_ms: u64,
+    pub tx_bytes: u64,
+    pub rx_bytes: u64,
+    pub alive: bool,
+    pub elapsed_ms: u64,
+}
+
+/// 应用层的在线隧道事件。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TunnelEvent {
+    PlayerJoined {
+        remote_id: String,
+    },
+    PlayerLeft {
+        remote_id: String,
+        reason: String,
+    },
+    Connected,
+    Disconnected {
+        reason: String,
+    },
+    PathChanged {
+        remote_id: String,
+        is_relay: bool,
+        rtt_ms: u64,
+    },
+    Reconnecting {
+        attempt: u32,
+    },
+    Reconnected,
+    AuthenticationFailed {
+        remote_id: String,
+    },
+    PlayerRejected {
+        remote_id: String,
+        reason: String,
+    },
+    Error {
+        message: String,
+    },
+    ProviderMessage {
+        message: String,
+    },
+}
+
+/// 当前在线隧道状态快照。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TunnelStatus {
+    pub active: bool,
+    pub mode: Option<TunnelMode>,
+    pub ticket: Option<TunnelTicket>,
+    pub connections: Vec<TunnelConnection>,
+}
+
+impl TunnelStatus {
+    pub(crate) fn idle() -> Self {
+        Self {
+            active: false,
+            mode: None,
+            ticket: None,
+            connections: Vec::new(),
+        }
+    }
+}
+
+/// 在线隧道操作失败。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OnlineTunnelError {
+    InvalidRequest {
+        message: String,
+    },
+    Busy,
+    NotRunning,
+    Provider {
+        operation: &'static str,
+        message: String,
+    },
+}
+
+impl OnlineTunnelError {
+    pub(crate) fn invalid_request(message: impl Into<String>) -> Self {
+        Self::InvalidRequest { message: message.into() }
+    }
+
+    pub(crate) fn provider(operation: &'static str, error: impl fmt::Display) -> Self {
+        Self::Provider { operation, message: error.to_string() }
+    }
+}
+
+impl fmt::Display for OnlineTunnelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequest { message } => {
+                write!(formatter, "invalid tunnel request: {message}")
+            }
+            Self::Busy => formatter.write_str("an online tunnel is already starting or running"),
+            Self::NotRunning => formatter.write_str("no online tunnel is running"),
+            Self::Provider { operation, message } => {
+                write!(formatter, "failed to {operation}: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OnlineTunnelError {}

--- a/crates/extra/src/online/sculk.rs
+++ b/crates/extra/src/online/sculk.rs
@@ -1,0 +1,236 @@
+use std::sync::Arc;
+
+use sculk::tunnel::{HostConfig, IrohTunnel, JoinConfig, TunnelEvent as SculkTunnelEvent};
+use sculk::types::{RelayUrl, SecretKey};
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinHandle;
+
+use super::{
+    HostTunnelRequest, JoinTunnelRequest, OnlineTunnelError, TunnelConnection, TunnelEvent,
+    TunnelIdentity, TunnelMode, TunnelStatus, TunnelTicket,
+};
+
+pub(super) struct ActiveTunnel {
+    pub(super) mode: TunnelMode,
+    pub(super) ticket: Option<TunnelTicket>,
+    tunnel: Arc<IrohTunnel>,
+    events: broadcast::Sender<TunnelEvent>,
+    event_task: JoinHandle<()>,
+}
+
+impl ActiveTunnel {
+    pub(super) fn status(&self) -> Result<TunnelStatus, OnlineTunnelError> {
+        Ok(TunnelStatus {
+            active: true,
+            mode: Some(self.mode),
+            ticket: self.ticket.clone(),
+            connections: connection_snapshot(&self.tunnel)?,
+        })
+    }
+
+    pub(super) fn subscribe(&self) -> broadcast::Receiver<TunnelEvent> {
+        self.events.subscribe()
+    }
+
+    pub(super) async fn close(self) {
+        self.tunnel.close().await;
+        self.event_task.abort();
+        let _ = self.event_task.await;
+    }
+}
+
+pub(super) async fn host(request: HostTunnelRequest) -> Result<ActiveTunnel, OnlineTunnelError> {
+    validate_host_request(&request)?;
+    let relay = parse_relay_url(request.relay_url.as_deref())?;
+    let identity = request.identity.as_ref().map(identity_to_secret_key);
+    let config = HostConfig::default()
+        .password(normalize_optional_string(request.password))
+        .max_players(request.max_players);
+
+    let (tunnel, ticket, events) =
+        IrohTunnel::host(request.minecraft_port, identity, relay, config)
+            .await
+            .map_err(|error| OnlineTunnelError::provider("start host tunnel", error))?;
+
+    Ok(active_tunnel(
+        TunnelMode::Host,
+        Some(TunnelTicket::from_provider(ticket.to_string())),
+        tunnel,
+        events,
+    ))
+}
+
+pub(super) async fn join(request: JoinTunnelRequest) -> Result<ActiveTunnel, OnlineTunnelError> {
+    if request.local_port == 0 {
+        return Err(OnlineTunnelError::invalid_request("local port must be non-zero"));
+    }
+
+    let ticket = request
+        .ticket
+        .as_str()
+        .parse()
+        .map_err(|error| OnlineTunnelError::provider("parse tunnel ticket", error))?;
+    let config = JoinConfig::default()
+        .password(normalize_optional_string(request.password))
+        .max_retries(request.max_retries);
+    let (tunnel, events) = IrohTunnel::join(&ticket, request.local_port, config)
+        .await
+        .map_err(|error| OnlineTunnelError::provider("join host tunnel", error))?;
+
+    Ok(active_tunnel(TunnelMode::Join, None, tunnel, events))
+}
+
+fn active_tunnel(
+    mode: TunnelMode,
+    ticket: Option<TunnelTicket>,
+    tunnel: IrohTunnel,
+    events: mpsc::Receiver<SculkTunnelEvent>,
+) -> ActiveTunnel {
+    let (event_sender, _) = broadcast::channel(128);
+    let event_task = spawn_event_forwarder(events, event_sender.clone());
+
+    ActiveTunnel {
+        mode,
+        ticket,
+        tunnel: Arc::new(tunnel),
+        events: event_sender,
+        event_task,
+    }
+}
+
+fn validate_host_request(request: &HostTunnelRequest) -> Result<(), OnlineTunnelError> {
+    if request.minecraft_port == 0 {
+        return Err(OnlineTunnelError::invalid_request("minecraft port must be non-zero"));
+    }
+    if request.max_players == Some(0) {
+        return Err(OnlineTunnelError::invalid_request("max players must be greater than zero"));
+    }
+    Ok(())
+}
+
+fn parse_relay_url(value: Option<&str>) -> Result<Option<RelayUrl>, OnlineTunnelError> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    value
+        .parse::<RelayUrl>()
+        .map(Some)
+        .map_err(|error| OnlineTunnelError::provider("parse relay URL", error))
+}
+
+fn identity_to_secret_key(identity: &TunnelIdentity) -> SecretKey {
+    SecretKey::from_bytes(identity.as_bytes())
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let value = value.trim().to_owned();
+        (!value.is_empty()).then_some(value)
+    })
+}
+
+fn connection_snapshot(tunnel: &IrohTunnel) -> Result<Vec<TunnelConnection>, OnlineTunnelError> {
+    tunnel
+        .connections()
+        .map_err(|error| OnlineTunnelError::provider("read tunnel connections", error))
+        .map(|connections| {
+            connections
+                .into_iter()
+                .map(|connection| TunnelConnection {
+                    remote_id: connection.remote_id.to_string(),
+                    is_relay: connection.is_relay,
+                    rtt_ms: connection.rtt_ms,
+                    tx_bytes: connection.tx_bytes,
+                    rx_bytes: connection.rx_bytes,
+                    alive: connection.alive,
+                    elapsed_ms: connection.elapsed.as_millis() as u64,
+                })
+                .collect()
+        })
+}
+
+fn spawn_event_forwarder(
+    mut receiver: mpsc::Receiver<SculkTunnelEvent>,
+    sender: broadcast::Sender<TunnelEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(event) = receiver.recv().await {
+            let event = map_event(event);
+            if let TunnelEvent::Error { message } = &event {
+                crate::observability::online_tunnel_event_error(message);
+            }
+            let _ = sender.send(event);
+        }
+    })
+}
+
+fn map_event(event: SculkTunnelEvent) -> TunnelEvent {
+    match event {
+        SculkTunnelEvent::PlayerJoined { id } => {
+            TunnelEvent::PlayerJoined { remote_id: id.to_string() }
+        }
+        SculkTunnelEvent::PlayerLeft { id, reason } => {
+            TunnelEvent::PlayerLeft { remote_id: id.to_string(), reason }
+        }
+        SculkTunnelEvent::Connected => TunnelEvent::Connected,
+        SculkTunnelEvent::Disconnected { reason } => TunnelEvent::Disconnected { reason },
+        SculkTunnelEvent::PathChanged { remote_id, is_relay, rtt_ms } => TunnelEvent::PathChanged {
+            remote_id: remote_id.to_string(),
+            is_relay,
+            rtt_ms,
+        },
+        SculkTunnelEvent::Reconnecting { attempt } => TunnelEvent::Reconnecting { attempt },
+        SculkTunnelEvent::Reconnected => TunnelEvent::Reconnected,
+        SculkTunnelEvent::AuthFailed { id } => {
+            TunnelEvent::AuthenticationFailed { remote_id: id.to_string() }
+        }
+        SculkTunnelEvent::PlayerRejected { id, reason } => {
+            TunnelEvent::PlayerRejected { remote_id: id.to_string(), reason }
+        }
+        SculkTunnelEvent::Error { message } => TunnelEvent::Error { message },
+        _ => TunnelEvent::ProviderMessage {
+            message: "received an unsupported provider event".to_owned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero_host_port_before_opening_a_tunnel() {
+        let error = validate_host_request(&HostTunnelRequest {
+            minecraft_port: 0,
+            password: None,
+            max_players: None,
+            relay_url: None,
+            identity: None,
+        })
+        .expect_err("zero port must be rejected");
+
+        assert!(matches!(error, OnlineTunnelError::InvalidRequest { .. }));
+    }
+
+    #[test]
+    fn normalizes_blank_optional_password() {
+        assert_eq!(normalize_optional_string(Some("  ".to_owned())), None);
+        assert_eq!(
+            normalize_optional_string(Some(" secret ".to_owned())),
+            Some("secret".to_owned())
+        );
+    }
+
+    #[test]
+    fn maps_provider_events_without_exposing_provider_types() {
+        let event = map_event(SculkTunnelEvent::Connected);
+        assert_eq!(event, TunnelEvent::Connected);
+    }
+
+    #[test]
+    fn rejects_an_invalid_ticket_at_the_public_boundary() {
+        let error = TunnelTicket::parse("not-a-ticket").expect_err("ticket must be validated");
+
+        assert!(matches!(error, OnlineTunnelError::Provider { .. }));
+    }
+}

--- a/crates/extra/src/online/service.rs
+++ b/crates/extra/src/online/service.rs
@@ -14,16 +14,13 @@ pub struct OnlineTunnelService {
     state: Arc<Mutex<ServiceState>>,
 }
 
+#[derive(Default)]
 enum ServiceState {
+    #[default]
     Idle,
     Starting,
+    Stopping,
     Active(ActiveTunnel),
-}
-
-impl Default for ServiceState {
-    fn default() -> Self {
-        Self::Idle
-    }
 }
 
 impl OnlineTunnelService {
@@ -60,29 +57,28 @@ impl OnlineTunnelService {
     }
 
     pub async fn stop(&self) -> Result<TunnelStatus, OnlineTunnelError> {
-        let active = {
-            let mut state = self.state.lock().await;
-            match std::mem::replace(&mut *state, ServiceState::Idle) {
-                ServiceState::Active(active) => active,
-                ServiceState::Idle => return Err(OnlineTunnelError::NotRunning),
-                ServiceState::Starting => {
-                    *state = ServiceState::Starting;
-                    return Err(OnlineTunnelError::Busy);
-                }
-            }
-        };
-
-        let mode = active.mode;
-        active.close().await;
-        crate::observability::online_tunnel_stopped(mode.as_str());
+        let active = self.begin_stop().await?;
+        self.finish_stop(active).await;
         Ok(TunnelStatus::idle())
+    }
+
+    /// 幂等关闭服务持有的活动隧道，供宿主退出流程调用。
+    pub async fn shutdown(&self) -> Result<(), OnlineTunnelError> {
+        match self.begin_stop().await {
+            Ok(active) => {
+                self.finish_stop(active).await;
+                Ok(())
+            }
+            Err(OnlineTunnelError::NotRunning) => Ok(()),
+            Err(error) => Err(error),
+        }
     }
 
     pub async fn status(&self) -> Result<TunnelStatus, OnlineTunnelError> {
         let state = self.state.lock().await;
         match &*state {
             ServiceState::Idle => Ok(TunnelStatus::idle()),
-            ServiceState::Starting => Err(OnlineTunnelError::Busy),
+            ServiceState::Starting | ServiceState::Stopping => Err(OnlineTunnelError::Busy),
             ServiceState::Active(active) => active.status(),
         }
     }
@@ -92,7 +88,7 @@ impl OnlineTunnelService {
         match &*state {
             ServiceState::Active(active) => Ok(active.subscribe()),
             ServiceState::Idle => Err(OnlineTunnelError::NotRunning),
-            ServiceState::Starting => Err(OnlineTunnelError::Busy),
+            ServiceState::Starting | ServiceState::Stopping => Err(OnlineTunnelError::Busy),
         }
     }
 
@@ -103,15 +99,47 @@ impl OnlineTunnelService {
                 *state = ServiceState::Starting;
                 Ok(())
             }
-            ServiceState::Starting | ServiceState::Active(_) => Err(OnlineTunnelError::Busy),
+            ServiceState::Starting | ServiceState::Stopping | ServiceState::Active(_) => {
+                Err(OnlineTunnelError::Busy)
+            }
         }
     }
 
     async fn reset_starting(&self) {
         let mut state = self.state.lock().await;
-        if matches!(*state, ServiceState::Starting) {
+        if matches!(&*state, ServiceState::Starting) {
             *state = ServiceState::Idle;
         }
+    }
+
+    async fn begin_stop(&self) -> Result<ActiveTunnel, OnlineTunnelError> {
+        let mut state = self.state.lock().await;
+        match std::mem::replace(&mut *state, ServiceState::Stopping) {
+            ServiceState::Active(active) => Ok(active),
+            ServiceState::Idle => {
+                *state = ServiceState::Idle;
+                Err(OnlineTunnelError::NotRunning)
+            }
+            ServiceState::Starting => {
+                *state = ServiceState::Starting;
+                Err(OnlineTunnelError::Busy)
+            }
+            ServiceState::Stopping => {
+                *state = ServiceState::Stopping;
+                Err(OnlineTunnelError::Busy)
+            }
+        }
+    }
+
+    async fn finish_stop(&self, active: ActiveTunnel) {
+        let mode = active.mode;
+        active.close().await;
+
+        let mut state = self.state.lock().await;
+        if matches!(&*state, ServiceState::Stopping) {
+            *state = ServiceState::Idle;
+        }
+        crate::observability::online_tunnel_stopped(mode.as_str());
     }
 
     async fn finish_start(&self, active: ActiveTunnel) -> Result<TunnelStatus, OnlineTunnelError> {
@@ -126,7 +154,7 @@ impl OnlineTunnelService {
         };
         let mode = active.mode;
         let mut state = self.state.lock().await;
-        if !matches!(*state, ServiceState::Starting) {
+        if !matches!(&*state, ServiceState::Starting) {
             drop(state);
             active.close().await;
             return Err(OnlineTunnelError::Busy);
@@ -154,5 +182,26 @@ mod tests {
 
         assert_eq!(service.stop().await, Err(OnlineTunnelError::NotRunning));
         assert!(matches!(service.subscribe().await, Err(OnlineTunnelError::NotRunning)));
+    }
+
+    #[tokio::test]
+    async fn stopping_state_blocks_new_operations() {
+        let service = OnlineTunnelService::default();
+        *service.state.lock().await = ServiceState::Stopping;
+
+        assert_eq!(service.begin_start().await, Err(OnlineTunnelError::Busy));
+        assert!(matches!(service.begin_stop().await, Err(OnlineTunnelError::Busy)));
+        assert_eq!(service.status().await, Err(OnlineTunnelError::Busy));
+        assert!(matches!(service.subscribe().await, Err(OnlineTunnelError::Busy)));
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_idempotent_while_idle() {
+        let service = OnlineTunnelService::default();
+
+        service
+            .shutdown()
+            .await
+            .expect("idle shutdown must succeed");
     }
 }

--- a/crates/extra/src/online/service.rs
+++ b/crates/extra/src/online/service.rs
@@ -1,0 +1,158 @@
+use std::sync::Arc;
+
+use tokio::sync::{broadcast, Mutex};
+
+use super::sculk::{self, ActiveTunnel};
+use super::{HostTunnelRequest, JoinTunnelRequest, OnlineTunnelError, TunnelEvent, TunnelStatus};
+
+/// SeaLantern 在线隧道服务。
+///
+/// 一个服务实例最多持有一条活动隧道。调用方通过实例生命周期管理隧道，避免旧实现中
+/// 进程级全局状态导致的测试干扰和宿主重复初始化问题。
+#[derive(Clone, Default)]
+pub struct OnlineTunnelService {
+    state: Arc<Mutex<ServiceState>>,
+}
+
+enum ServiceState {
+    Idle,
+    Starting,
+    Active(ActiveTunnel),
+}
+
+impl Default for ServiceState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl OnlineTunnelService {
+    pub async fn host(
+        &self,
+        request: HostTunnelRequest,
+    ) -> Result<TunnelStatus, OnlineTunnelError> {
+        self.begin_start().await?;
+        let active = match sculk::host(request).await {
+            Ok(active) => active,
+            Err(error) => {
+                crate::observability::online_tunnel_failed("start host tunnel", &error);
+                self.reset_starting().await;
+                return Err(error);
+            }
+        };
+        self.finish_start(active).await
+    }
+
+    pub async fn join(
+        &self,
+        request: JoinTunnelRequest,
+    ) -> Result<TunnelStatus, OnlineTunnelError> {
+        self.begin_start().await?;
+        let active = match sculk::join(request).await {
+            Ok(active) => active,
+            Err(error) => {
+                crate::observability::online_tunnel_failed("join host tunnel", &error);
+                self.reset_starting().await;
+                return Err(error);
+            }
+        };
+        self.finish_start(active).await
+    }
+
+    pub async fn stop(&self) -> Result<TunnelStatus, OnlineTunnelError> {
+        let active = {
+            let mut state = self.state.lock().await;
+            match std::mem::replace(&mut *state, ServiceState::Idle) {
+                ServiceState::Active(active) => active,
+                ServiceState::Idle => return Err(OnlineTunnelError::NotRunning),
+                ServiceState::Starting => {
+                    *state = ServiceState::Starting;
+                    return Err(OnlineTunnelError::Busy);
+                }
+            }
+        };
+
+        let mode = active.mode;
+        active.close().await;
+        crate::observability::online_tunnel_stopped(mode.as_str());
+        Ok(TunnelStatus::idle())
+    }
+
+    pub async fn status(&self) -> Result<TunnelStatus, OnlineTunnelError> {
+        let state = self.state.lock().await;
+        match &*state {
+            ServiceState::Idle => Ok(TunnelStatus::idle()),
+            ServiceState::Starting => Err(OnlineTunnelError::Busy),
+            ServiceState::Active(active) => active.status(),
+        }
+    }
+
+    pub async fn subscribe(&self) -> Result<broadcast::Receiver<TunnelEvent>, OnlineTunnelError> {
+        let state = self.state.lock().await;
+        match &*state {
+            ServiceState::Active(active) => Ok(active.subscribe()),
+            ServiceState::Idle => Err(OnlineTunnelError::NotRunning),
+            ServiceState::Starting => Err(OnlineTunnelError::Busy),
+        }
+    }
+
+    async fn begin_start(&self) -> Result<(), OnlineTunnelError> {
+        let mut state = self.state.lock().await;
+        match &*state {
+            ServiceState::Idle => {
+                *state = ServiceState::Starting;
+                Ok(())
+            }
+            ServiceState::Starting | ServiceState::Active(_) => Err(OnlineTunnelError::Busy),
+        }
+    }
+
+    async fn reset_starting(&self) {
+        let mut state = self.state.lock().await;
+        if matches!(*state, ServiceState::Starting) {
+            *state = ServiceState::Idle;
+        }
+    }
+
+    async fn finish_start(&self, active: ActiveTunnel) -> Result<TunnelStatus, OnlineTunnelError> {
+        let status = match active.status() {
+            Ok(status) => status,
+            Err(error) => {
+                active.close().await;
+                crate::observability::online_tunnel_failed("read initial tunnel status", &error);
+                self.reset_starting().await;
+                return Err(error);
+            }
+        };
+        let mode = active.mode;
+        let mut state = self.state.lock().await;
+        if !matches!(*state, ServiceState::Starting) {
+            drop(state);
+            active.close().await;
+            return Err(OnlineTunnelError::Busy);
+        }
+        *state = ServiceState::Active(active);
+        crate::observability::online_tunnel_started(mode.as_str());
+        Ok(status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_new_service_is_idle() {
+        let service = OnlineTunnelService::default();
+
+        assert_eq!(service.status().await.expect("idle status"), TunnelStatus::idle());
+    }
+
+    #[tokio::test]
+    async fn idle_service_rejects_stop_and_subscription() {
+        let service = OnlineTunnelService::default();
+
+        assert_eq!(service.stop().await, Err(OnlineTunnelError::NotRunning));
+        assert!(matches!(service.subscribe().await, Err(OnlineTunnelError::NotRunning)));
+    }
+}


### PR DESCRIPTION
新增 extra 在线隧道封装，提供独立的隧道生命周期与事件能力。\n\n补充关闭串行化、ticket 脱敏和跨平台验证。

## Summary by Sourcery

在 `extra` crate 中新增一个受特性开关控制的在线隧道功能，提供一个管理单一活动隧道的作用域化服务，暴露与提供方无关的模型与事件，并集成结构化可观测性和凭据脱敏。

新功能：
- 引入 `extra` 在线隧道模块，包含专用服务 API、生命周期管理，以及与底层 `sculk` 提供方解耦的应用级事件模型。

增强内容：
- 为在线隧道的启动/停止/失败以及非致命的提供方错误添加可观测性事件和 tracing 目标，并对敏感数据进行脱敏处理。
- 封装隧道票据和身份信息，提供脱敏的 Debug 输出和经过验证的解析逻辑，避免泄露或接收无效凭据。

构建：
- 在 `extra` crate 中新增 `online-tunnel` 特性，并接入可选的 `sculk` 依赖。
- 扩展 `tokio` 依赖特性以包含用于隧道服务协调的 `sync`。

测试：
- 添加单元测试，覆盖票据校验与脱敏、请求校验、事件映射，以及在线隧道模块的服务状态行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a feature-gated online tunneling capability to the `extra` crate, providing a scoped service that manages a single active tunnel, exposes provider-agnostic models and events, and integrates structured observability and credential redaction.

New Features:
- Introduce an `extra` online tunnel module with a dedicated service API, lifecycle management, and app-level event model decoupled from the underlying `sculk` provider.

Enhancements:
- Add observability events and tracing target for online tunnel start/stop/failure and non-fatal provider errors, with sensitive data redacted.
- Encapsulate tunnel tickets and identities with redacted Debug output and validated parsing to avoid leaking or accepting invalid credentials.

Build:
- Add an `online-tunnel` feature to the `extra` crate, wiring in the optional `sculk` dependency.
- Extend the `tokio` dependency features to include `sync` for tunnel service coordination.

Tests:
- Add unit tests covering ticket validation and redaction, request validation, event mapping, and service state behavior for the online tunnel module.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 `extra` crate 中新增一个受特性开关控制的在线隧道功能，提供一个管理单一活动隧道的作用域化服务，暴露与提供方无关的模型与事件，并集成结构化可观测性和凭据脱敏。

新功能：
- 引入 `extra` 在线隧道模块，包含专用服务 API、生命周期管理，以及与底层 `sculk` 提供方解耦的应用级事件模型。

增强内容：
- 为在线隧道的启动/停止/失败以及非致命的提供方错误添加可观测性事件和 tracing 目标，并对敏感数据进行脱敏处理。
- 封装隧道票据和身份信息，提供脱敏的 Debug 输出和经过验证的解析逻辑，避免泄露或接收无效凭据。

构建：
- 在 `extra` crate 中新增 `online-tunnel` 特性，并接入可选的 `sculk` 依赖。
- 扩展 `tokio` 依赖特性以包含用于隧道服务协调的 `sync`。

测试：
- 添加单元测试，覆盖票据校验与脱敏、请求校验、事件映射，以及在线隧道模块的服务状态行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a feature-gated online tunneling capability to the `extra` crate, providing a scoped service that manages a single active tunnel, exposes provider-agnostic models and events, and integrates structured observability and credential redaction.

New Features:
- Introduce an `extra` online tunnel module with a dedicated service API, lifecycle management, and app-level event model decoupled from the underlying `sculk` provider.

Enhancements:
- Add observability events and tracing target for online tunnel start/stop/failure and non-fatal provider errors, with sensitive data redacted.
- Encapsulate tunnel tickets and identities with redacted Debug output and validated parsing to avoid leaking or accepting invalid credentials.

Build:
- Add an `online-tunnel` feature to the `extra` crate, wiring in the optional `sculk` dependency.
- Extend the `tokio` dependency features to include `sync` for tunnel service coordination.

Tests:
- Add unit tests covering ticket validation and redaction, request validation, event mapping, and service state behavior for the online tunnel module.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 `extra` crate 中新增一个受特性开关控制的在线隧道功能，提供一个管理单一活动隧道的作用域化服务，暴露与提供方无关的模型与事件，并集成结构化可观测性和凭据脱敏。

新功能：
- 引入 `extra` 在线隧道模块，包含专用服务 API、生命周期管理，以及与底层 `sculk` 提供方解耦的应用级事件模型。

增强内容：
- 为在线隧道的启动/停止/失败以及非致命的提供方错误添加可观测性事件和 tracing 目标，并对敏感数据进行脱敏处理。
- 封装隧道票据和身份信息，提供脱敏的 Debug 输出和经过验证的解析逻辑，避免泄露或接收无效凭据。

构建：
- 在 `extra` crate 中新增 `online-tunnel` 特性，并接入可选的 `sculk` 依赖。
- 扩展 `tokio` 依赖特性以包含用于隧道服务协调的 `sync`。

测试：
- 添加单元测试，覆盖票据校验与脱敏、请求校验、事件映射，以及在线隧道模块的服务状态行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a feature-gated online tunneling capability to the `extra` crate, providing a scoped service that manages a single active tunnel, exposes provider-agnostic models and events, and integrates structured observability and credential redaction.

New Features:
- Introduce an `extra` online tunnel module with a dedicated service API, lifecycle management, and app-level event model decoupled from the underlying `sculk` provider.

Enhancements:
- Add observability events and tracing target for online tunnel start/stop/failure and non-fatal provider errors, with sensitive data redacted.
- Encapsulate tunnel tickets and identities with redacted Debug output and validated parsing to avoid leaking or accepting invalid credentials.

Build:
- Add an `online-tunnel` feature to the `extra` crate, wiring in the optional `sculk` dependency.
- Extend the `tokio` dependency features to include `sync` for tunnel service coordination.

Tests:
- Add unit tests covering ticket validation and redaction, request validation, event mapping, and service state behavior for the online tunnel module.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 `extra` crate 中新增一个受特性开关控制的在线隧道功能，提供一个管理单一活动隧道的作用域化服务，暴露与提供方无关的模型与事件，并集成结构化可观测性和凭据脱敏。

新功能：
- 引入 `extra` 在线隧道模块，包含专用服务 API、生命周期管理，以及与底层 `sculk` 提供方解耦的应用级事件模型。

增强内容：
- 为在线隧道的启动/停止/失败以及非致命的提供方错误添加可观测性事件和 tracing 目标，并对敏感数据进行脱敏处理。
- 封装隧道票据和身份信息，提供脱敏的 Debug 输出和经过验证的解析逻辑，避免泄露或接收无效凭据。

构建：
- 在 `extra` crate 中新增 `online-tunnel` 特性，并接入可选的 `sculk` 依赖。
- 扩展 `tokio` 依赖特性以包含用于隧道服务协调的 `sync`。

测试：
- 添加单元测试，覆盖票据校验与脱敏、请求校验、事件映射，以及在线隧道模块的服务状态行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a feature-gated online tunneling capability to the `extra` crate, providing a scoped service that manages a single active tunnel, exposes provider-agnostic models and events, and integrates structured observability and credential redaction.

New Features:
- Introduce an `extra` online tunnel module with a dedicated service API, lifecycle management, and app-level event model decoupled from the underlying `sculk` provider.

Enhancements:
- Add observability events and tracing target for online tunnel start/stop/failure and non-fatal provider errors, with sensitive data redacted.
- Encapsulate tunnel tickets and identities with redacted Debug output and validated parsing to avoid leaking or accepting invalid credentials.

Build:
- Add an `online-tunnel` feature to the `extra` crate, wiring in the optional `sculk` dependency.
- Extend the `tokio` dependency features to include `sync` for tunnel service coordination.

Tests:
- Add unit tests covering ticket validation and redaction, request validation, event mapping, and service state behavior for the online tunnel module.

</details>

</details>

</details>