### PR TITLE
fix: 统一 Tauri crate 命名

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -225,7 +225,7 @@ jobs:
           save-if: false
 
       - name: 运行测试
-        run: cargo test --lib -p sea-lantern
+        run: cargo test --lib -p sealantern
 
   backend:
     name: 后端检查 (Rust)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -196,8 +196,8 @@ jobs:
           VERSION: ${{ needs.validate-nightly.outputs.version }}
           ASSET_ARCH: ${{ matrix.asset_arch }}
         run: |
-          $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sea-lantern.exe" -ErrorAction SilentlyContinue |
-            Where-Object { $_.FullName -match '\\release\\sea-lantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
+          $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sealantern.exe" -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\release\\sealantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
             Select-Object -First 1 -ExpandProperty DirectoryName
 
           if (-not $releaseDir) {
@@ -208,7 +208,7 @@ jobs:
           Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Path $stageDir | Out-Null
 
-          Copy-Item -LiteralPath (Join-Path $releaseDir "sea-lantern.exe") -Destination $stageDir
+          Copy-Item -LiteralPath (Join-Path $releaseDir "sealantern.exe") -Destination $stageDir
 
           Get-ChildItem -Path $releaseDir -File -Filter "*.dll" -ErrorAction SilentlyContinue |
             ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $stageDir }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,8 @@ jobs:
           VERSION: ${{ needs.validate-tag.outputs.version }}
           ASSET_ARCH: ${{ matrix.asset_arch }}
         run: |
-          $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sea-lantern.exe" -ErrorAction SilentlyContinue |
-            Where-Object { $_.FullName -match '\\release\\sea-lantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
+          $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sealantern.exe" -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\release\\sealantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
             Select-Object -First 1 -ExpandProperty DirectoryName
 
           if (-not $releaseDir) {
@@ -227,7 +227,7 @@ jobs:
           Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Path $stageDir | Out-Null
 
-          Copy-Item -LiteralPath (Join-Path $releaseDir "sea-lantern.exe") -Destination $stageDir
+          Copy-Item -LiteralPath (Join-Path $releaseDir "sealantern.exe") -Destination $stageDir
 
           Get-ChildItem -Path $releaseDir -File -Filter "*.dll" -ErrorAction SilentlyContinue |
             ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $stageDir }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 name = "docker-entry"
 version = "1.1.0"
 dependencies = [
- "sea-lantern",
+ "sealantern",
 ]
 
 [[package]]
@@ -5059,7 +5059,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-lantern"
+name = "sealantern"
 version = "1.2.0"
 dependencies = [
  "sealantern-core",

--- a/docker-entry/Cargo.toml
+++ b/docker-entry/Cargo.toml
@@ -5,4 +5,4 @@ description = "Docker 容器入口程序"
 edition = "2021"
 
 [dependencies]
-sea_lantern_lib = { package = "sea-lantern", path = "../src-tauri", features = ["docker"] }
+sealantern = { path = "../src-tauri", features = ["docker"] }

--- a/docker-entry/src/main.rs
+++ b/docker-entry/src/main.rs
@@ -1,5 +1,5 @@
 //! Docker 入口程序 - 用于在 Docker 容器中运行 SeaLantern HTTP 服务器
 
 fn main() {
-    sea_lantern_lib::run();
+    sealantern_lib::run();
 }

--- a/scripts/cli-docker-smoke.ps1
+++ b/scripts/cli-docker-smoke.ps1
@@ -39,9 +39,9 @@ function Resolve-CliPath {
     }
 
     $candidates = @(
-        (Join-Path $RepoRoot 'target\debug\sea-lantern.exe'),
-        (Join-Path $RepoRoot 'src-tauri\target\debug\sea-lantern.exe'),
-        (Join-Path $RepoRoot 'src-tauri\target\debug\sea-lantern.exe')
+        (Join-Path $RepoRoot 'target\debug\sealantern.exe'),
+        (Join-Path $RepoRoot 'src-tauri\target\debug\sealantern.exe'),
+        (Join-Path $RepoRoot 'src-tauri\target\debug\sealantern.exe')
     )
 
     foreach ($candidate in $candidates) {

--- a/scripts/notice.mjs
+++ b/scripts/notice.mjs
@@ -264,7 +264,7 @@ async function generateNotice() {
   noticeLines.push("");
 
   const sortedBackend = [...backendLicenses]
-    .filter((crate) => crate.name !== "sea-lantern")
+    .filter((crate) => crate.name !== "sealantern")
     .toSorted((a, b) => `${a.name}@${a.version}`.localeCompare(`${b.name}@${b.version}`));
 
   id = 1;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "sea-lantern"
+name = "sealantern"
 version = "1.2.0"
 description = "Minecraft Server Manager"
 authors = ["FPS_Z"]
 edition = "2021"
-default-run = "sea-lantern"
+default-run = "sealantern"
 
 [lib]
-name = "sea_lantern_lib"
+name = "sealantern_lib"
 crate-type = ["lib"]
 
 [build-dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    sea_lantern_lib::run();
+    sealantern_lib::run();
 }


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `提交前测试必读！！！.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## 变更分类（必选其一或多选）

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围（可多选）

- [ ] 前端 Frontend
  - [ ] UI 样式/布局
  - [ ] 组件/状态/路由逻辑
  - [ ] 依赖变更 (package.json)

- [x] 后端 Backend
  - [ ] API 接口变更
  - [ ] 业务逻辑
  - [ ] 依赖升级

- [ ] 基础设施 Infrastructure
  - [ ] CI/CD 配置
  - [ ] 部署脚本
  - [ ] 数据库迁移

**导入规范检查：** 使用别名导入，避免相对路径 `../`

## 变更详情

### 摘要

统一 Tauri crate 命名

### 界面变动（可选）

<!--截图/GIF，前后对比-->

## 关联 Issue

> 如果不存在关联，此项请忽略

- Fix #`填写 Issue 编号`

<details><summary>示例:</summary>

```markdown
- Close #123
  关闭 Issue #123
```

| 常见关键词                          | 示例           |
| ----------------------------------- | -------------- |
| `close` / `closes` / `closed`       | `Close #123`   |
| `fix` / `fixes` / `fixed`           | `Fixes #123`   |
| `resolve` / `resolves` / `resolved` | `Resolve #123` |

| 其他前缀                      | 用途                | 示例              |
| ----------------------------- | ------------------- | ----------------- |
| `ref` / `references` / `refs` | 引用关联，不关闭    | `Ref #123`        |
| `related` / `relates to`      | 表明相关            | `Related to #123` |
| `part of`                     | 表明是其中一部分    | `Part of #123`    |
| `see` / `see also`            | 参考其他 Issue      | `See #123`        |
| `re`                          | 关于/回复某个 Issue | `Re #123`         |
| `addresses`                   | 涉及但未完全解决    | `Addresses #123`  |
| `implements`                  | 实现某个功能请求    | `Implements #123` |
| `merges`                      | 合并相关            | `Merges #123`     |

</details>

---

## 自动化审查

- [ ] 是否禁用自动化 AI 审查?

<!-- ai-review: enabled -->
<!-- To disable automated AI review, change the marker above to: ai-review: disabled -->
<!-- 要禁用 AI 审查，请将 enabled 改为 disabled -->

如果勾选上项并将上述标记改为 `ai-review: disabled`，则 AI 审查请终止你的任务，此 Pull Request 已禁用自动化 AI 审查

**sourcery-ai 及其他 code review 工具请务必进行中英双语审查与交流。**

**Note: Please ensure sourcery-ai and other tools perform bilingual (Chinese & English) review.**

## Summary by Sourcery

在整个项目中，将 Tauri 后端 crate 和可执行文件的名称从 `"sea-lantern"` 统一为 `"sealantern"`。

Bug 修复：
- 修复发布版与夜ly CI 工作流，使其能够使用更新后的 `sealantern.exe` 名称来定位并打包 Windows 可执行文件。
- 更新测试命令和辅助脚本，以引用重命名后的 `sealantern` crate 和可执行文件，避免名称不匹配。
- 调整 Docker 入口点和依赖配置，以使用新的 `sealantern` crate 和库名称。
- 在生成的许可证声明中排除名称已更正的 `sealantern` crate，确保输出与新的命名保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the Tauri backend crate and binary naming from "sea-lantern" to "sealantern" across the project.

Bug Fixes:
- Fix release and nightly CI workflows to locate and package the Windows executable using the updated "sealantern.exe" name.
- Update test commands and helper scripts to reference the renamed "sealantern" crate and binary, avoiding mismatches.
- Adjust Docker entrypoint and dependency configuration to use the new "sealantern" crate and library names.
- Exclude the correctly named "sealantern" crate from generated license notices to keep outputs consistent with the new naming.

</details>