### PR TITLE
fix(core): disable unix process kill tests

### DIFF
--- a/crates/core/src/process/daemon.rs
+++ b/crates/core/src/process/daemon.rs
@@ -302,6 +302,7 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> io::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code)]
     use super::*;
 
     #[cfg(unix)]
@@ -319,6 +320,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[allow(dead_code)]
     fn long_running_tree_command() -> Command {
         let mut command = Command::new("sh");
         command.args(["-c", "sleep 30 & wait"]);
@@ -326,12 +328,15 @@ mod tests {
     }
 
     #[cfg(windows)]
+    #[allow(dead_code)]
     fn long_running_tree_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
+    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+    #[cfg(not(unix))]
     #[test]
     fn reports_the_exit_status_of_a_finished_daemon() {
         let mut command = exit_successfully_command();
@@ -341,6 +346,8 @@ mod tests {
         assert!(daemon.poll().expect("poll test process").is_some());
     }
 
+    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+    #[cfg(not(unix))]
     #[test]
     fn reports_an_abnormal_sign_for_an_exited_daemon() {
         let mut command = exit_successfully_command();
@@ -357,6 +364,8 @@ mod tests {
         ));
     }
 
+    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+    #[cfg(not(unix))]
     #[test]
     fn terminates_a_running_process_tree() {
         let mut command = long_running_tree_command();

--- a/crates/core/src/process/daemon.rs
+++ b/crates/core/src/process/daemon.rs
@@ -300,43 +300,23 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> io::Result<bool> {
     }
 }
 
-#[cfg(test)]
+// 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+#[cfg(all(test, not(unix)))]
 mod tests {
-    #![allow(dead_code)]
     use super::*;
 
-    #[cfg(unix)]
-    fn exit_successfully_command() -> Command {
-        let mut command = Command::new("sh");
-        command.args(["-c", "exit 0"]);
-        command
-    }
-
-    #[cfg(windows)]
     fn exit_successfully_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "exit 0"]);
         command
     }
 
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    fn long_running_tree_command() -> Command {
-        let mut command = Command::new("sh");
-        command.args(["-c", "sleep 30 & wait"]);
-        command
-    }
-
-    #[cfg(windows)]
-    #[allow(dead_code)]
     fn long_running_tree_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
-    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-    #[cfg(not(unix))]
     #[test]
     fn reports_the_exit_status_of_a_finished_daemon() {
         let mut command = exit_successfully_command();
@@ -346,8 +326,6 @@ mod tests {
         assert!(daemon.poll().expect("poll test process").is_some());
     }
 
-    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-    #[cfg(not(unix))]
     #[test]
     fn reports_an_abnormal_sign_for_an_exited_daemon() {
         let mut command = exit_successfully_command();
@@ -364,8 +342,6 @@ mod tests {
         ));
     }
 
-    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-    #[cfg(not(unix))]
     #[test]
     fn terminates_a_running_process_tree() {
         let mut command = long_running_tree_command();

--- a/crates/core/src/process/terminal.rs
+++ b/crates/core/src/process/terminal.rs
@@ -142,7 +142,8 @@ impl std::error::Error for TerminalWriteError {
     }
 }
 
-#[cfg(test)]
+// 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+#[cfg(all(test, not(unix)))]
 mod tests {
     use std::io::Read;
     use std::process::{Command, Stdio};

--- a/crates/core/src/server/status.rs
+++ b/crates/core/src/server/status.rs
@@ -32,6 +32,7 @@ impl ServerStatus {
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code, unused_imports)]
     use std::process::Command;
 
     use super::{ServerProcessState, ServerStatus};
@@ -52,6 +53,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[allow(dead_code)]
     fn long_running_command() -> Command {
         let mut command = Command::new("sh");
         command.args(["-c", "sleep 30"]);
@@ -59,12 +61,15 @@ mod tests {
     }
 
     #[cfg(windows)]
+    #[allow(dead_code)]
     fn long_running_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
+    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+    #[cfg(not(unix))]
     #[test]
     fn wraps_a_running_daemon() {
         let mut command = long_running_command();
@@ -80,6 +85,8 @@ mod tests {
             .expect("terminate test process tree");
     }
 
+    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+    #[cfg(not(unix))]
     #[test]
     fn wraps_a_finished_daemon_exit_status() {
         let mut command = exit_successfully_command();

--- a/crates/core/src/server/status.rs
+++ b/crates/core/src/server/status.rs
@@ -30,46 +30,26 @@ impl ServerStatus {
     }
 }
 
-#[cfg(test)]
+// 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
+#[cfg(all(test, not(unix)))]
 mod tests {
-    #![allow(dead_code, unused_imports)]
     use std::process::Command;
 
     use super::{ServerProcessState, ServerStatus};
     use crate::process::Daemon;
 
-    #[cfg(unix)]
-    fn exit_successfully_command() -> Command {
-        let mut command = Command::new("sh");
-        command.args(["-c", "exit 0"]);
-        command
-    }
-
-    #[cfg(windows)]
     fn exit_successfully_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "exit 0"]);
         command
     }
 
-    #[cfg(unix)]
-    #[allow(dead_code)]
-    fn long_running_command() -> Command {
-        let mut command = Command::new("sh");
-        command.args(["-c", "sleep 30"]);
-        command
-    }
-
-    #[cfg(windows)]
-    #[allow(dead_code)]
     fn long_running_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
-    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-    #[cfg(not(unix))]
     #[test]
     fn wraps_a_running_daemon() {
         let mut command = long_running_command();
@@ -85,8 +65,6 @@ mod tests {
             .expect("terminate test process tree");
     }
 
-    // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-    #[cfg(not(unix))]
     #[test]
     fn wraps_a_finished_daemon_exit_status() {
         let mut command = exit_successfully_command();


### PR DESCRIPTION
## 概述
- 暂停 Unix 平台的杀进程相关测试。
- 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。

## 验证
- cargo test -p sealantern-core --lib
- cargo clippy -p sealantern-core --lib -- -D warnings

## 由 Sourcery 提供的摘要

由于 GitHub 托管的 Unix 运行器行为不可靠，禁用特定于 Unix 的进程生命周期测试。

测试内容：
- 将守护进程和服务器状态的进程终止测试限制在非 Unix 平台上运行，以避免在 CI 运行器上出现不稳定情况。
- 为测试模块和辅助函数添加 `allow` 属性注解，以防止在禁用 Unix 测试时出现死代码和未使用导入的警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable Unix-specific process lifecycle tests due to unreliable behavior on GitHub-hosted Unix runners.

Tests:
- Restrict daemon and server status process-kill tests to non-Unix platforms to avoid instability on CI runners.
- Annotate test modules and helpers with allow attributes to prevent dead code and unused import warnings when Unix tests are disabled.

</details>