### PR TITLE
refactor: 重构version.mjs脚本，统一项目内crate版本

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "docker-entry"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "sealantern",
 ]
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "sealantern-core"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "tracing",
  "zip",
@@ -5085,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "sealantern-extra"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "dirs 5.0.1",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "sealantern-infra"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "atomicwrites",
  "cap-std",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "sealantern-server"
-version = "0.1.0"
+version = "1.2.0"
 dependencies = [
  "axum",
  "sealantern-core",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sealantern-core"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/crates/extra/Cargo.toml
+++ b/crates/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sealantern-extra"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sealantern-infra"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/docker-entry/Cargo.toml
+++ b/docker-entry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-entry"
-version = "1.1.0"
+version = "1.2.0"
 description = "Docker 容器入口程序"
 edition = "2021"
 

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -5,21 +5,18 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
+const workspaceCargo = path.join(rootDir, "Cargo.toml");
 
-const files = {
-  packageJson: path.join(rootDir, "package.json"),
-  cargoToml: path.join(rootDir, "src-tauri", "Cargo.toml"),
-  tauriConf: path.join(rootDir, "src-tauri", "tauri.conf.json"),
-  pkgbuild: path.join(rootDir, "PKGBUILD"),
-  srcinfo: path.join(rootDir, ".SRCINFO"),
-};
+// ---------------------------------------------------------------------------
+// 工具函数
+// ---------------------------------------------------------------------------
 
-// 校验输入版本号是否符合语义化版本格式。
+/** 校验输入版本号是否符合语义化版本格式。 */
 function isValidVersion(version) {
   return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version);
 }
 
