### PR TITLE
feat(extra): add server cron task api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,8 +738,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -929,6 +931,17 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -3254,6 +3267,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,6 +3580,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "noq"
@@ -5088,6 +5117,8 @@ name = "sealantern-extra"
 version = "1.2.0"
 dependencies = [
  "async-trait",
+ "chrono",
+ "cron",
  "dirs 5.0.1",
  "mlua",
  "regex",
@@ -5097,9 +5128,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "tokio",
  "tracing",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/extra/Cargo.toml
+++ b/crates/extra/Cargo.toml
@@ -16,6 +16,8 @@ tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+cron = "0.12"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "sync"] }
 urlencoding = "2"
 sealantern-infra = { path = "../infra" }
@@ -25,3 +27,7 @@ sha2 = "0.10"
 dirs = "5"
 mlua = { version = "0.10", features = ["lua54", "vendored", "serialize", "send"] }
 sculk = { version = "=0.3.1", default-features = false, optional = true }
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/extra/src/lib.rs
+++ b/crates/extra/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod download_link;
 pub mod models;
 pub mod observability;
+pub mod server;
 pub mod update;
 
 #[cfg(feature = "online-tunnel")]

--- a/crates/extra/src/observability.rs
+++ b/crates/extra/src/observability.rs
@@ -7,6 +7,55 @@ use std::fmt::Display;
 
 use crate::config::sealantern::types::SettingsGroup;
 
+/// 服务器定时任务模块的 tracing 目标。
+pub const SERVER_CRON_TASK_TARGET: &str = "sealantern.extra.server.cron_task";
+
+/// Event: 定时任务开始执行。
+pub const EVENT_SERVER_CRON_TASK_STARTED: &str = "server_cron_task_started";
+/// Event: 定时任务执行成功。
+pub const EVENT_SERVER_CRON_TASK_COMPLETED: &str = "server_cron_task_completed";
+/// Event: 定时任务执行失败。
+pub const EVENT_SERVER_CRON_TASK_FAILED: &str = "server_cron_task_failed";
+
+pub(crate) fn server_cron_task_started(task_id: &str, server_id: &str, action: &str) {
+    tracing::info!(
+        target: SERVER_CRON_TASK_TARGET,
+        event_name = EVENT_SERVER_CRON_TASK_STARTED,
+        task_id,
+        server_id,
+        action,
+        "server cron task started"
+    );
+}
+
+pub(crate) fn server_cron_task_completed(task_id: &str, server_id: &str, action: &str) {
+    tracing::info!(
+        target: SERVER_CRON_TASK_TARGET,
+        event_name = EVENT_SERVER_CRON_TASK_COMPLETED,
+        task_id,
+        server_id,
+        action,
+        "server cron task completed"
+    );
+}
+
+pub(crate) fn server_cron_task_failed(
+    task_id: &str,
+    server_id: &str,
+    action: &str,
+    error: &dyn Display,
+) {
+    tracing::error!(
+        target: SERVER_CRON_TASK_TARGET,
+        event_name = EVENT_SERVER_CRON_TASK_FAILED,
+        task_id,
+        server_id,
+        action,
+        error = %error,
+        "server cron task failed"
+    );
+}
+
 /// 应用插件执行内核的 tracing 目标。
 pub const APP_PLUGIN_TARGET: &str = "sealantern.extra.app_plugin";
 

--- a/crates/extra/src/server/cron_task/mod.rs
+++ b/crates/extra/src/server/cron_task/mod.rs
@@ -1,0 +1,11 @@
+//! 服务器 Cron 定时任务。
+//!
+//! 此模块只负责任务模型、持久化和执行调度。宿主通过
+//! [`CronTaskExecutor`] 注入实际的服务器操作，避免 `extra` 反向依赖
+//! `core` 或特定的桌面运行时。
+
+mod model;
+mod service;
+
+pub use model::{CronTask, CronTaskAction, CronTaskDraft, CronTaskList, CronTaskRun};
+pub use service::{CronTaskError, CronTaskExecutor, CronTaskService};

