### PR TITLE
refactor(core): 用 ci_skip_validation 替代 not(unix) 跳过进程测试

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -142,7 +142,7 @@ jobs:
       - name: 运行测试
         run: cargo test -p sealantern-core --lib
         env:
-          RUSTFLAGS: '--cfg ci_skip_validation'
+          RUSTFLAGS: "--cfg ci_skip_validation"
 
   backend-test-infra:
     name: 后端测试 (infra)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -141,6 +141,8 @@ jobs:
 
       - name: 运行测试
         run: cargo test -p sealantern-core --lib
+        env:
+          RUSTFLAGS: '--cfg ci_skip_validation'
 
   backend-test-infra:
     name: 后端测试 (infra)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,3 +10,6 @@ path = "src/lib.rs"
 [dependencies]
 tracing = "0.1"
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci_skip_validation)'] }

--- a/crates/core/src/process/daemon.rs
+++ b/crates/core/src/process/daemon.rs
@@ -301,22 +301,39 @@ fn wait_for_exit(child: &mut Child, timeout: Duration) -> io::Result<bool> {
 }
 
 // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-#[cfg(all(test, not(unix)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn exit_successfully_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 0"]);
+        command
+    }
+
+    #[cfg(windows)]
     fn exit_successfully_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "exit 0"]);
         command
     }
 
+    #[cfg(unix)]
+    fn long_running_tree_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 30 & wait"]);
+        command
+    }
+
+    #[cfg(windows)]
     fn long_running_tree_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn reports_the_exit_status_of_a_finished_daemon() {
         let mut command = exit_successfully_command();
@@ -326,6 +343,7 @@ mod tests {
         assert!(daemon.poll().expect("poll test process").is_some());
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn reports_an_abnormal_sign_for_an_exited_daemon() {
         let mut command = exit_successfully_command();
@@ -342,6 +360,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn terminates_a_running_process_tree() {
         let mut command = long_running_tree_command();

--- a/crates/core/src/process/terminal.rs
+++ b/crates/core/src/process/terminal.rs
@@ -143,7 +143,7 @@ impl std::error::Error for TerminalWriteError {
 }
 
 // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-#[cfg(all(test, not(unix)))]
+#[cfg(test)]
 mod tests {
     use std::io::Read;
     use std::process::{Command, Stdio};
@@ -197,6 +197,7 @@ mod tests {
         command
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn transfers_output_streams_without_losing_their_identity() {
         let mut command = output_command();
@@ -229,6 +230,7 @@ mod tests {
         assert!(terminal.take_output(TerminalStream::Stdout).is_none());
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn host_selected_console_input_writes_and_flushes_a_command_line() {
         let mut command = command_reader_command();
@@ -251,6 +253,7 @@ mod tests {
         assert!(output.contains("say hello"));
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn reports_unavailable_standard_input_without_discarding_state() {
         let mut command = exit_successfully_command();
@@ -268,6 +271,7 @@ mod tests {
         let _ = daemon.wait().expect("wait for test process");
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn terminal_output_implements_read_for_host_owned_readers() {
         let mut command = output_command();
@@ -289,6 +293,7 @@ mod tests {
         let _ = daemon.wait().expect("wait for test process");
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn shell_mode_discards_piped_input() {
         let mut command = exit_successfully_command();
@@ -306,6 +311,7 @@ mod tests {
         let _ = daemon.wait().expect("wait for test process");
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn legacy_custom_command_discards_piped_input() {
         let mut command = exit_successfully_command();

--- a/crates/core/src/server/status.rs
+++ b/crates/core/src/server/status.rs
@@ -31,25 +31,42 @@ impl ServerStatus {
 }
 
 // 受制于 GitHub 机器关于杀进程的不稳定性，杀进程测试不会为 Unix 开放。
-#[cfg(all(test, not(unix)))]
+#[cfg(test)]
 mod tests {
     use std::process::Command;
 
     use super::{ServerProcessState, ServerStatus};
     use crate::process::Daemon;
 
+    #[cfg(unix)]
+    fn exit_successfully_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "exit 0"]);
+        command
+    }
+
+    #[cfg(windows)]
     fn exit_successfully_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "exit 0"]);
         command
     }
 
+    #[cfg(unix)]
+    fn long_running_command() -> Command {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 30"]);
+        command
+    }
+
+    #[cfg(windows)]
     fn long_running_command() -> Command {
         let mut command = Command::new("cmd");
         command.args(["/C", "ping -n 30 127.0.0.1 > NUL"]);
         command
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn wraps_a_running_daemon() {
         let mut command = long_running_command();
@@ -65,6 +82,7 @@ mod tests {
             .expect("terminate test process tree");
     }
 
+    #[cfg_attr(ci_skip_validation, ignore)]
     #[test]
     fn wraps_a_finished_daemon_exit_status() {
         let mut command = exit_successfully_command();


### PR DESCRIPTION
- 将 daemon.rs/terminal.rs/status.rs 的测试模块条件从 #[cfg(all(test, not(unix)))] 恢复为 #[cfg(test)]
- 恢复被删除的 Unix 辅助函数（sh 命令版本）
- 给每个进程相关测试添加 #[cfg_attr(ci_skip_validation, ignore)] 替代整个模块不编译的方式
- 在 CI 的 check.yml 中通过 RUSTFLAGS='--cfg ci_skip_validation' 让这些测试在 CI 上自动跳过，本地开发不受影响
- 在 core/Cargo.toml 的 [lints.rust] 中注册 ci_skip_validation cfg 消除 unexpected_cfgs 警告

---

## Summary by Sourcery

在所有平台上启用与进程相关的核心测试，同时通过专用配置标志允许 CI 跳过这些测试。

Enhancements:
- 恢复用于进程和服务器状态测试的 Unix 特定辅助命令，以支持跨平台行为覆盖。

Build:
- 在 core 的 Cargo.toml lint 配置中注册 `ci_skip_validation` cfg，以避免 `unexpected_cfgs` 警告。

CI:
- 配置 check 工作流传递 `RUSTFLAGS='--cfg ci_skip_validation'`，这样在 CI 上标记相应属性的进程相关测试会被自动忽略。

Tests:
- 修改进程、服务器状态和终端测试模块为始终参与编译，对不稳定的进程测试使用 `#[cfg_attr(ci_skip_validation, ignore)]`，而不是在 Unix 上将其排除。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable process-related core tests across all platforms while allowing CI to skip them via a dedicated configuration flag.

Enhancements:
- Restore Unix-specific helper commands for process and server status tests to support cross-platform behaviour coverage.

Build:
- Register the ci_skip_validation cfg in core's Cargo.toml lint configuration to avoid unexpected_cfgs warnings.

CI:
- Configure the check workflow to pass RUSTFLAGS='--cfg ci_skip_validation' so process-related tests are automatically ignored on CI when marked accordingly.

Tests:
- Change process, server status, and terminal test modules to always compile, using #[cfg_attr(ci_skip_validation, ignore)] on unstable process tests instead of excluding them on Unix.

</details>