### PR TITLE
refactor: 去掉tauri不用的server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,7 +5065,6 @@ dependencies = [
  "sealantern-core",
  "sealantern-extra",
  "sealantern-infra",
- "sealantern-server",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,6 @@ tauri-plugin-http = "2.5"
 tauri-plugin-opener = "2.5"
 tauri-plugin-process = "2.3"
 tauri-plugin-window-state = "2"
-sealantern-server = { path = "../server" }
 sealantern-extra = { path = "../crates/extra" }
 sealantern-core = { path = "../crates/core" }
 sealantern-infra = { path = "../crates/infra" }


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 从 Tauri 的 Cargo 清单中移除对 `sealantern-server` 的路径依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Remove the sealantern-server path dependency from the Tauri Cargo manifest.

</details>