-// 判断指定路径的文件是否存在且可访问。
+/** 判断指定路径的文件是否存在且可访问。 */
 async function exists(filePath) {
   try {
     await access(filePath);
@@ -29,142 +26,193 @@ async function exists(filePath) {
   }
 }
 
-// 从 Cargo.toml 的 [package] 段中提取 version 值。
+/** 从 Cargo.toml 的 [package] 段中提取 version 值。 */
 function extractCargoPackageVersion(content) {
-  const packageSectionMatch = content.match(/\[package\][\s\S]*?(?=\n\[|$)/);
-  if (!packageSectionMatch) return null;
+  const section = content.match(/\[package\][\s\S]*?(?=\n\[|$)/)?.[0];
+  if (!section) return null;
 
-  const section = packageSectionMatch[0];
-  const versionMatch = section.match(/^version\s*=\s*"([^"]+)"/m);
-  return versionMatch?.[1] ?? null;
+  return section.match(/^version\s*=\s*"([^"]+)"/m)?.[1] ?? null;
 }
 
-// 将 Cargo.toml 的 [package] 段 version 字段替换为新版本。
+/** 将 Cargo.toml 的 [package] 段 version 字段替换为新版本。 */
 function replaceCargoPackageVersion(content, version) {
-  const packageSectionMatch = content.match(/\[package\][\s\S]*?(?=\n\[|$)/);
-  if (!packageSectionMatch) {
-    throw new Error("Cargo.toml 中未找到 [package] 段");
-  }
+  const section = content.match(/\[package\][\s\S]*?(?=\n\[|$)/)?.[0];
+  if (!section) throw new Error("Cargo.toml 中未找到 [package] 段");
 
-  const section = packageSectionMatch[0];
   if (!/^version\s*=\s*"[^"]+"/m.test(section)) {
     throw new Error("Cargo.toml 的 [package] 段中未找到 version 字段");
   }
 
   const newSection = section.replace(/^version\s*=\s*"[^"]+"/m, `version = "${version}"`);
-
   return content.replace(section, newSection);
 }
 
-// 读取并汇总核心及可选文件中的版本号信息。
-async function readVersions() {
-  const packageJsonRaw = await readFile(files.packageJson, "utf8");
-  const packageJson = JSON.parse(packageJsonRaw);
+// ---------------------------------------------------------------------------
+// 文件发现
+// ---------------------------------------------------------------------------
 
-  const cargoTomlRaw = await readFile(files.cargoToml, "utf8");
-  const cargoVersion = extractCargoPackageVersion(cargoTomlRaw);
+/** 从 workspace Cargo.toml 中解析 [workspace] members 列表。 */
+function parseWorkspaceMembers(content) {
+  const wsSection = content.match(/\[workspace\][\s\S]*?(?=\n\[|$)/)?.[0];
+  if (!wsSection) return [];
 
-  const tauriConfRaw = await readFile(files.tauriConf, "utf8");
-  const tauriConf = JSON.parse(tauriConfRaw);
+  const membersLine = wsSection.match(/^members\s*=\s*\[([^\]]+)\]/m)?.[1];
+  if (!membersLine) return [];
 
-  const versions = {
-    "package.json": packageJson.version ?? "(未找到)",
-    "src-tauri/Cargo.toml": cargoVersion ?? "(未找到)",
-    "src-tauri/tauri.conf.json": tauriConf.version ?? "(未找到)",
-  };
-
-  if (await exists(files.pkgbuild)) {
-    const pkgbuildRaw = await readFile(files.pkgbuild, "utf8");
-    const pkgver = pkgbuildRaw.match(/^pkgver\s*=\s*([^\s#]+)/m)?.[1] ?? "(未找到)";
-    versions.PKGBUILD = pkgver;
-  }
-
-  if (await exists(files.srcinfo)) {
-    const srcinfoRaw = await readFile(files.srcinfo, "utf8");
-    const pkgver = srcinfoRaw.match(/^\s*pkgver\s*=\s*(.+)$/m)?.[1]?.trim() ?? "(未找到)";
-    versions[".SRCINFO"] = pkgver;
-  }
-
-  return versions;
+  return membersLine
+    .split(",")
+    .map((m) => m.trim().replace(/["\s]/g, ""))
+    .filter(Boolean);
 }
 
-// 按统一格式输出版本信息并检查是否一致。
+/** 发现所有需要管理的文件路径。 */
+async function discoverFiles() {
+  const workspaceRaw = await readFile(workspaceCargo, "utf8");
+  const members = parseWorkspaceMembers(workspaceRaw);
+
+  // 先收集所有候选路径，再批量检查存在性
+  const candidates = [];
+
+  // workspace member 的 Cargo.toml
+  for (const member of members) {
+    candidates.push({
+      label: `${member}/Cargo.toml`,
+      path: path.join(rootDir, member, "Cargo.toml"),
+      type: "cargo",
+    });
+  }
+
+  // package.json
+  candidates.push({
+    label: "package.json",
+    path: path.join(rootDir, "package.json"),
+    type: "json",
+  });
+
+  // tauri.conf.json
+  candidates.push({
+    label: "src-tauri/tauri.conf.json",
+    path: path.join(rootDir, "src-tauri", "tauri.conf.json"),
+    type: "json",
+  });
+
+  // 可选：PKGBUILD / .SRCINFO（AUR 打包）
+  for (const name of ["PKGBUILD", ".SRCINFO"]) {
+    candidates.push({ label: name, path: path.join(rootDir, name), type: "pkgbuild" });
+  }
+
+  // 批量检查存在性
+  const results = await Promise.all(candidates.map((c) => exists(c.path)));
+
+  return candidates.filter((_, i) => results[i]);
+}
+
+// ---------------------------------------------------------------------------
+// 读取与输出
+// ---------------------------------------------------------------------------
+
+/** 提取单个文件的版本号。 */
+async function readVersion(file) {
+  const raw = await readFile(file.path, "utf8");
+
+  if (file.type === "cargo") {
+    return extractCargoPackageVersion(raw) ?? "(未找到)";
+  }
+  if (file.type === "json") {
+    try {
+      return JSON.parse(raw).version ?? "(未找到)";
+    } catch {
+      return "(解析失败)";
+    }
+  }
+  if (file.type === "pkgbuild") {
+    return raw.match(/^pkgver\s*=\s*([^\s#]+)/m)?.[1] ?? "(未找到)";
+  }
+  return "(未知类型)";
+}
+
+/** 读取所有文件的版本号。 */
+async function readVersions(files) {
+  const entries = await Promise.all(
+    files.map(async (file) => [file.label, await readVersion(file)]),
+  );
+  return Object.fromEntries(entries);
+}
+
+/** 按统一格式输出版本信息并检查是否一致。 */
 function printVersions(versions) {
   console.log("当前版本信息：\n");
   Object.entries(versions).forEach(([file, version]) => {
-    console.log(`${file}: ${version}`);
+    console.log(`  ${file}: ${version}`);
   });
 
-  const validValues = Object.values(versions).filter((v) => v !== "(未找到)");
+  const validValues = Object.values(versions).filter((v) => v !== "(未找到)" && v !== "(解析失败)");
   const unique = new Set(validValues);
   console.log("");
   if (unique.size <= 1) {
-    console.log("版本状态：所有已检测文件版本一致");
+    console.log("✅ 版本状态：所有已检测文件版本一致");
   } else {
-    console.log("版本状态：检测到版本不一致，请检查上述文件");
+    console.log("❌ 版本状态：检测到版本不一致，请检查上述文件");
   }
 }
 
-// 将新版本写入核心文件，并在存在时同步更新 AUR 相关文件。
-async function updateVersion(version) {
-  const packageJsonRaw = await readFile(files.packageJson, "utf8");
-  const packageJson = JSON.parse(packageJsonRaw);
-  packageJson.version = version;
-  await writeFile(files.packageJson, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+// ---------------------------------------------------------------------------
+// 写入
+// ---------------------------------------------------------------------------
 
-  const cargoTomlRaw = await readFile(files.cargoToml, "utf8");
-  const cargoTomlUpdated = replaceCargoPackageVersion(cargoTomlRaw, version);
-  await writeFile(files.cargoToml, cargoTomlUpdated, "utf8");
-
-  const tauriConfRaw = await readFile(files.tauriConf, "utf8");
-  const tauriConf = JSON.parse(tauriConfRaw);
-  tauriConf.version = version;
-  await writeFile(files.tauriConf, `${JSON.stringify(tauriConf, null, 2)}\n`, "utf8");
-
-  const optionalUpdated = [];
-
-  if (await exists(files.pkgbuild)) {
-    const pkgbuildRaw = await readFile(files.pkgbuild, "utf8");
-    const pkgbuildUpdated = pkgbuildRaw.replace(/^pkgver\s*=\s*([^\s#]+)/m, `pkgver=${version}`);
-    await writeFile(files.pkgbuild, pkgbuildUpdated, "utf8");
-    optionalUpdated.push("PKGBUILD");
+/** 生成单个文件的新内容。 */
+function buildUpdatedContent(file, raw, version) {
+  if (file.type === "cargo") {
+    return replaceCargoPackageVersion(raw, version);
   }
-
-  if (await exists(files.srcinfo)) {
-    const srcinfoRaw = await readFile(files.srcinfo, "utf8");
-    let srcinfoUpdated = srcinfoRaw
-      .replace(/^\s*pkgver\s*=\s*.+$/m, `\tpkgver = ${version}`)
-      .replace(
-        /^\s*source\s*=\s*.*Sea\.Lantern_.*\.deb$/m,
-        `\tsource = sealantern-${version}-amd64.deb::https://github.com/SeaLantern-Studio/SeaLantern/releases/download/v${version}/Sea.Lantern_${version}_amd64.deb`,
-      );
-
-    await writeFile(files.srcinfo, srcinfoUpdated, "utf8");
-    optionalUpdated.push(".SRCINFO");
+  if (file.type === "json") {
+    const parsed = JSON.parse(raw);
+    parsed.version = version;
+    return `${JSON.stringify(parsed, null, 2)}\n`;
   }
+  if (file.type === "pkgbuild") {
+    return raw.replace(/^pkgver\s*=\s*([^\s#]+)/m, `pkgver=${version}`);
+  }
+  throw new Error(`未知文件类型：${file.type}`);
+}
 
-  console.log(`已更新核心版本文件为 ${version}：`);
-  console.log("- package.json");
-  console.log("- src-tauri/Cargo.toml");
-  console.log("- src-tauri/tauri.conf.json");
-  if (optionalUpdated.length > 0) {
-    console.log(`另外已同步更新：${optionalUpdated.join(", ")}`);
+/** 将新版本写入所有核心文件。 */
+async function updateVersion(files, version) {
+  // 先并行读取所有文件
+  const contents = await Promise.all(files.map((f) => readFile(f.path, "utf8")));
+
+  // 并行生成新内容并写入
+  const writes = files.map(async (file, i) => {
+    const newContent = buildUpdatedContent(file, contents[i], version);
+    await writeFile(file.path, newContent, "utf8");
+    return file.label;
+  });
+
+  const updated = await Promise.all(writes);
+
+  console.log(`已更新 ${updated.length} 个文件为 ${version}：`);
+  for (const label of updated) {
+    console.log(`  - ${label}`);
   }
 }
 
-// 输出脚本命令帮助信息。
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
 function printUsage() {
   console.log("用法：");
-  console.log("  pnpm sv");
-  console.log("  pnpm cv <version>");
+  console.log("  pnpm sv                     查看当前所有版本号");
+  console.log("  pnpm cv <version>           统一修改所有版本号");
 }
 
-// 解析命令参数并分发到查看或修改版本流程。
 async function main() {
   const [command, value] = process.argv.slice(2);
 
+  const files = await discoverFiles();
+
   if (!command || command === "show") {
-    const versions = await readVersions();
+    const versions = await readVersions(files);
     printVersions(versions);
     return;
   }
@@ -173,14 +221,13 @@ async function main() {
     if (!value) {
       throw new Error("请提供新版本号，例如：pnpm cv 1.2.3");
     }
-
     if (!isValidVersion(value)) {
       throw new Error(`无效版本号：${value}，请使用语义化版本，例如 1.2.3`);
     }
 
-    await updateVersion(value);
-    const versions = await readVersions();
+    await updateVersion(files, value);
     console.log("");
+    const versions = await readVersions(files);
     printVersions(versions);
     return;
   }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sealantern-server"
-version = "0.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "GPL-3.0-only"
 


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `提交前测试必读！！！.md` 并完成测试
- [x] CI 通过
- [x] Self-review 完成

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

> 导入规范：使用别名导入，避免 `../`

## 变更摘要

懒得写

### 界面变动（可选）

<img width="912" height="517" alt="image" src="https://github.com/user-attachments/assets/b032f661-693d-4b98-9b70-b9ad60b1e0be" />

## 关联 Issue

- 无

## 自动化审查

- [ ] 禁用 AI 审查

<!-- ai-review: enabled -- 改为 disabled 可禁用 -->

---
## Summary by Sourcery

重构版本管理脚本，使其能够作用于所有工作区 crate 及相关配置文件，并将 Rust crate 版本统一到同一发布版本。

增强功能：
- 重新设计 `version.mjs`，以动态发现工作区成员，并在 `Cargo.toml`、`package.json`、`tauri.conf.json` 以及可选的 AUR 打包文件中统一管理版本。
- 改进版本报告和 CLI 使用输出，更清晰地展示版本一致性状态及支持的命令。

日常维护：
- 将工作区中所有 Rust crate 包的版本更新为 `1.2.0`，实现统一的项目版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the version management script to operate on all workspace crates and related config files, and align Rust crate versions to a unified release.

Enhancements:
- Redesign version.mjs to dynamically discover workspace members and manage versions across Cargo.toml, package.json, tauri.conf.json, and optional AUR packaging files.
- Improve version reporting and CLI usage output to clearly show consistency status and supported commands.

Chores:
- Update all Rust crate package versions in the workspace to 1.2.0 for a unified project version.

</details>