--- a/crates/extra/src/server/cron_task/model.rs
+++ b/crates/extra/src/server/cron_task/model.rs
@@ -1,0 +1,59 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// 定时任务的实际服务器动作。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CronTaskAction {
+    Restart,
+    Command { command: String },
+}
+
+impl CronTaskAction {
+    pub(crate) const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Restart => "restart",
+            Self::Command { .. } => "command",
+        }
+    }
+}
+
+/// 创建或更新定时任务时可修改的字段。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CronTaskDraft {
+    pub name: String,
+    pub server_id: String,
+    pub cron_expression: String,
+    pub action: CronTaskAction,
+    pub enabled: bool,
+}
+
+/// 已持久化的服务器定时任务。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CronTask {
+    pub id: String,
+    pub name: String,
+    pub server_id: String,
+    pub cron_expression: String,
+    pub action: CronTaskAction,
+    pub enabled: bool,
+    pub last_run_at: Option<DateTime<Utc>>,
+    pub next_run_at: Option<DateTime<Utc>>,
+    pub last_error: Option<String>,
+}
+
+/// 定时任务持久化文件的根对象。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CronTaskList {
+    pub tasks: Vec<CronTask>,
+}
+
+/// 一次定时任务执行的结果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronTaskRun {
+    pub task_id: String,
+    pub server_id: String,
+    pub action: &'static str,
+    pub succeeded: bool,
+    pub error: Option<String>,
+}

