### PR TITLE
feat: 增加实例注册表存储

### DIFF
--- a/crates/infra/src/persistence/instance_registry.rs
+++ b/crates/infra/src/persistence/instance_registry.rs
@@ -1,0 +1,225 @@
+use std::fmt;
+
+use rusqlite::params;
+
+use super::{PersistenceError, SqlValue, SqliteDatabase};
+
+const CREATE_INSTANCE_REGISTRY_TABLE: &str = "
+    CREATE TABLE IF NOT EXISTS instance_registry (
+        instance_id TEXT PRIMARY KEY NOT NULL CHECK (length(trim(instance_id)) > 0),
+        payload TEXT NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+";
+
+/// 不依赖领域模型的实例注册表记录。
+///
+/// `payload` 由调用方负责序列化和反序列化，避免基础设施 crate 依赖 `core`。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceRegistryRecord {
+    id: String,
+    payload: String,
+}
+
+impl InstanceRegistryRecord {
+    /// 使用非空实例标识和不透明持久化载荷构造记录。
+    pub fn new(
+        id: impl Into<String>,
+        payload: impl Into<String>,
+    ) -> Result<Self, InstanceRegistryError> {
+        let id = normalize_id(id.into())?;
+        Ok(Self { id, payload: payload.into() })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn payload(&self) -> &str {
+        &self.payload
+    }
+}
+
+/// 实例注册表的 SQLite 持久化适配器。
+///
+/// 此类型只保存 ID 和调用方提供的载荷，不实现 `core::instance::InstanceRepository`。
+#[derive(Clone)]
+pub struct InstanceRegistry {
+    database: SqliteDatabase,
+}
+
+impl InstanceRegistry {
+    /// 初始化注册表表结构并绑定到已打开的数据库。
+    pub async fn initialize(database: SqliteDatabase) -> Result<Self, InstanceRegistryError> {
+        database
+            .write("initialize instance registry", |transaction| {
+                transaction.execute_batch(CREATE_INSTANCE_REGISTRY_TABLE)?;
+                Ok(())
+            })
+            .await
+            .map_err(InstanceRegistryError::Persistence)?;
+        Ok(Self { database })
+    }
+
+    /// 按稳定 ID 排序列出所有注册表记录。
+    pub async fn list(&self) -> Result<Vec<InstanceRegistryRecord>, InstanceRegistryError> {
+        let rows = self
+            .database
+            .query_with_operation(
+                "list instance registry records",
+                "SELECT instance_id, payload FROM instance_registry ORDER BY instance_id",
+                Vec::new(),
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .await
+            .map_err(InstanceRegistryError::Persistence)?;
+        rows.into_iter()
+            .map(|(id, payload)| InstanceRegistryRecord::new(id, payload))
+            .collect()
+    }
+
+    /// 查找一个实例注册表记录。
+    pub async fn find(
+        &self,
+        id: &str,
+    ) -> Result<Option<InstanceRegistryRecord>, InstanceRegistryError> {
+        let id = normalize_id(id.to_owned())?;
+        let mut rows = self
+            .database
+            .query_with_operation(
+                "find instance registry record",
+                "SELECT instance_id, payload FROM instance_registry WHERE instance_id = ?1",
+                vec![SqlValue::Text(id)],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .await
+            .map_err(InstanceRegistryError::Persistence)?;
+        rows.pop()
+            .map(|(id, payload)| InstanceRegistryRecord::new(id, payload))
+            .transpose()
+    }
+
+    /// 以 ID 为键原子创建或更新一个记录。
+    pub async fn save(&self, record: InstanceRegistryRecord) -> Result<(), InstanceRegistryError> {
+        self.database
+            .write("save instance registry record", move |transaction| {
+                transaction.execute(
+                    "INSERT INTO instance_registry (instance_id, payload) VALUES (?1, ?2) \
+                     ON CONFLICT(instance_id) DO UPDATE SET \
+                         payload = excluded.payload, \
+                         updated_at = CURRENT_TIMESTAMP",
+                    params![record.id, record.payload],
+                )?;
+                Ok(())
+            })
+            .await
+            .map_err(InstanceRegistryError::Persistence)
+    }
+
+    /// 删除一个记录，并报告该 ID 是否原本存在。
+    pub async fn remove(&self, id: &str) -> Result<bool, InstanceRegistryError> {
+        let id = normalize_id(id.to_owned())?;
+        self.database
+            .write("remove instance registry record", move |transaction| {
+                let affected = transaction
+                    .execute("DELETE FROM instance_registry WHERE instance_id = ?1", params![id])?;
+                Ok(affected != 0)
+            })
+            .await
+            .map_err(InstanceRegistryError::Persistence)
+    }
+}
+
+/// 实例注册表操作的可诊断错误。
+#[derive(Debug)]
+pub enum InstanceRegistryError {
+    EmptyId,
+    Persistence(PersistenceError),
+}
+
+impl fmt::Display for InstanceRegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyId => write!(formatter, "instance registry ID cannot be empty"),
+            Self::Persistence(error) => {
+                write!(formatter, "instance registry operation failed: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for InstanceRegistryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Persistence(error) => Some(error),
+            Self::EmptyId => None,
+        }
+    }
+}
+
+fn normalize_id(id: String) -> Result<String, InstanceRegistryError> {
+    let id = id.trim().to_owned();
+    if id.is_empty() {
+        return Err(InstanceRegistryError::EmptyId);
+    }
+    Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{InstanceRegistry, InstanceRegistryError, InstanceRegistryRecord};
+    use crate::persistence::SqliteDatabase;
+
+    fn database_path(label: &str) -> PathBuf {
+        crate::fs::test_dir(label).join("state.sqlite")
+    }
+
+    #[tokio::test]
+    async fn saves_lists_finds_and_removes_records() {
+        let path = database_path("instance-registry-crud");
+        let registry = InstanceRegistry::initialize(SqliteDatabase::open(&path).await.unwrap())
+            .await
+            .unwrap();
+        registry
+            .save(InstanceRegistryRecord::new("beta", "first").unwrap())
+            .await
+            .unwrap();
+        registry
+            .save(InstanceRegistryRecord::new("alpha", "initial").unwrap())
+            .await
+            .unwrap();
+        registry
+            .save(InstanceRegistryRecord::new("alpha", "updated").unwrap())
+            .await
+            .unwrap();
+
+        let records = registry.list().await.unwrap();
+        assert_eq!(
+            records,
+            vec![
+                InstanceRegistryRecord::new("alpha", "updated").unwrap(),
+                InstanceRegistryRecord::new("beta", "first").unwrap(),
+            ]
+        );
+        assert_eq!(
+            registry.find(" alpha ").await.unwrap(),
+            Some(InstanceRegistryRecord::new("alpha", "updated").unwrap())
+        );
+        assert!(registry.remove("alpha").await.unwrap());
+        assert!(!registry.remove("alpha").await.unwrap());
+        assert!(registry.find("alpha").await.unwrap().is_none());
+
+        drop(registry);
+        std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_registry_ids() {
+        assert!(matches!(
+            InstanceRegistryRecord::new("  ", "payload"),
+            Err(InstanceRegistryError::EmptyId)
+        ));
+    }
+}

--- a/crates/infra/src/persistence/mod.rs
+++ b/crates/infra/src/persistence/mod.rs
@@ -1,9 +1,11 @@
 pub mod config;
 mod coordination;
 mod error;
+mod instance_registry;
 mod sqlite;
 
 pub use config::{ConfigError, ConfigFile, ConfigFormat};
 pub use coordination::{process_lock_registry, ProcessLockRegistry, ProcessResourceLock};
 pub use error::PersistenceError;
+pub use instance_registry::{InstanceRegistry, InstanceRegistryError, InstanceRegistryRecord};
 pub use sqlite::{Migration, SqlValue, SqliteDatabase, SqliteOptions, SqliteSynchronousMode};

--- a/crates/infra/src/persistence/sqlite.rs
+++ b/crates/infra/src/persistence/sqlite.rs
@@ -150,6 +150,23 @@ impl SqliteDatabase {
         &self,
         sql: impl Into<String>,
         params: P,
+        map_row: F,
+    ) -> Result<Vec<T>, PersistenceError>
+    where
+        T: Send + 'static,
+        P: IntoIterator<Item = SqlValue> + Send + 'static,
+        F: FnMut(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        self.query_with_operation("query", sql, params, map_row)
+            .await
+    }
+
+    /// 查询记录，并为错误追踪指定调用方的稳定操作名称。
+    pub async fn query_with_operation<T, P, F>(
+        &self,
+        operation: &'static str,
+        sql: impl Into<String>,
+        params: P,
         mut map_row: F,
     ) -> Result<Vec<T>, PersistenceError>
     where
@@ -159,14 +176,14 @@ impl SqliteDatabase {
     {
         let sql = sql.into();
         let result = self
-            .with_connection("query", move |connection| {
+            .with_connection(operation, move |connection| {
                 let mut statement = connection.prepare(&sql)?;
                 let rows =
                     statement.query_map(rusqlite::params_from_iter(params), |row| map_row(row))?;
                 rows.collect()
             })
             .await;
-        report_operation_error("query", &self.path, &result);
+        report_operation_error(operation, &self.path, &result);
         result
     }
 


### PR DESCRIPTION
补充 infra 实例注册表的 SQLite 持久化能力与可诊断查询操作。

## Summary by Sourcery

引入一个以 SQLite 为后端的实例注册表，支持 CRUD 操作，并通过允许为数据库操作打上稳定名称标签来改进查询诊断能力。

新功能：
- 添加一个实例注册表持久化适配器，通过 SQLite 存储实例 ID 和不透明负载（opaque payload）。
- 从持久化模块中导出实例注册表相关类型（registry、record 和 error），以便其他 crate 使用。

改进：
- 扩展 `SqliteDatabase` 的查询支持，使其可选地接受一个命名的操作，以提供更好的错误报告。

测试：
- 添加类似集成测试的用例，覆盖实例注册表初始化、CRUD 行为、ID 规范化以及空 ID 校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a SQLite-backed instance registry with CRUD operations and improve diagnostics for database queries by allowing operations to be tagged with stable names.

New Features:
- Add an instance registry persistence adapter that stores instance IDs and opaque payloads in SQLite.
- Expose instance registry types (registry, record, and error) from the persistence module for use by other crates.

Enhancements:
- Extend SqliteDatabase query support to optionally accept a named operation for better error reporting.

Tests:
- Add integration-style tests covering instance registry initialization, CRUD behavior, ID normalization, and empty-ID validation.

</details>