### PR TITLE
fix(ci): 微调issue-check逻辑

### DIFF
--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -3,7 +3,7 @@ name: 检查 PR 关联的 Issue
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
 permissions:
   pull-requests: read
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check-linked-issue:
     runs-on: ubuntu-22.04
-    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) }}
+    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && !contains(toJSON(github.event.pull_request.labels), '"name":"internal"') }}
     steps:
       - name: 检查是否关联 Issue
         uses: actions/github-script@v7

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -12,12 +12,13 @@ permissions:
 jobs:
   check-linked-issue:
     runs-on: ubuntu-22.04
-    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && !contains(toJSON(github.event.pull_request.labels), '"name":"internal"') }}
+    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association) && !contains(github.event.pull_request.labels.*.name, 'internal') }}
     steps:
       - name: 检查是否关联 Issue
         uses: actions/github-script@v7
         with:
           script: |
+            core.info(`author_association: ${context.payload.pull_request.author_association}`);
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
 

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.info(`author_association: ${context.payload.pull_request.author_association}`);
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
 


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

调整 PR issue-check 工作流的触发条件以及针对非成员作者的基于标签过滤。

CI：
- 当 PR 标签被添加或移除时触发 issue-check 工作流。
- 对被标记为 internal 的 PR 跳过 issue-check，同时仍然排除 MEMBER 和 OWNER 作者。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust PR issue-check workflow triggers and label-based filtering for non-member authors.

CI:
- Trigger the issue-check workflow when PR labels are added or removed.
- Skip issue-check for PRs labeled as internal while still excluding MEMBER and OWNER authors.

</details>