### PR TITLE
feat(tauri): 接入桌面端文件对话框与 tracing 初始化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,8 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-window-state",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ tauri-plugin-http = "2.5"
 tauri-plugin-opener = "2.5"
 tauri-plugin-process = "2.3"
 tauri-plugin-window-state = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sealantern-extra = { path = "../crates/extra" }
 sealantern-core = { path = "../crates/core" }
 sealantern-infra = { path = "../crates/infra" }

--- a/src-tauri/src/desktop/dialog.rs
+++ b/src-tauri/src/desktop/dialog.rs
@@ -1,0 +1,205 @@
+//! 文件对话框命令。
+//!
+//! 实现 system 模块的文件选择、保存与文件夹选择接口：
+//! `pick_jar_file` / `pick_archive_file` / `pick_startup_file` /
+//! `pick_server_executable` / `pick_java_file` / `pick_save_file` /
+//! `pick_folder` / `pick_image_file`。
+//!
+//! 对话框由 `tauri-plugin-dialog` 提供，采用回调 + 通道转发结果：
+//! 选中返回路径字符串，取消返回 `null`。
+
+use std::path::Path;
+use std::sync::mpsc;
+
+use tauri_plugin_dialog::DialogExt;
+
+/// 打开系统文件选择器选择 JAR 文件。
+///
+/// 返回选中文件的路径，取消则返回 `null`。
+pub async fn pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Select server JAR file")
+        .add_filter("JAR Files", &["jar"])
+        .add_filter("All Files", &["*"])
+        .pick_file(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件选择器选择压缩包文件（.zip/.tar/.tar.gz/.tgz/.jar）。
+///
+/// 返回选中文件的路径，取消则返回 `null`。
+pub async fn pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Select server file")
+        .add_filter("Server Files", &["jar", "zip", "tar", "tgz", "gz"])
+        .add_filter("JAR Files", &["jar"])
+        .add_filter("ZIP Files", &["zip"])
+        .add_filter("TAR Files", &["tar"])
+        .add_filter("Compressed TAR", &["tgz", "gz"])
+        .add_filter("All Files", &["*"])
+        .pick_file(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件选择器选择启动文件。
+///
+/// `mode` 决定过滤器：`"jar"` / `"bat"` / `"sh"`，未知模式按 JAR 处理。
+/// 返回选中文件的路径，取消则返回 `null`。
+pub async fn pick_startup_file(
+    app: tauri::AppHandle,
+    mode: String,
+) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+    let mode = mode.to_ascii_lowercase();
+
+    let mut dialog = app.dialog().file();
+    match mode.as_str() {
+        "bat" => {
+            dialog = dialog
+                .set_title("Select server BAT file")
+                .add_filter("BAT Files", &["bat"]);
+        }
+        "sh" => {
+            dialog = dialog
+                .set_title("Select server SH file")
+                .add_filter("Shell Scripts", &["sh"]);
+        }
+        _ => {
+            dialog = dialog
+                .set_title("Select server JAR file")
+                .add_filter("JAR Files", &["jar"]);
+        }
+    }
+
+    dialog
+        .add_filter("All Files", &["*"])
+        .pick_file(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件选择器选择服务端可执行文件，同时返回启动模式。
+///
+/// 返回 `[路径, 启动模式]`，模式为 `"jar" | "bat" | "sh"`；取消则返回 `null`。
+pub async fn pick_server_executable(
+    app: tauri::AppHandle,
+) -> Result<Option<(String, String)>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Select server executable")
+        .add_filter("Server Files", &["jar", "bat", "sh"])
+        .add_filter("JAR Files", &["jar"])
+        .add_filter("Batch Files", &["bat"])
+        .add_filter("Shell Scripts", &["sh"])
+        .add_filter("All Files", &["*"])
+        .pick_file(move |path| {
+            let result = path.map(|p| {
+                let path_str = p.to_string();
+                let ext = Path::new(&path_str)
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .to_lowercase();
+                let mode = match ext.as_str() {
+                    "bat" => "bat",
+                    "sh" => "sh",
+                    _ => "jar",
+                };
+                (path_str, mode.to_string())
+            });
+            let _ = tx.send(result);
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件选择器选择 Java 可执行文件。
+///
+/// 返回选中文件的路径，取消则返回 `null`。
+pub async fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Select Java executable")
+        .add_filter(
+            if cfg!(windows) {
+                "Java Executable"
+            } else {
+                "Java Binary"
+            },
+            if cfg!(windows) { &["exe"] } else { &[""] },
+        )
+        .add_filter("All Files", &["*"])
+        .pick_file(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件保存对话框。
+///
+/// 返回保存路径，取消则返回 `null`。
+pub async fn pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Save File")
+        .save_file(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件夹选择器。
+///
+/// 返回选中的文件夹路径，取消则返回 `null`。
+pub async fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Select folder")
+        .pick_folder(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 打开系统文件选择器选择图片文件。
+///
+/// 返回选中文件的路径，取消则返回 `null`。
+pub async fn pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let (tx, rx) = mpsc::channel();
+
+    app.dialog()
+        .file()
+        .set_title("Select image")
+        .add_filter("Images", &["png", "jpg", "jpeg", "gif", "webp", "bmp"])
+        .add_filter("All Files", &["*"])
+        .pick_file(move |path| {
+            let _ = tx.send(path.map(|p| p.to_string()));
+        });
+
+    rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}

--- a/src-tauri/src/desktop/dialog.rs
+++ b/src-tauri/src/desktop/dialog.rs
@@ -16,7 +16,7 @@ use tauri_plugin_dialog::DialogExt;
 /// 打开系统文件选择器选择 JAR 文件。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-pub async fn pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+pub fn pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -34,7 +34,7 @@ pub async fn pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, Stri
 /// 打开系统文件选择器选择压缩包文件（.zip/.tar/.tar.gz/.tgz/.jar）。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-pub async fn pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+pub fn pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -57,10 +57,7 @@ pub async fn pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, 
 ///
 /// `mode` 决定过滤器：`"jar"` / `"bat"` / `"sh"`，未知模式按 JAR 处理。
 /// 返回选中文件的路径，取消则返回 `null`。
-pub async fn pick_startup_file(
-    app: tauri::AppHandle,
-    mode: String,
-) -> Result<Option<String>, String> {
+pub fn pick_startup_file(app: tauri::AppHandle, mode: String) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
     let mode = mode.to_ascii_lowercase();
 
@@ -95,9 +92,7 @@ pub async fn pick_startup_file(
 /// 打开系统文件选择器选择服务端可执行文件，同时返回启动模式。
 ///
 /// 返回 `[路径, 启动模式]`，模式为 `"jar" | "bat" | "sh"`；取消则返回 `null`。
-pub async fn pick_server_executable(
-    app: tauri::AppHandle,
-) -> Result<Option<(String, String)>, String> {
+pub fn pick_server_executable(app: tauri::AppHandle) -> Result<Option<(String, String)>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -131,21 +126,18 @@ pub async fn pick_server_executable(
 
 /// 打开系统文件选择器选择 Java 可执行文件。
 ///
+/// Windows 上按 `.exe` 过滤，其他平台不设扩展名过滤器（Java 二进制无扩展名）。
 /// 返回选中文件的路径，取消则返回 `null`。
-pub async fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+pub fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
-    app.dialog()
-        .file()
-        .set_title("Select Java executable")
-        .add_filter(
-            if cfg!(windows) {
-                "Java Executable"
-            } else {
-                "Java Binary"
-            },
-            if cfg!(windows) { &["exe"] } else { &[""] },
-        )
+    let mut dialog = app.dialog().file();
+    #[cfg(target_os = "windows")]
+    {
+        dialog = dialog.add_filter("Java Executable", &["exe"]);
+    }
+
+    dialog
         .add_filter("All Files", &["*"])
         .pick_file(move |path| {
             let _ = tx.send(path.map(|p| p.to_string()));
@@ -157,7 +149,7 @@ pub async fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, Str
 /// 打开系统文件保存对话框。
 ///
 /// 返回保存路径，取消则返回 `null`。
-pub async fn pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+pub fn pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -173,7 +165,7 @@ pub async fn pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, Str
 /// 打开系统文件夹选择器。
 ///
 /// 返回选中的文件夹路径，取消则返回 `null`。
-pub async fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
+pub fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -189,7 +181,7 @@ pub async fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String
 /// 打开系统文件选择器选择图片文件。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-pub async fn pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+pub fn pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()

--- a/src-tauri/src/desktop/dialog.rs
+++ b/src-tauri/src/desktop/dialog.rs
@@ -131,11 +131,10 @@ pub fn pick_server_executable(app: tauri::AppHandle) -> Result<Option<(String, S
 pub fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
-    let mut dialog = app.dialog().file();
     #[cfg(target_os = "windows")]
-    {
-        dialog = dialog.add_filter("Java Executable", &["exe"]);
-    }
+    let dialog = app.dialog().file().add_filter("Java Executable", &["exe"]);
+    #[cfg(not(target_os = "windows"))]
+    let dialog = app.dialog().file();
 
     dialog
         .add_filter("All Files", &["*"])

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -1,0 +1,11 @@
+//! 桌面端命令模块。
+//!
+//! 按职责拆分各子模块，并将子模块的公开命令统一重新导出，
+//! 便于宿主在 `invoke_handler` 中集中注册。
+
+pub mod dialog;
+
+pub use dialog::{
+    pick_archive_file, pick_folder, pick_image_file, pick_jar_file, pick_java_file, pick_save_file,
+    pick_server_executable, pick_startup_file,
+};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,16 @@
 //! Sea Lantern 桌面端的 Tauri 宿主入口。
 
+pub mod desktop;
+pub mod observability;
+
 use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 /// 启动桌面应用。
 pub fn run() {
+    // 初始化 tracing 日志（在 Tauri 构建之前）
+    observability::init();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())

--- a/src-tauri/src/observability.rs
+++ b/src-tauri/src/observability.rs
@@ -1,15 +1,20 @@
 //! 桌面端可观测性初始化。
 
+use std::sync::Once;
+
+use tracing_subscriber::EnvFilter;
+
+static INIT_TRACING: Once = Once::new();
+
 /// 初始化 tracing 日志。
 ///
 /// 通过 `RUST_LOG` 环境变量控制日志等级与目标过滤
 /// （未设置时默认 `sealantern=info`，即仅输出本项目各 crate 的日志），
-/// 以人类可读格式输出到标准输出。
+/// 以人类可读格式输出到标准输出。由 `Once` 保证幂等，多次调用安全。
 pub fn init() {
-    use tracing_subscriber::EnvFilter;
-
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("sealantern=info"));
-
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    INIT_TRACING.call_once(|| {
+        let filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("sealantern=info"));
+        tracing_subscriber::fmt().with_env_filter(filter).init();
+    });
 }

--- a/src-tauri/src/observability.rs
+++ b/src-tauri/src/observability.rs
@@ -1,0 +1,15 @@
+//! 桌面端可观测性初始化。
+
+/// 初始化 tracing 日志。
+///
+/// 通过 `RUST_LOG` 环境变量控制日志等级与目标过滤
+/// （未设置时默认 `sealantern=info`，即仅输出本项目各 crate 的日志），
+/// 以人类可读格式输出到标准输出。
+pub fn init() {
+    use tracing_subscriber::EnvFilter;
+
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("sealantern=info"));
+
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}


### PR DESCRIPTION
- 实现 desktop/dialog 文件对话框：pick_jar_file、pick_archive_file、pick_startup_file、pick_server_executable、pick_java_file、pick_save_file、pick_folder、pick_image_file
- desktop 模块统一重新导出 dialog 命令
- 新增 observability::init，通过 RUST_LOG 控制日志等级，在 Tauri 启动前初始化
- 添加 tracing、tracing-subscriber 依赖

<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

不想写

## Summary by Sourcery

初始化桌面可观测性，并为 Tauri 主机添加系统文件对话框命令。

New Features:
- 添加桌面文件对话框命令，用于选择 JAR 文件、归档文件、启动脚本、服务器可执行文件、Java 二进制文件、保存文件、文件夹和图像，并通过桌面模块重新导出这些命令。

Enhancements:
- 引入一个可观测性模块，在 Tauri 应用构建器运行之前初始化追踪日志记录，其配置由 `RUST_LOG` 环境变量驱动。

Build:
- 为 Tauri 桌面 crate 添加 `tracing` 和 `tracing-subscriber` 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Initialize desktop observability and add system file dialog commands for the Tauri host.

New Features:
- Add desktop file dialog commands for selecting JARs, archives, startup scripts, server executables, Java binaries, save files, folders, and images, and re-export them via the desktop module.

Enhancements:
- Introduce an observability module that initializes tracing logging before the Tauri application builder runs, with configuration driven by the RUST_LOG environment variable.

Build:
- Add tracing and tracing-subscriber dependencies to the Tauri desktop crate.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

初始化桌面可观测性，并为 Tauri 主机添加系统文件对话框命令。

New Features:
- 添加桌面文件对话框命令，用于选择 JAR 文件、归档文件、启动脚本、服务器可执行文件、Java 二进制文件、保存文件、文件夹和图像，并通过桌面模块重新导出这些命令。

Enhancements:
- 引入一个可观测性模块，在 Tauri 应用构建器运行之前初始化追踪日志记录，其配置由 `RUST_LOG` 环境变量驱动。

Build:
- 为 Tauri 桌面 crate 添加 `tracing` 和 `tracing-subscriber` 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Initialize desktop observability and add system file dialog commands for the Tauri host.

New Features:
- Add desktop file dialog commands for selecting JARs, archives, startup scripts, server executables, Java binaries, save files, folders, and images, and re-export them via the desktop module.

Enhancements:
- Introduce an observability module that initializes tracing logging before the Tauri application builder runs, with configuration driven by the RUST_LOG environment variable.

Build:
- Add tracing and tracing-subscriber dependencies to the Tauri desktop crate.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

初始化桌面可观测性，并为 Tauri 主机添加系统文件对话框命令。

New Features:
- 添加桌面文件对话框命令，用于选择 JAR 文件、归档文件、启动脚本、服务器可执行文件、Java 二进制文件、保存文件、文件夹和图像，并通过桌面模块重新导出这些命令。

Enhancements:
- 引入一个可观测性模块，在 Tauri 应用构建器运行之前初始化追踪日志记录，其配置由 `RUST_LOG` 环境变量驱动。

Build:
- 为 Tauri 桌面 crate 添加 `tracing` 和 `tracing-subscriber` 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Initialize desktop observability and add system file dialog commands for the Tauri host.

New Features:
- Add desktop file dialog commands for selecting JARs, archives, startup scripts, server executables, Java binaries, save files, folders, and images, and re-export them via the desktop module.

Enhancements:
- Introduce an observability module that initializes tracing logging before the Tauri application builder runs, with configuration driven by the RUST_LOG environment variable.

Build:
- Add tracing and tracing-subscriber dependencies to the Tauri desktop crate.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

初始化桌面可观测性，并为 Tauri 主机添加系统文件对话框命令。

New Features:
- 添加桌面文件对话框命令，用于选择 JAR 文件、归档文件、启动脚本、服务器可执行文件、Java 二进制文件、保存文件、文件夹和图像，并通过桌面模块重新导出这些命令。

Enhancements:
- 引入一个可观测性模块，在 Tauri 应用构建器运行之前初始化追踪日志记录，其配置由 `RUST_LOG` 环境变量驱动。

Build:
- 为 Tauri 桌面 crate 添加 `tracing` 和 `tracing-subscriber` 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Initialize desktop observability and add system file dialog commands for the Tauri host.

New Features:
- Add desktop file dialog commands for selecting JARs, archives, startup scripts, server executables, Java binaries, save files, folders, and images, and re-export them via the desktop module.

Enhancements:
- Introduce an observability module that initializes tracing logging before the Tauri application builder runs, with configuration driven by the RUST_LOG environment variable.

Build:
- Add tracing and tracing-subscriber dependencies to the Tauri desktop crate.

</details>

</details>

</details>