--- a/crates/extra/src/server/cron_task/service.rs
+++ b/crates/extra/src/server/cron_task/service.rs
@@ -1,0 +1,516 @@
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use sealantern_infra::fs::FsError;
+use sealantern_infra::persistence::ConfigFile;
+use uuid::Uuid;
+
+use crate::observability;
+
+use super::model::{CronTask, CronTaskAction, CronTaskDraft, CronTaskList, CronTaskRun};
+
+/// 宿主提供的服务器操作。
+#[async_trait]
+pub trait CronTaskExecutor: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    async fn restart_server(&self, server_id: &str) -> Result<(), Self::Error>;
+
+    async fn send_server_command(&self, server_id: &str, command: &str) -> Result<(), Self::Error>;
+}
+
+/// Cron 任务服务错误。
+#[derive(Debug)]
+pub enum CronTaskError {
+    Storage(FsError),
+    TaskNotFound(String),
+    InvalidTask(&'static str),
+    InvalidCron { expression: String, message: String },
+    Execution { task_id: String, message: String },
+}
+
+impl fmt::Display for CronTaskError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Storage(error) => write!(formatter, "cron task storage failed: {error}"),
+            Self::TaskNotFound(id) => write!(formatter, "cron task not found: {id}"),
+            Self::InvalidTask(reason) => write!(formatter, "invalid cron task: {reason}"),
+            Self::InvalidCron { expression, message } => {
+                write!(formatter, "invalid cron expression '{expression}': {message}")
+            }
+            Self::Execution { task_id, message } => {
+                write!(formatter, "cron task execution failed for {task_id}: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CronTaskError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Storage(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<FsError> for CronTaskError {
+    fn from(error: FsError) -> Self {
+        Self::Storage(error)
+    }
+}
+
+/// 任务的持久化和执行调度服务。
+pub struct CronTaskService<E> {
+    config: ConfigFile<CronTaskList>,
+    executor: E,
+}
+
+impl<E: CronTaskExecutor> CronTaskService<E> {
+    /// 从 JSON 文件加载任务；文件不存在时创建空列表。
+    pub async fn load(path: impl Into<PathBuf>, executor: E) -> Result<Self, CronTaskError> {
+        let config = ConfigFile::load_or_create(path, CronTaskList::default()).await?;
+        Ok(Self { config, executor })
+    }
+
+    /// 返回当前任务列表。
+    pub fn tasks(&self) -> &[CronTask] {
+        &self.config.get().tasks
+    }
+
+    /// 创建任务并计算首次执行时间。
+    pub async fn create(&mut self, draft: CronTaskDraft) -> Result<CronTask, CronTaskError> {
+        validate_draft(&draft)?;
+        let task = CronTask {
+            id: Uuid::new_v4().to_string(),
+            name: draft.name.trim().to_owned(),
+            server_id: draft.server_id.trim().to_owned(),
+            cron_expression: normalize_cron_expression(&draft.cron_expression)?,
+            action: draft.action,
+            enabled: draft.enabled,
+            last_run_at: None,
+            next_run_at: None,
+            last_error: None,
+        };
+        let mut task = task;
+        task.next_run_at = Some(next_run_after(&task.cron_expression, Utc::now())?);
+
+        let previous = self.config.get().clone();
+        self.config.update(|list| list.tasks.push(task.clone()));
+        self.persist_or_restore(previous).await?;
+        Ok(task)
+    }
+
+    /// 更新任务配置，保留执行历史并重新计算下次运行时间。
+    pub async fn update(
+        &mut self,
+        id: &str,
+        draft: CronTaskDraft,
+    ) -> Result<CronTask, CronTaskError> {
+        validate_draft(&draft)?;
+        let cron_expression = normalize_cron_expression(&draft.cron_expression)?;
+        let next_run_at = next_run_after(&cron_expression, Utc::now())?;
+        let previous = self.config.get().clone();
+        let index = self
+            .config
+            .get()
+            .tasks
+            .iter()
+            .position(|task| task.id == id)
+            .ok_or_else(|| CronTaskError::TaskNotFound(id.to_owned()))?;
+        let task = self.config.get().tasks[index].clone();
+
+        let updated = CronTask {
+            id: task.id,
+            name: draft.name.trim().to_owned(),
+            server_id: draft.server_id.trim().to_owned(),
+            cron_expression,
+            action: draft.action,
+            enabled: draft.enabled,
+            last_run_at: task.last_run_at,
+            next_run_at: Some(next_run_at),
+            last_error: task.last_error,
+        };
+        self.config
+            .update(|list| list.tasks[index] = updated.clone());
+        self.persist_or_restore(previous).await?;
+        Ok(updated)
+    }
+
+    /// 删除任务。
+    pub async fn delete(&mut self, id: &str) -> Result<(), CronTaskError> {
+        let previous = self.config.get().clone();
+        self.config
+            .update(|list| list.tasks.retain(|task| task.id != id));
+        if self.config.get().tasks.len() == previous.tasks.len() {
+            self.config.set(previous);
+            return Err(CronTaskError::TaskNotFound(id.to_owned()));
+        }
+        self.persist_or_restore(previous).await
+    }
+
+    /// 设置任务是否参与自动调度。
+    pub async fn set_enabled(
+        &mut self,
+        id: &str,
+        enabled: bool,
+    ) -> Result<CronTask, CronTaskError> {
+        let previous = self.config.get().clone();
+        let index = self
+            .config
+            .get()
+            .tasks
+            .iter()
+            .position(|task| task.id == id)
+            .ok_or_else(|| CronTaskError::TaskNotFound(id.to_owned()))?;
+        let task = self.config.get().tasks[index].clone();
+        let mut updated = task;
+        updated.enabled = enabled;
+        if enabled {
+            updated.next_run_at = Some(next_run_after(&updated.cron_expression, Utc::now())?);
+        }
+        self.config
+            .update(|list| list.tasks[index] = updated.clone());
+        self.persist_or_restore(previous).await?;
+        Ok(updated)
+    }
+
+    /// 执行指定任务，并记录本次尝试及下一次计划时间。
+    pub async fn run_now(
+        &mut self,
+        id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<CronTaskRun, CronTaskError> {
+        let task = self
+            .config
+            .get()
+            .tasks
+            .iter()
+            .find(|task| task.id == id)
+            .cloned()
+            .ok_or_else(|| CronTaskError::TaskNotFound(id.to_owned()))?;
+        self.run_task(task, now).await
+    }
+
+    /// 执行所有已到期且启用的任务。
+    pub async fn run_due(&mut self, now: DateTime<Utc>) -> Result<Vec<CronTaskRun>, CronTaskError> {
+        let due_tasks = self
+            .config
+            .get()
+            .tasks
+            .iter()
+            .filter(|task| task.enabled && task.next_run_at.is_some_and(|next_run| next_run <= now))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        let mut runs = Vec::with_capacity(due_tasks.len());
+        for task in due_tasks {
+            let failed_run = CronTaskRun {
+                task_id: task.id.clone(),
+                server_id: task.server_id.clone(),
+                action: task.action.as_str(),
+                succeeded: false,
+                error: None,
+            };
+            match self.run_task(task, now).await {
+                Ok(run) => runs.push(run),
+                Err(CronTaskError::Execution { message, .. }) => {
+                    runs.push(CronTaskRun { error: Some(message), ..failed_run })
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(runs)
+    }
+
+    async fn run_task(
+        &mut self,
+        task: CronTask,
+        now: DateTime<Utc>,
+    ) -> Result<CronTaskRun, CronTaskError> {
+        let action = task.action.as_str();
+        observability::server_cron_task_started(&task.id, &task.server_id, action);
+
+        let execution_error = match &task.action {
+            CronTaskAction::Restart => self
+                .executor
+                .restart_server(&task.server_id)
+                .await
+                .err()
+                .map(|error| error.to_string()),
+            CronTaskAction::Command { command } => self
+                .executor
+                .send_server_command(&task.server_id, command)
+                .await
+                .err()
+                .map(|error| error.to_string()),
+        };
+
+        let run = CronTaskRun {
+            task_id: task.id.clone(),
+            server_id: task.server_id.clone(),
+            action,
+            succeeded: execution_error.is_none(),
+            error: execution_error.clone(),
+        };
+        self.record_attempt(&task.id, now, execution_error).await?;
+
+        if let Some(error) = &run.error {
+            let error = CronTaskError::Execution {
+                task_id: task.id.clone(),
+                message: error.clone(),
+            };
+            observability::server_cron_task_failed(&task.id, &task.server_id, action, &error);
+            return Err(error);
+        }
+
+        observability::server_cron_task_completed(&task.id, &task.server_id, action);
+        Ok(run)
+    }
+
+    async fn record_attempt(
+        &mut self,
+        id: &str,
+        now: DateTime<Utc>,
+        error: Option<String>,
+    ) -> Result<(), CronTaskError> {
+        let index = self
+            .config
+            .get()
+            .tasks
+            .iter()
+            .position(|task| task.id == id)
+            .ok_or_else(|| CronTaskError::TaskNotFound(id.to_owned()))?;
+        let next_run = next_run_after(&self.config.get().tasks[index].cron_expression, now)?;
+        let previous = self.config.get().clone();
+        self.config.update(|list| {
+            let task = &mut list.tasks[index];
+            task.last_run_at = Some(now);
+            task.next_run_at = Some(next_run);
+            task.last_error = error;
+        });
+        self.persist_or_restore(previous).await
+    }
+
+    async fn persist_or_restore(&mut self, previous: CronTaskList) -> Result<(), CronTaskError> {
+        if let Err(error) = self.config.save(false).await {
+            self.config.set(previous);
+            return Err(error.into());
+        }
+        Ok(())
+    }
+}
+
+fn validate_draft(draft: &CronTaskDraft) -> Result<(), CronTaskError> {
+    if draft.name.trim().is_empty() {
+        return Err(CronTaskError::InvalidTask("name must not be empty"));
+    }
+    if draft.server_id.trim().is_empty() {
+        return Err(CronTaskError::InvalidTask("server_id must not be empty"));
+    }
+    if matches!(&draft.action, CronTaskAction::Command { command } if command.trim().is_empty()) {
+        return Err(CronTaskError::InvalidTask("command must not be empty"));
+    }
+    Ok(())
+}
+
+fn normalize_cron_expression(expression: &str) -> Result<String, CronTaskError> {
+    let trimmed = expression.trim();
+    let field_count = trimmed.split_whitespace().count();
+    let normalized = match field_count {
+        5 => format!("0 {trimmed}"),
+        6 => trimmed.to_owned(),
+        _ => {
+            return Err(CronTaskError::InvalidCron {
+                expression: expression.to_owned(),
+                message: "expected five or six fields".to_owned(),
+            });
+        }
+    };
+    Schedule::from_str(&normalized).map_err(|error| CronTaskError::InvalidCron {
+        expression: expression.to_owned(),
+        message: error.to_string(),
+    })?;
+    Ok(normalized)
+}
+
+fn next_run_after(expression: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>, CronTaskError> {
+    let schedule = Schedule::from_str(expression).map_err(|error| CronTaskError::InvalidCron {
+        expression: expression.to_owned(),
+        message: error.to_string(),
+    })?;
+    schedule
+        .after(&now)
+        .next()
+        .ok_or_else(|| CronTaskError::InvalidCron {
+            expression: expression.to_owned(),
+            message: "no upcoming occurrence".to_owned(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    use chrono::Duration;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct TestExecutor {
+        calls: Arc<Mutex<Vec<String>>>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl CronTaskExecutor for TestExecutor {
+        type Error = io::Error;
+
+        async fn restart_server(&self, server_id: &str) -> Result<(), Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("restart:{server_id}"));
+            if self.fail {
+                return Err(io::Error::other("restart failed"));
+            }
+            Ok(())
+        }
+
+        async fn send_server_command(
+            &self,
+            server_id: &str,
+            command: &str,
+        ) -> Result<(), Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("command:{server_id}:{command}"));
+            if self.fail {
+                return Err(io::Error::other("command failed"));
+            }
+            Ok(())
+        }
+    }
+
+    fn draft(action: CronTaskAction) -> CronTaskDraft {
+        CronTaskDraft {
+            name: "Nightly task".to_owned(),
+            server_id: "server-a".to_owned(),
+            cron_expression: "* * * * *".to_owned(),
+            action,
+            enabled: true,
+        }
+    }
+
+    async fn service(executor: TestExecutor) -> (tempfile::TempDir, CronTaskService<TestExecutor>) {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("cron_tasks.json");
+        let service = CronTaskService::load(path, executor).await.unwrap();
+        (directory, service)
+    }
+
+    #[tokio::test]
+    async fn creates_and_executes_a_command_task() {
+        let executor = TestExecutor::default();
+        let calls = Arc::clone(&executor.calls);
+        let (_directory, mut service) = service(executor).await;
+        let task = service
+            .create(draft(CronTaskAction::Command { command: "say scheduled".to_owned() }))
+            .await
+            .unwrap();
+
+        let run = service.run_now(&task.id, Utc::now()).await.unwrap();
+
+        assert!(run.succeeded);
+        assert_eq!(*calls.lock().unwrap(), ["command:server-a:say scheduled"]);
+        assert!(service.tasks()[0].last_run_at.is_some());
+        assert!(service.tasks()[0].last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_execution_is_recorded_and_rescheduled() {
+        let (_directory, mut service) =
+            service(TestExecutor { fail: true, ..Default::default() }).await;
+        let task = service
+            .create(draft(CronTaskAction::Restart))
+            .await
+            .unwrap();
+        let now = Utc::now();
+
+        let result = service.run_now(&task.id, now).await;
+
+        assert!(matches!(result, Err(CronTaskError::Execution { .. })));
+        let task = &service.tasks()[0];
+        assert_eq!(task.last_run_at, Some(now));
+        assert!(task.next_run_at.is_some_and(|next| next > now));
+        assert_eq!(task.last_error.as_deref(), Some("restart failed"));
+    }
+
+    #[tokio::test]
+    async fn due_tasks_execute_once_and_advance_the_schedule() {
+        let executor = TestExecutor::default();
+        let calls = Arc::clone(&executor.calls);
+        let (_directory, mut service) = service(executor).await;
+        let task = service
+            .create(draft(CronTaskAction::Restart))
+            .await
+            .unwrap();
+        let now = Utc::now();
+        service.config.update(|list| {
+            list.tasks[0].next_run_at = Some(now - Duration::seconds(1));
+        });
+
+        let runs = service.run_due(now).await.unwrap();
+
+        assert_eq!(runs.len(), 1);
+        assert!(runs[0].succeeded);
+        assert_eq!(*calls.lock().unwrap(), ["restart:server-a"]);
+        assert!(service.tasks()[0]
+            .next_run_at
+            .is_some_and(|next| next > now));
+        assert_eq!(service.tasks()[0].id, task.id);
+    }
+
+    #[tokio::test]
+    async fn due_task_failure_does_not_stop_later_tasks() {
+        let executor = TestExecutor { fail: true, ..Default::default() };
+        let (_directory, mut service) = service(executor).await;
+        let first = service
+            .create(draft(CronTaskAction::Restart))
+            .await
+            .unwrap();
+        let second = service
+            .create(CronTaskDraft {
+                name: "Second task".to_owned(),
+                ..draft(CronTaskAction::Command { command: "say still runs".to_owned() })
+            })
+            .await
+            .unwrap();
+        let now = Utc::now();
+        service.config.update(|list| {
+            for task in &mut list.tasks {
+                task.next_run_at = Some(now - Duration::seconds(1));
+            }
+        });
+
+        let runs = service.run_due(now).await.unwrap();
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].task_id, first.id);
+        assert_eq!(runs[1].task_id, second.id);
+        assert!(runs.iter().all(|run| !run.succeeded));
+    }
+
+    #[test]
+    fn accepts_five_or_six_field_cron_expressions() {
+        assert_eq!(normalize_cron_expression("0 4 * * *").unwrap(), "0 0 4 * * *");
+        assert_eq!(normalize_cron_expression("0 0 4 * * *").unwrap(), "0 0 4 * * *");
+    }
+}

--- a/crates/extra/src/server/mod.rs
+++ b/crates/extra/src/server/mod.rs
@@ -1,0 +1,3 @@
+//! 服务器扩展功能。
+
+pub mod cron_task;


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

完成了定时任务功能

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

增加了定时任务调度器能力，支持通过 Cron 表达式管理服务相关定时任务。用户现在可以在应用内新增、编辑、删除、启用/禁用以及立即执行任务，同时后端也新增了对应的任务执行引擎与持久化逻辑。

<!-- 前端须知： -->

在左侧导航栏中增加定时任务栏

<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

引入一个服务器定时任务子系统，用于对服务端的定时动作进行建模、持久化和调度，并具备追踪和错误处理能力。

New Features:
- 添加服务器定时任务模块，支持通过 cron 表达式驱动的服务器重启和命令执行动作。
- 暴露服务 API，用于创建、更新、删除、启用/禁用、立即运行以及自动运行到期的定时任务。
- 为服务器定时任务的开始、完成和失败添加可观测性事件，以便集成到现有的追踪系统中。

Enhancements:
- 将基于 cron 的调度和基于 UUID 的任务标识集成进 extra crate，实现持久化的服务器任务管理。

Build:
- 在 extra crate 中添加 `chrono`、`cron` 和 `uuid` 依赖，用于支持基于时间的调度和任务标识。

Tests:
- 添加单元测试，覆盖 cron 表达式规范化、任务持久化，以及单个和多个到期任务在成功与失败执行路径上的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a server cron task subsystem that models, persists, and schedules server-side timed actions with tracing and error handling.

New Features:
- Add a server cron task module that supports restart and command actions for servers driven by cron expressions.
- Expose a service API to create, update, delete, enable/disable, run immediately, and automatically run due cron tasks.
- Add observability events for server cron task start, completion, and failure to integrate with existing tracing.

Enhancements:
- Integrate cron-based scheduling and UUID-based task identifiers into the extra crate, enabling durable server task management.

Build:
- Add chrono, cron, and uuid dependencies to support time-based scheduling and task identification in the extra crate.

Tests:
- Add unit tests covering cron expression normalization, task persistence, and successful and failed execution flows for single and multiple due tasks.

</details>