### PR TITLE
Fix docker text del shit and add image update

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -10,12 +10,6 @@ on:
         default: 'main'
         type: string
 
-  # 2. 自动触发规则（如果不希望推送代码时自动触发，可以将下面几行注释掉）
-  push:
-    branches: [ "main", "master", "dev" ]
-  pull_request:
-    branches: [ "main", "master" ]
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -30,27 +30,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 开启 Docker BuildKit 层缓存
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
+      # 构建并直接导出为 Docker TAR 文件 (使用 type=docker)
       - name: Build Docker Image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile
-          push: false # 仅测试编译，不推送
+          push: false
           tags: sealantern-server:test
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          outputs: type=docker,dest=/tmp/sealantern-server-test.tar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # 更新缓存目录
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      # 上传生成的镜像包到 GitHub Artifacts 供下载
+      - name: Upload Docker Image Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image-sealantern-server
+          path: /tmp/sealantern-server-test.tar
+          retention-days: 7 # 缓存保留天数（可按需修改）


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [ ] 已阅读 `docs/CONTRIBUTING.md`
- [ ] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

更新 Docker 构建 CI 工作流程，以生成可下载的镜像制品，并简化缓存和触发机制。

CI：
- 禁用 Docker 构建工作流程的自动 `push`/`pull_request` 触发，仅保留手动触发（manual dispatch）。
- 将 Docker 构建缓存切换为使用 GitHub Actions 的缓存存储，并移除自定义缓存目录的处理逻辑。
- 将测试用的 Docker 镜像导出为 tar 文件，并作为工作流程制品上传，以供下载使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Docker build CI workflow to produce downloadable image artifacts and simplify caching and triggers.

CI:
- Disable automatic push/pull_request triggers for the Docker build workflow, keeping manual dispatch only.
- Switch Docker build caching to GitHub Actions cache storage and remove custom cache directory handling.
- Export the test Docker image as a tar file and upload it as a workflow artifact for download.

</details>