### PR TITLE
fix(extra): 修复clippy问题

### DIFF
--- a/crates/extra/src/update/arch.rs
+++ b/crates/extra/src/update/arch.rs
@@ -6,8 +6,6 @@ use super::types::UpdateInfo;
 use super::version::compare_versions;
 #[cfg(target_os = "linux")]
 use tracing::{debug, info};
-#[cfg(target_os = "linux")]
-use tracing::{debug, info};
 
 /// 检查是否为 Arch Linux 系统
 #[cfg(target_os = "linux")]
@@ -97,7 +95,7 @@ pub async fn check_aur_update(current_version: &str) -> Result<UpdateInfo, Strin
     };
 
     debug!("=== AUR 检查结果 ===");
-    debug!(has_update, source = "arch-aur", latest_version = %aur_version; "AUR update check completed");
+    debug!(has_update, source = "arch-aur", latest_version = %aur_version, "AUR update check completed");
 
     Ok(UpdateInfo {
         has_update,

--- a/crates/extra/src/update/arch.rs
+++ b/crates/extra/src/update/arch.rs
@@ -5,7 +5,7 @@ use super::types::UpdateInfo;
 #[cfg(target_os = "linux")]
 use super::version::compare_versions;
 #[cfg(target_os = "linux")]
-use tracing::{debug, info};
+use tracing::debug;
 
 /// 检查是否为 Arch Linux 系统
 #[cfg(target_os = "linux")]

--- a/crates/extra/src/update/install/windows.rs
+++ b/crates/extra/src/update/install/windows.rs
@@ -182,6 +182,8 @@ mod imp {
 
 #[cfg(not(target_os = "windows"))]
 mod imp {
+    /// 非 Windows 平台上的桩实现，始终返回错误。
+    #[allow(dead_code)]
     pub fn spawn_elevated_windows_process(
         _file_path: &str,
         _args: &[&str],
@@ -192,4 +194,5 @@ mod imp {
     }
 }
 
+#[cfg(target_os = "windows")]
 pub use imp::spawn_elevated_windows_process;

--- a/crates/extra/src/update/install/windows.rs
+++ b/crates/extra/src/update/install/windows.rs
@@ -192,7 +192,4 @@ mod imp {
     }
 }
 
-#[cfg(target_os = "windows")]
-pub use imp::spawn_elevated_windows_process;
-#[cfg(not(target_os = "windows"))]
 pub use imp::spawn_elevated_windows_process;

--- a/src-tauri/src/commands/update/mod.rs
+++ b/src-tauri/src/commands/update/mod.rs
@@ -16,12 +16,12 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
+#[cfg(target_os = "linux")]
+use sealantern_extra::update::is_arch_linux;
 #[cfg(all(not(debug_assertions), target_os = "linux"))]
 use sealantern_extra::update::{
     check_aur_update, fetch_cnb_release, fetch_github_release, get_github_config,
 };
-#[cfg(target_os = "linux")]
-use sealantern_extra::update::is_arch_linux;
 
 #[cfg(target_os = "windows")]
 use sealantern_extra::update::spawn_elevated_windows_process;

--- a/src-tauri/src/commands/update/mod.rs
+++ b/src-tauri/src/commands/update/mod.rs
@@ -16,7 +16,7 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(not(debug_assertions), target_os = "linux"))]
 use sealantern_extra::update::{
     check_aur_update, fetch_cnb_release, fetch_github_release, get_github_config, is_arch_linux,
 };

--- a/src-tauri/src/commands/update/mod.rs
+++ b/src-tauri/src/commands/update/mod.rs
@@ -18,8 +18,10 @@ use std::sync::atomic::Ordering;
 
 #[cfg(all(not(debug_assertions), target_os = "linux"))]
 use sealantern_extra::update::{
-    check_aur_update, fetch_cnb_release, fetch_github_release, get_github_config, is_arch_linux,
+    check_aur_update, fetch_cnb_release, fetch_github_release, get_github_config,
 };
+#[cfg(target_os = "linux")]
+use sealantern_extra::update::is_arch_linux;
 
 #[cfg(target_os = "windows")]
 use sealantern_extra::update::spawn_elevated_windows_process;


### PR DESCRIPTION
- 修一下clippy

---

## Summary by Sourcery

解决 Arch Linux 更新检查和 Windows 提权进程创建中的 Clippy 警告。

改进内容：
- 清理 Arch Linux AUR 更新检查中的 tracing 引用和日志宏使用方式。
- 简化 Windows 提权进程创建的条件性再导出，以满足代码检查要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve Clippy warnings in Arch Linux update checks and Windows elevated process spawning.

Enhancements:
- Clean up tracing imports and logging macro usage in Arch Linux AUR update checks.
- Simplify conditional re-exports for Windows elevated process spawning to satisfy linting.

</details>