### PR TITLE
feat(core): 增加服务端检查基础能力

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5170,6 +5170,8 @@ name = "sealantern-core"
 version = "1.2.0"
 dependencies = [
  "serde",
+ "serde_json",
+ "sha2 0.10.9",
  "tracing",
  "zip",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,8 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 tracing = "0.1"
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
 

--- a/crates/core/src/provisioning/lib.rs
+++ b/crates/core/src/provisioning/lib.rs
@@ -4,6 +4,8 @@ pub mod create;
 pub mod existing;
 pub mod modpack;
 pub mod run_dir;
+#[path = "server_inspection/lib.rs"]
+pub mod server_inspection;
 pub mod startup_parsing;
 
 pub use copy::{plan_copy, CopyInstanceError, CopyInstancePlan, CopyInstanceRequest};
@@ -16,6 +18,9 @@ pub use modpack::{
     plan_modpack, ModpackProvisionError, ModpackProvisionPlan, ModpackProvisionRequest,
 };
 pub use run_dir::{resolve_run_directory, RunDirectoryError, RunDirectoryState};
+pub use server_inspection::{
+    inspect_server_artifact, InspectionOptions, ServerInspectionError, ServerInspectionReport,
+};
 pub use startup_parsing::{
     parse_startup_script_content, parse_startup_script_file, JavaLaunch, StartupParseError,
     StartupScriptInfo, StartupScriptKind,

--- a/crates/core/src/provisioning/server_inspection/archive.rs
+++ b/crates/core/src/provisioning/server_inspection/archive.rs
@@ -1,0 +1,166 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use zip::ZipArchive;
+
+use super::error::ServerInspectionError;
+use super::model::{DiagnosticSeverity, InspectionDiagnostic};
+use super::InspectionOptions;
+
+const MANIFEST_ENTRY: &str = "META-INF/MANIFEST.MF";
+const MOJANG_VERSION_ENTRY: &str = "version.json";
+
+pub(super) struct ArchiveMetadata {
+    pub(super) manifest: Option<Vec<u8>>,
+    pub(super) mojang_version: Option<Vec<u8>>,
+    pub(super) diagnostics: Vec<InspectionDiagnostic>,
+}
+
+pub(super) fn read_metadata(
+    path: &Path,
+    options: &InspectionOptions,
+) -> Result<ArchiveMetadata, ServerInspectionError> {
+    let file = File::open(path)
+        .map_err(|source| ServerInspectionError::Open { path: path.to_path_buf(), source })?;
+    let mut archive = ZipArchive::new(file)
+        .map_err(|source| ServerInspectionError::Archive { path: path.to_path_buf(), source })?;
+    if archive.len() > options.max_archive_entries {
+        return Err(ServerInspectionError::TooManyArchiveEntries {
+            path: path.to_path_buf(),
+            count: archive.len(),
+            limit: options.max_archive_entries,
+        });
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut consumed = 0_u64;
+    let manifest = read_optional_entry(
+        &mut archive,
+        path,
+        MANIFEST_ENTRY,
+        options,
+        &mut consumed,
+        &mut diagnostics,
+    )?;
+    let mojang_version = read_optional_entry(
+        &mut archive,
+        path,
+        MOJANG_VERSION_ENTRY,
+        options,
+        &mut consumed,
+        &mut diagnostics,
+    )?;
+
+    Ok(ArchiveMetadata { manifest, mojang_version, diagnostics })
+}
+
+fn read_optional_entry(
+    archive: &mut ZipArchive<File>,
+    path: &Path,
+    expected_name: &str,
+    options: &InspectionOptions,
+    consumed: &mut u64,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Result<Option<Vec<u8>>, ServerInspectionError> {
+    let Some(index) = find_entry(archive, path, expected_name)? else {
+        return Ok(None);
+    };
+    let mut entry =
+        archive
+            .by_index(index)
+            .map_err(|source| ServerInspectionError::ArchiveEntry {
+                path: path.to_path_buf(),
+                entry: expected_name.to_string(),
+                source,
+            })?;
+    if entry.size() > options.max_metadata_entry_bytes {
+        diagnostics.push(limit_diagnostic(
+            "metadata_entry_too_large",
+            format!(
+                "metadata entry {expected_name} is {} bytes; the inspection limit is {} bytes",
+                entry.size(),
+                options.max_metadata_entry_bytes
+            ),
+        ));
+        return Ok(None);
+    }
+    if consumed.saturating_add(entry.size()) > options.max_total_metadata_bytes {
+        diagnostics.push(limit_diagnostic(
+            "metadata_budget_exceeded",
+            format!(
+                "reading metadata entry {expected_name} would exceed the total inspection limit of {} bytes",
+                options.max_total_metadata_bytes
+            ),
+        ));
+        return Ok(None);
+    }
+
+    let remaining_total = options.max_total_metadata_bytes.saturating_sub(*consumed);
+    let read_limit = options
+        .max_metadata_entry_bytes
+        .min(remaining_total)
+        .saturating_add(1);
+    let mut bytes = Vec::new();
+    entry
+        .by_ref()
+        .take(read_limit)
+        .read_to_end(&mut bytes)
+        .map_err(|source| ServerInspectionError::ArchiveEntryRead {
+            path: path.to_path_buf(),
+            entry: expected_name.to_string(),
+            source,
+        })?;
+    if bytes.len() as u64 > options.max_metadata_entry_bytes {
+        diagnostics.push(limit_diagnostic(
+            "metadata_entry_too_large",
+            format!(
+                "metadata entry {expected_name} expanded beyond the inspection limit of {} bytes",
+                options.max_metadata_entry_bytes
+            ),
+        ));
+        return Ok(None);
+    }
+    if bytes.len() as u64 > remaining_total {
+        diagnostics.push(limit_diagnostic(
+            "metadata_budget_exceeded",
+            format!(
+                "metadata entry {expected_name} expanded beyond the remaining total inspection budget of {remaining_total} bytes"
+            ),
+        ));
+        return Ok(None);
+    }
+
+    *consumed = consumed.saturating_add(bytes.len() as u64);
+    Ok(Some(bytes))
+}
+
+fn find_entry(
+    archive: &mut ZipArchive<File>,
+    path: &Path,
+    expected_name: &str,
+) -> Result<Option<usize>, ServerInspectionError> {
+    for index in 0..archive.len() {
+        let entry =
+            archive
+                .by_index(index)
+                .map_err(|source| ServerInspectionError::ArchiveEntry {
+                    path: path.to_path_buf(),
+                    entry: format!("entry #{index}"),
+                    source,
+                })?;
+        if entry.name().eq_ignore_ascii_case(expected_name) {
+            return Ok(Some(index));
+        }
+    }
+    Ok(None)
+}
+
+fn limit_diagnostic(code: &str, message: String) -> InspectionDiagnostic {
+    InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: code.to_string(),
+        message,
+        evidence: Vec::new(),
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/error.rs
+++ b/crates/core/src/provisioning/server_inspection/error.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+
+use zip::result::ZipError;
+
+#[derive(Debug)]
+pub enum ServerInspectionError {
+    InvalidOptions {
+        detail: &'static str,
+    },
+    Metadata {
+        path: PathBuf,
+        source: io::Error,
+    },
+    UnsupportedSubject {
+        path: PathBuf,
+    },
+    Open {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Archive {
+        path: PathBuf,
+        source: ZipError,
+    },
+    ArchiveEntry {
+        path: PathBuf,
+        entry: String,
+        source: ZipError,
+    },
+    ArchiveEntryRead {
+        path: PathBuf,
+        entry: String,
+        source: io::Error,
+    },
+    TooManyArchiveEntries {
+        path: PathBuf,
+        count: usize,
+        limit: usize,
+    },
+    FingerprintRead {
+        path: PathBuf,
+        source: io::Error,
+    },
+}
+
+impl fmt::Display for ServerInspectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidOptions { detail } => {
+                write!(formatter, "invalid server inspection options: {detail}")
+            }
+            Self::Metadata { path, source } => {
+                write!(formatter, "could not inspect server artifact {}: {source}", path.display())
+            }
+            Self::UnsupportedSubject { path } => write!(
+                formatter,
+                "server artifact must be a regular file or directory: {}",
+                path.display()
+            ),
+            Self::Open { path, source } => {
+                write!(formatter, "could not open server artifact {}: {source}", path.display())
+            }
+            Self::Archive { path, source } => {
+                write!(formatter, "could not parse JAR archive {}: {source}", path.display())
+            }
+            Self::ArchiveEntry { path, entry, source } => write!(
+                formatter,
+                "could not open metadata entry {entry} in {}: {source}",
+                path.display()
+            ),
+            Self::ArchiveEntryRead { path, entry, source } => write!(
+                formatter,
+                "could not read metadata entry {entry} in {}: {source}",
+                path.display()
+            ),
+            Self::TooManyArchiveEntries { path, count, limit } => write!(
+                formatter,
+                "JAR archive {} contains {count} entries, exceeding the inspection limit of {limit}",
+                path.display()
+            ),
+            Self::FingerprintRead { path, source } => write!(
+                formatter,
+                "could not calculate fingerprint for {}: {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ServerInspectionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidOptions { .. }
+            | Self::UnsupportedSubject { .. }
+            | Self::TooManyArchiveEntries { .. } => None,
+            Self::Metadata { source, .. }
+            | Self::Open { source, .. }
+            | Self::ArchiveEntryRead { source, .. }
+            | Self::FingerprintRead { source, .. } => Some(source),
+            Self::Archive { source, .. } | Self::ArchiveEntry { source, .. } => Some(source),
+        }
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/evidence.rs
+++ b/crates/core/src/provisioning/server_inspection/evidence.rs
@@ -1,0 +1,39 @@
+use super::model::{
+    DetectionEvidence, DetectionTarget, EvidenceId, EvidenceLocation, EvidenceSource,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct EvidenceCollector {
+    entries: Vec<DetectionEvidence>,
+}
+
+impl EvidenceCollector {
+    pub(crate) fn push(&mut self, evidence: NewEvidence) -> EvidenceId {
+        let id = EvidenceId(self.entries.len() as u32);
+        self.entries.push(DetectionEvidence {
+            id,
+            detector: evidence.detector.to_string(),
+            source: evidence.source,
+            location: evidence.location,
+            target: evidence.target,
+            candidate: evidence.candidate,
+            weight: evidence.weight.min(100),
+            correlation_group: evidence.correlation_group.to_string(),
+        });
+        id
+    }
+
+    pub(crate) fn into_entries(self) -> Vec<DetectionEvidence> {
+        self.entries
+    }
+}
+
+pub(crate) struct NewEvidence {
+    pub(crate) detector: &'static str,
+    pub(crate) source: EvidenceSource,
+    pub(crate) location: EvidenceLocation,
+    pub(crate) target: DetectionTarget,
+    pub(crate) candidate: String,
+    pub(crate) weight: u8,
+    pub(crate) correlation_group: &'static str,
+}

--- a/crates/core/src/provisioning/server_inspection/formats/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/lib.rs
@@ -1,0 +1,2 @@
+pub(super) mod manifest;
+pub(super) mod mojang_version;

--- a/crates/core/src/provisioning/server_inspection/formats/manifest.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/manifest.rs
@@ -1,0 +1,112 @@
+use std::collections::BTreeMap;
+
+use super::super::model::{ManifestSection, ManifestSummary};
+
+pub(crate) struct ParsedManifest {
+    pub(crate) summary: ManifestSummary,
+    pub(crate) used_lossy_utf8: bool,
+}
+
+impl ParsedManifest {
+    pub(crate) fn main_value(&self, key: &str) -> Option<&str> {
+        value_ignore_ascii_case(&self.summary.main_attributes, key)
+    }
+}
+
+pub(crate) fn parse(bytes: &[u8]) -> ParsedManifest {
+    let used_lossy_utf8 = std::str::from_utf8(bytes).is_err();
+    let content = String::from_utf8_lossy(bytes);
+    let mut blocks: Vec<BTreeMap<String, String>> = Vec::new();
+    let mut attributes = BTreeMap::new();
+    let mut current_key: Option<String> = None;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if line.is_empty() {
+            flush_attribute(&mut attributes, &mut current_key);
+            if !attributes.is_empty() {
+                blocks.push(std::mem::take(&mut attributes));
+            }
+            continue;
+        }
+        if let Some(continuation) = line.strip_prefix(' ') {
+            if let Some(key) = current_key.as_ref() {
+                if let Some(value) = attributes.get_mut(key) {
+                    value.push_str(continuation);
+                }
+            }
+            continue;
+        }
+
+        flush_attribute(&mut attributes, &mut current_key);
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim();
+            if !key.is_empty() {
+                let key = key.to_string();
+                attributes.insert(key.clone(), value.trim_start().to_string());
+                current_key = Some(key);
+            }
+        }
+    }
+    flush_attribute(&mut attributes, &mut current_key);
+    if !attributes.is_empty() {
+        blocks.push(attributes);
+    }
+
+    let mut blocks = blocks.into_iter();
+    let main_attributes = blocks.next().unwrap_or_default();
+    let sections = blocks
+        .map(|mut attributes| {
+            let name_key = attributes
+                .keys()
+                .find(|key| key.eq_ignore_ascii_case("Name"))
+                .cloned();
+            let name = name_key.and_then(|key| attributes.remove(&key));
+            ManifestSection { name, attributes }
+        })
+        .collect();
+
+    ParsedManifest {
+        summary: ManifestSummary { main_attributes, sections },
+        used_lossy_utf8,
+    }
+}
+
+fn flush_attribute(_attributes: &mut BTreeMap<String, String>, current_key: &mut Option<String>) {
+    *current_key = None;
+}
+
+fn value_ignore_ascii_case<'a>(
+    attributes: &'a BTreeMap<String, String>,
+    key: &str,
+) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn keeps_main_attributes_separate_from_named_sections() {
+        let parsed = parse(
+            b"Manifest-Version: 1.0\r\nMain-Class: com.example.\r\n Main\r\n\r\nName: forge\r\nImplementation-Version: 65.1.0\r\n\r\n",
+        );
+
+        assert_eq!(parsed.main_value("main-class"), Some("com.example.Main"));
+        assert_eq!(parsed.main_value("implementation-version"), None);
+        assert_eq!(parsed.summary.sections.len(), 1);
+        assert_eq!(parsed.summary.sections[0].name.as_deref(), Some("forge"));
+        assert_eq!(
+            parsed.summary.sections[0]
+                .attributes
+                .get("Implementation-Version")
+                .map(String::as_str),
+            Some("65.1.0")
+        );
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/formats/mojang_version.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/mojang_version.rs
@@ -1,0 +1,156 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use super::super::model::{MinecraftPackVersion, PackFormatVersion};
+
+pub(crate) struct MojangVersionDocument {
+    pub(crate) id: Option<String>,
+    pub(crate) name: Option<String>,
+    pub(crate) world_version: Option<i64>,
+    pub(crate) series_id: Option<String>,
+    pub(crate) protocol_version: Option<i64>,
+    pub(crate) pack_version: Option<MinecraftPackVersion>,
+    pub(crate) build_time: Option<String>,
+    pub(crate) java_component: Option<String>,
+    pub(crate) java_version: Option<u16>,
+    pub(crate) stable: Option<bool>,
+    pub(crate) use_editor: Option<bool>,
+    pub(crate) extra: BTreeMap<String, Value>,
+}
+
+pub(crate) fn parse(content: &[u8]) -> Result<Option<MojangVersionDocument>, serde_json::Error> {
+    let value: Value = serde_json::from_slice(content)?;
+    let Value::Object(mut object) = value else {
+        return Ok(None);
+    };
+    if !looks_like_mojang_version(&object) {
+        return Ok(None);
+    }
+
+    let id = take_string(&mut object, "id");
+    let name = take_string(&mut object, "name");
+    let world_version = take_i64(&mut object, "world_version");
+    let series_id = take_string(&mut object, "series_id");
+    let protocol_version = take_i64(&mut object, "protocol_version");
+    let pack_version = object.get("pack_version").and_then(parse_pack_version);
+    if pack_version.is_some() {
+        object.remove("pack_version");
+    }
+    let build_time = take_string(&mut object, "build_time");
+    let java_component = take_string(&mut object, "java_component");
+    let java_version = take_u16(&mut object, "java_version");
+    let stable = take_bool(&mut object, "stable");
+    let use_editor = take_bool(&mut object, "use_editor");
+
+    Ok(Some(MojangVersionDocument {
+        id,
+        name,
+        world_version,
+        series_id,
+        protocol_version,
+        pack_version,
+        build_time,
+        java_component,
+        java_version,
+        stable,
+        use_editor,
+        extra: object.into_iter().collect(),
+    }))
+}
+
+fn looks_like_mojang_version(object: &Map<String, Value>) -> bool {
+    object.get("id").is_some_and(Value::is_string)
+        && ["world_version", "protocol_version", "pack_version", "java_version"]
+            .iter()
+            .any(|key| object.contains_key(*key))
+}
+
+fn parse_pack_version(value: &Value) -> Option<MinecraftPackVersion> {
+    let object = value.as_object()?;
+    let resource = parse_named_pack_version(object, "resource", "resource_major", "resource_minor");
+    let data = parse_named_pack_version(object, "data", "data_major", "data_minor");
+    (resource.is_some() || data.is_some()).then_some(MinecraftPackVersion { resource, data })
+}
+
+fn parse_named_pack_version(
+    object: &Map<String, Value>,
+    short_name: &str,
+    major_name: &str,
+    minor_name: &str,
+) -> Option<PackFormatVersion> {
+    if let Some(major) = object.get(major_name).and_then(value_as_u32) {
+        return Some(PackFormatVersion {
+            major,
+            minor: object.get(minor_name).and_then(value_as_u32).unwrap_or(0),
+        });
+    }
+
+    match object.get(short_name)? {
+        Value::Number(number) => u32::try_from(number.as_u64()?)
+            .ok()
+            .map(|major| PackFormatVersion { major, minor: 0 }),
+        Value::Object(nested) => Some(PackFormatVersion {
+            major: nested.get("major").and_then(value_as_u32)?,
+            minor: nested.get("minor").and_then(value_as_u32).unwrap_or(0),
+        }),
+        _ => None,
+    }
+}
+
+fn take_string(object: &mut Map<String, Value>, key: &str) -> Option<String> {
+    let value = object.get(key)?.as_str()?.to_string();
+    object.remove(key);
+    Some(value)
+}
+
+fn take_i64(object: &mut Map<String, Value>, key: &str) -> Option<i64> {
+    let value = object.get(key)?.as_i64()?;
+    object.remove(key);
+    Some(value)
+}
+
+fn take_u16(object: &mut Map<String, Value>, key: &str) -> Option<u16> {
+    let value = u16::try_from(object.get(key)?.as_u64()?).ok()?;
+    object.remove(key);
+    Some(value)
+}
+
+fn take_bool(object: &mut Map<String, Value>, key: &str) -> Option<bool> {
+    let value = object.get(key)?.as_bool()?;
+    object.remove(key);
+    Some(value)
+}
+
+fn value_as_u32(value: &Value) -> Option<u32> {
+    u32::try_from(value.as_u64()?).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn parses_current_mojang_version_shape_and_keeps_unknown_fields() {
+        let parsed = parse(
+            br#"{
+                "id":"26.2",
+                "name":"26.2",
+                "world_version":4903,
+                "protocol_version":776,
+                "pack_version":{"resource_major":88,"resource_minor":0,"data_major":107,"data_minor":1},
+                "java_version":25,
+                "custom":"kept"
+            }"#,
+        )
+        .expect("valid JSON")
+        .expect("Mojang version document");
+
+        assert_eq!(parsed.id.as_deref(), Some("26.2"));
+        assert_eq!(parsed.java_version, Some(25));
+        let pack = parsed.pack_version.expect("pack version");
+        assert_eq!(pack.resource.expect("resource format").major, 88);
+        assert_eq!(pack.data.expect("data format").minor, 1);
+        assert_eq!(parsed.extra.get("custom").and_then(|value| value.as_str()), Some("kept"));
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -1,0 +1,768 @@
+mod archive;
+mod error;
+mod evidence;
+#[path = "formats/lib.rs"]
+mod formats;
+mod model;
+mod resolver;
+
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+use sha2::{Digest, Sha256};
+
+pub use error::ServerInspectionError;
+pub use model::*;
+
+use evidence::{EvidenceCollector, NewEvidence};
+use formats::manifest::ParsedManifest;
+use formats::mojang_version::MojangVersionDocument;
+use resolver::{resolve, DetectionClaim};
+
+const MANIFEST_ENTRY: &str = "META-INF/MANIFEST.MF";
+const MOJANG_VERSION_ENTRY: &str = "version.json";
+
+/// 控制静态检查的资源预算；检查过程不会执行 JAR、脚本或 shell 展开。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InspectionOptions {
+    pub max_archive_entries: usize,
+    pub max_metadata_entry_bytes: u64,
+    pub max_total_metadata_bytes: u64,
+    /// 后续嵌套归档检测的单归档上限；设为 0 可禁用嵌套归档读取。
+    pub max_nested_archive_bytes: u64,
+    /// 根归档深度为 0；设为 0 时仅检查根归档。
+    pub max_archive_depth: usize,
+    pub compute_sha256: bool,
+}
+
+impl Default for InspectionOptions {
+    fn default() -> Self {
+        Self {
+            max_archive_entries: 50_000,
+            max_metadata_entry_bytes: 4 * 1024 * 1024,
+            max_total_metadata_bytes: 32 * 1024 * 1024,
+            max_nested_archive_bytes: 128 * 1024 * 1024,
+            max_archive_depth: 2,
+            compute_sha256: false,
+        }
+    }
+}
+
+/// 检查单个服务端文件或安装目录，不执行其中的任何内容。
+pub fn inspect_server_artifact(
+    path: &Path,
+    options: &InspectionOptions,
+) -> Result<ServerInspectionReport, ServerInspectionError> {
+    validate_options(options)?;
+    let metadata = fs::metadata(path)
+        .map_err(|source| ServerInspectionError::Metadata { path: path.to_path_buf(), source })?;
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err(ServerInspectionError::UnsupportedSubject { path: path.to_path_buf() });
+    }
+
+    let subject_kind = if metadata.is_dir() {
+        InspectionSubjectKind::Directory
+    } else {
+        InspectionSubjectKind::File
+    };
+    let fingerprint = if metadata.is_file() && options.compute_sha256 {
+        Some(calculate_sha256(path)?)
+    } else {
+        None
+    };
+    let subject = InspectionSubject {
+        path: path.to_path_buf(),
+        kind: subject_kind,
+        size_bytes: metadata.is_file().then_some(metadata.len()),
+        modified_at_unix_secs: metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs()),
+        fingerprint,
+    };
+
+    let mut evidence = EvidenceCollector::default();
+    let mut diagnostics = Vec::new();
+    let mut format_claims = Vec::new();
+    let mut roles = Vec::new();
+    let mut launches = Vec::new();
+    let mut artifact = ArtifactInfo {
+        format: Detected::default(),
+        roles: Vec::new(),
+        main_class: Detected::default(),
+        premain_class: Detected::default(),
+        agent_class: Detected::default(),
+        automatic_module_name: Detected::default(),
+        manifest: None,
+    };
+    let mut minecraft = None;
+    let mut java = JavaRequirementInfo::default();
+
+    if metadata.is_dir() {
+        let format_evidence = evidence.push(NewEvidence {
+            detector: "subject-kind",
+            source: EvidenceSource::FileMetadata,
+            location: EvidenceLocation::path(path.to_path_buf()),
+            target: DetectionTarget::ArtifactFormat,
+            candidate: "directory".to_string(),
+            weight: 100,
+            correlation_group: "file-metadata",
+        });
+        format_claims.push(claim(ArtifactFormat::Directory, format_evidence, 100, "file-metadata"));
+
+        let role_evidence = evidence.push(NewEvidence {
+            detector: "subject-kind",
+            source: EvidenceSource::DirectoryLayout,
+            location: EvidenceLocation::path(path.to_path_buf()),
+            target: DetectionTarget::ArtifactRole,
+            candidate: "installation_directory".to_string(),
+            weight: 100,
+            correlation_group: "directory-layout",
+        });
+        roles.push(Attributed {
+            value: ArtifactRole::InstallationDirectory,
+            confidence: 100,
+            evidence: vec![role_evidence],
+        });
+    } else {
+        let format = format_from_path(path);
+        let format_weight = if format == ArtifactFormat::Unknown {
+            50
+        } else {
+            85
+        };
+        let format_evidence = evidence.push(NewEvidence {
+            detector: "file-extension",
+            source: EvidenceSource::FileName,
+            location: EvidenceLocation::path(path.to_path_buf()),
+            target: DetectionTarget::ArtifactFormat,
+            candidate: format_name(format).to_string(),
+            weight: format_weight,
+            correlation_group: "file-name",
+        });
+        format_claims.push(claim(format, format_evidence, format_weight, "file-name"));
+
+        if format == ArtifactFormat::Jar {
+            let archive_metadata = archive::read_metadata(path, options)?;
+            diagnostics.extend(archive_metadata.diagnostics);
+            let archive_evidence = evidence.push(NewEvidence {
+                detector: "jar-container",
+                source: EvidenceSource::JarEntry,
+                location: EvidenceLocation::path(path.to_path_buf()),
+                target: DetectionTarget::ArtifactFormat,
+                candidate: "jar".to_string(),
+                weight: 100,
+                correlation_group: "archive-container",
+            });
+            format_claims.push(claim(
+                ArtifactFormat::Jar,
+                archive_evidence,
+                100,
+                "archive-container",
+            ));
+
+            if let Some(bytes) = archive_metadata.manifest {
+                let parsed = formats::manifest::parse(&bytes);
+                if parsed.used_lossy_utf8 {
+                    diagnostics.push(InspectionDiagnostic {
+                        severity: DiagnosticSeverity::Warning,
+                        code: "manifest_invalid_utf8".to_string(),
+                        message: format!(
+                            "manifest in {} contains invalid UTF-8; invalid bytes were replaced",
+                            path.display()
+                        ),
+                        evidence: Vec::new(),
+                    });
+                }
+                apply_manifest(
+                    path,
+                    &parsed,
+                    &mut artifact,
+                    &mut roles,
+                    &mut launches,
+                    &mut evidence,
+                );
+                artifact.manifest = Some(parsed.summary);
+            }
+
+            if let Some(bytes) = archive_metadata.mojang_version {
+                match formats::mojang_version::parse(&bytes) {
+                    Ok(Some(document)) => {
+                        let (minecraft_info, java_info, mut version_diagnostics) =
+                            apply_mojang_version(path, document, &mut evidence);
+                        minecraft = Some(minecraft_info);
+                        java = java_info;
+                        diagnostics.append(&mut version_diagnostics);
+                    }
+                    Ok(None) => diagnostics.push(InspectionDiagnostic {
+                        severity: DiagnosticSeverity::Info,
+                        code: "unrecognized_version_json".to_string(),
+                        message: format!(
+                            "version.json in {} does not match the Mojang version metadata shape",
+                            path.display()
+                        ),
+                        evidence: Vec::new(),
+                    }),
+                    Err(source) => diagnostics.push(InspectionDiagnostic {
+                        severity: DiagnosticSeverity::Warning,
+                        code: "invalid_version_json".to_string(),
+                        message: format!(
+                            "could not parse version.json in {}: {source}",
+                            path.display()
+                        ),
+                        evidence: Vec::new(),
+                    }),
+                }
+            }
+        }
+    }
+
+    artifact.format = resolve(format_claims);
+    artifact.roles = roles;
+
+    Ok(ServerInspectionReport {
+        schema_version: SERVER_INSPECTION_SCHEMA_VERSION,
+        subject,
+        artifact,
+        identity: ServerIdentityInfo::default(),
+        minecraft,
+        java,
+        components: Vec::new(),
+        launches,
+        evidence: evidence.into_entries(),
+        diagnostics,
+    })
+}
+
+fn validate_options(options: &InspectionOptions) -> Result<(), ServerInspectionError> {
+    if options.max_archive_entries == 0 {
+        return Err(ServerInspectionError::InvalidOptions {
+            detail: "max_archive_entries must be greater than zero",
+        });
+    }
+    if options.max_metadata_entry_bytes == 0 {
+        return Err(ServerInspectionError::InvalidOptions {
+            detail: "max_metadata_entry_bytes must be greater than zero",
+        });
+    }
+    if options.max_total_metadata_bytes == 0 {
+        return Err(ServerInspectionError::InvalidOptions {
+            detail: "max_total_metadata_bytes must be greater than zero",
+        });
+    }
+    Ok(())
+}
+
+fn apply_manifest(
+    path: &Path,
+    manifest: &ParsedManifest,
+    artifact: &mut ArtifactInfo,
+    roles: &mut Vec<Attributed<ArtifactRole>>,
+    launches: &mut Vec<Attributed<LaunchProfile>>,
+    evidence: &mut EvidenceCollector,
+) {
+    artifact.main_class =
+        detect_manifest_value(path, manifest, "Main-Class", DetectionTarget::MainClass, evidence);
+    artifact.premain_class = detect_manifest_value(
+        path,
+        manifest,
+        "Premain-Class",
+        DetectionTarget::PremainClass,
+        evidence,
+    );
+    artifact.agent_class =
+        detect_manifest_value(path, manifest, "Agent-Class", DetectionTarget::AgentClass, evidence);
+    artifact.automatic_module_name = detect_manifest_value(
+        path,
+        manifest,
+        "Automatic-Module-Name",
+        DetectionTarget::AutomaticModuleName,
+        evidence,
+    );
+
+    if let Some(main_class) = artifact.main_class.value.as_ref() {
+        let role_evidence = evidence.push(NewEvidence {
+            detector: "jar-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            target: DetectionTarget::ArtifactRole,
+            candidate: "runnable".to_string(),
+            weight: 95,
+            correlation_group: "manifest-main",
+        });
+        roles.push(Attributed {
+            value: ArtifactRole::Runnable,
+            confidence: 95,
+            evidence: vec![role_evidence],
+        });
+        let launch_evidence = evidence.push(NewEvidence {
+            detector: "jar-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            target: DetectionTarget::LaunchProfile,
+            candidate: format!("java -jar {} ({main_class})", path.display()),
+            weight: 95,
+            correlation_group: "manifest-main",
+        });
+        launches.push(Attributed {
+            value: LaunchProfile {
+                id: "manifest-main".to_string(),
+                platform: LaunchPlatform::Any,
+                working_directory: path
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .map(Path::to_path_buf),
+                target: LaunchTarget::Jar { path: path.to_path_buf() },
+                jvm_arguments: Vec::new(),
+                program_arguments: Vec::new(),
+                required_java_major: None,
+            },
+            confidence: 95,
+            evidence: vec![launch_evidence],
+        });
+    }
+}
+
+fn detect_manifest_value(
+    path: &Path,
+    manifest: &ParsedManifest,
+    field: &'static str,
+    target: DetectionTarget,
+    evidence: &mut EvidenceCollector,
+) -> Detected<String> {
+    let Some(value) = manifest.main_value(field).map(str::to_string) else {
+        return Detected::default();
+    };
+    let evidence_id = evidence.push(NewEvidence {
+        detector: "jar-manifest",
+        source: EvidenceSource::ManifestMain,
+        location: manifest_location(path, field),
+        target,
+        candidate: value.clone(),
+        weight: 100,
+        correlation_group: "manifest-main",
+    });
+    resolve(vec![claim(value, evidence_id, 100, "manifest-main")])
+}
+
+fn apply_mojang_version(
+    path: &Path,
+    document: MojangVersionDocument,
+    evidence: &mut EvidenceCollector,
+) -> (MinecraftVersionInfo, JavaRequirementInfo, Vec<InspectionDiagnostic>) {
+    let mut version_claims = Vec::new();
+    let mut version_evidence = Vec::new();
+    if let Some(id) = document.id.as_ref() {
+        let evidence_id = json_field_evidence(
+            path,
+            "id",
+            id,
+            DetectionTarget::MinecraftVersion,
+            95,
+            "mojang-version-json",
+            evidence,
+        );
+        version_evidence.push(evidence_id);
+        version_claims.push(claim(id.to_string(), evidence_id, 95, "mojang-version-json"));
+    }
+    if let Some(name) = document.name.as_ref() {
+        let evidence_id = json_field_evidence(
+            path,
+            "name",
+            name,
+            DetectionTarget::MinecraftVersion,
+            90,
+            "mojang-version-json",
+            evidence,
+        );
+        version_evidence.push(evidence_id);
+        version_claims.push(claim(name.to_string(), evidence_id, 90, "mojang-version-json"));
+    }
+    let version = resolve(version_claims);
+
+    record_minecraft_metadata(path, &document, &mut version_evidence, evidence);
+
+    let required_major = document
+        .java_version
+        .map_or_else(Detected::default, |major| {
+            let evidence_id = json_field_evidence(
+                path,
+                "java_version",
+                &major.to_string(),
+                DetectionTarget::JavaMajor,
+                90,
+                "mojang-java-version",
+                evidence,
+            );
+            version_evidence.push(evidence_id);
+            resolve(vec![claim(major, evidence_id, 90, "mojang-java-version")])
+        });
+    let runtime_component =
+        document
+            .java_component
+            .as_ref()
+            .map_or_else(Detected::default, |component| {
+                let evidence_id = json_field_evidence(
+                    path,
+                    "java_component",
+                    component,
+                    DetectionTarget::JavaRuntimeComponent,
+                    90,
+                    "mojang-java-component",
+                    evidence,
+                );
+                version_evidence.push(evidence_id);
+                resolve(vec![claim(component.clone(), evidence_id, 90, "mojang-java-component")])
+            });
+
+    let diagnostics = if version.value.is_none() && version.alternatives.len() > 1 {
+        vec![InspectionDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: "conflicting_minecraft_versions".to_string(),
+            message: format!(
+                "Mojang version metadata in {} contains conflicting id and name values",
+                path.display()
+            ),
+            evidence: version
+                .alternatives
+                .iter()
+                .flat_map(|candidate| candidate.evidence.iter().copied())
+                .collect(),
+        }]
+    } else {
+        Vec::new()
+    };
+
+    (
+        MinecraftVersionInfo {
+            version,
+            id: document.id,
+            name: document.name,
+            world_version: document.world_version,
+            series_id: document.series_id,
+            protocol_version: document.protocol_version,
+            pack_version: document.pack_version,
+            build_time: document.build_time,
+            java_component: document.java_component,
+            java_version: document.java_version,
+            stable: document.stable,
+            use_editor: document.use_editor,
+            extra: document.extra,
+            evidence: version_evidence,
+        },
+        JavaRequirementInfo { required_major, runtime_component },
+        diagnostics,
+    )
+}
+
+fn record_minecraft_metadata(
+    path: &Path,
+    document: &MojangVersionDocument,
+    version_evidence: &mut Vec<EvidenceId>,
+    evidence: &mut EvidenceCollector,
+) {
+    let mut record = |field: &str, candidate: String| {
+        version_evidence.push(json_field_evidence(
+            path,
+            field,
+            &candidate,
+            DetectionTarget::MinecraftVersion,
+            95,
+            "mojang-version-json",
+            evidence,
+        ));
+    };
+    if let Some(value) = document.world_version {
+        record("world_version", value.to_string());
+    }
+    if let Some(value) = document.series_id.as_ref() {
+        record("series_id", value.clone());
+    }
+    if let Some(value) = document.protocol_version {
+        record("protocol_version", value.to_string());
+    }
+    if let Some(value) = document.pack_version.as_ref() {
+        record("pack_version", format_pack_version(value));
+    }
+    if let Some(value) = document.build_time.as_ref() {
+        record("build_time", value.clone());
+    }
+    if let Some(value) = document.stable {
+        record("stable", value.to_string());
+    }
+    if let Some(value) = document.use_editor {
+        record("use_editor", value.to_string());
+    }
+}
+
+fn format_pack_version(pack: &MinecraftPackVersion) -> String {
+    let resource = pack
+        .resource
+        .map(|version| format!("{}.{}", version.major, version.minor))
+        .unwrap_or_else(|| "unknown".to_string());
+    let data = pack
+        .data
+        .map(|version| format!("{}.{}", version.major, version.minor))
+        .unwrap_or_else(|| "unknown".to_string());
+    format!("resource={resource},data={data}")
+}
+
+fn manifest_location(path: &Path, field: &str) -> EvidenceLocation {
+    EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some(MANIFEST_ENTRY.to_string()),
+        manifest_section: None,
+        field: Some(field.to_string()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn json_field_evidence(
+    path: &Path,
+    field: &str,
+    candidate: &str,
+    target: DetectionTarget,
+    weight: u8,
+    correlation_group: &'static str,
+    evidence: &mut EvidenceCollector,
+) -> EvidenceId {
+    evidence.push(NewEvidence {
+        detector: "mojang-version-json",
+        source: EvidenceSource::JsonField,
+        location: EvidenceLocation {
+            path: path.to_path_buf(),
+            archive_entry: Some(MOJANG_VERSION_ENTRY.to_string()),
+            manifest_section: None,
+            field: Some(field.to_string()),
+        },
+        target,
+        candidate: candidate.to_string(),
+        weight,
+        correlation_group,
+    })
+}
+
+fn claim<T>(
+    value: T,
+    evidence: EvidenceId,
+    weight: u8,
+    correlation_group: &str,
+) -> DetectionClaim<T> {
+    DetectionClaim {
+        value,
+        evidence,
+        weight,
+        correlation_group: correlation_group.to_string(),
+    }
+}
+
+fn format_from_path(path: &Path) -> ArtifactFormat {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("jar") => ArtifactFormat::Jar,
+        Some("zip") => ArtifactFormat::Zip,
+        Some("bat" | "cmd" | "sh" | "ps1") => ArtifactFormat::Script,
+        Some("exe") => ArtifactFormat::Executable,
+        _ => ArtifactFormat::Unknown,
+    }
+}
+
+fn format_name(format: ArtifactFormat) -> &'static str {
+    match format {
+        ArtifactFormat::Directory => "directory",
+        ArtifactFormat::Jar => "jar",
+        ArtifactFormat::Zip => "zip",
+        ArtifactFormat::Script => "script",
+        ArtifactFormat::Executable => "executable",
+        ArtifactFormat::Unknown => "unknown",
+    }
+}
+
+fn calculate_sha256(path: &Path) -> Result<ArtifactFingerprint, ServerInspectionError> {
+    let mut file = File::open(path).map_err(|source| ServerInspectionError::FingerprintRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read =
+            file.read(&mut buffer)
+                .map_err(|source| ServerInspectionError::FingerprintRead {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+
+    Ok(ArtifactFingerprint {
+        algorithm: FingerprintAlgorithm::Sha256,
+        value: format!("{:x}", digest.finalize()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use zip::write::FileOptions;
+
+    use super::{
+        inspect_server_artifact, ArtifactFormat, ArtifactRole, InspectionOptions,
+        InspectionSubjectKind, LaunchTarget,
+    };
+
+    fn temporary_path(suffix: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "sealantern-server-inspection-{}-{timestamp}-{suffix}",
+            std::process::id()
+        ))
+    }
+
+    fn write_test_jar(path: &Path, manifest: &str, version_json: &str) {
+        let file = File::create(path).expect("create test JAR");
+        let mut archive = zip::ZipWriter::new(file);
+        archive
+            .start_file("META-INF/MANIFEST.MF", FileOptions::<()>::default())
+            .expect("create manifest entry");
+        archive
+            .write_all(manifest.as_bytes())
+            .expect("write manifest");
+        archive
+            .start_file("version.json", FileOptions::<()>::default())
+            .expect("create version entry");
+        archive
+            .write_all(version_json.as_bytes())
+            .expect("write version JSON");
+        archive.finish().expect("finish test JAR");
+    }
+
+    #[test]
+    fn inspects_manifest_and_current_mojang_version_metadata() {
+        let path = temporary_path("server.jar");
+        write_test_jar(
+            &path,
+            "Manifest-Version: 1.0\r\nMain-Class: net.minecraft.bundler.Main\r\nImplementation-Title: Minecraft\r\n\r\nName: product\r\nImplementation-Version: named-only\r\n\r\n",
+            r#"{"id":"26.2","name":"26.2","world_version":4903,"series_id":"main","protocol_version":776,"pack_version":{"resource_major":88,"resource_minor":0,"data_major":107,"data_minor":1},"build_time":"2026-06-16T12:01:27+00:00","java_component":"java-runtime-epsilon","java_version":25,"stable":true,"use_editor":false,"vendor_field":"preserved"}"#,
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect test JAR");
+        fs::remove_file(&path).expect("remove test JAR");
+
+        assert_eq!(report.artifact.format.value, Some(ArtifactFormat::Jar));
+        assert_eq!(report.artifact.format.confidence, 100);
+        assert_eq!(report.artifact.main_class.value.as_deref(), Some("net.minecraft.bundler.Main"));
+        assert!(report
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::Runnable));
+        assert_eq!(
+            report
+                .artifact
+                .manifest
+                .as_ref()
+                .expect("manifest")
+                .sections
+                .len(),
+            1
+        );
+        assert!(matches!(report.launches[0].value.target, LaunchTarget::Jar { .. }));
+
+        let minecraft = report.minecraft.expect("Minecraft metadata");
+        assert_eq!(minecraft.version.value.as_deref(), Some("26.2"));
+        assert_eq!(minecraft.world_version, Some(4903));
+        assert_eq!(
+            minecraft
+                .pack_version
+                .expect("pack version")
+                .data
+                .expect("data format")
+                .minor,
+            1
+        );
+        assert_eq!(
+            minecraft
+                .extra
+                .get("vendor_field")
+                .and_then(|value| value.as_str()),
+            Some("preserved")
+        );
+        assert_eq!(report.java.required_major.value, Some(25));
+        assert_eq!(report.java.runtime_component.value.as_deref(), Some("java-runtime-epsilon"));
+    }
+
+    #[test]
+    fn skips_oversized_optional_metadata_without_losing_the_report() {
+        let path = temporary_path("limited.jar");
+        write_test_jar(
+            &path,
+            "Main-Class: example.Main\r\n\r\n",
+            &format!(r#"{{"id":"26.2","world_version":4903,"padding":"{}"}}"#, "x".repeat(256)),
+        );
+        let options = InspectionOptions {
+            max_metadata_entry_bytes: 128,
+            ..InspectionOptions::default()
+        };
+
+        let report = inspect_server_artifact(&path, &options).expect("inspect bounded JAR");
+        fs::remove_file(&path).expect("remove test JAR");
+
+        assert_eq!(report.artifact.main_class.value.as_deref(), Some("example.Main"));
+        assert!(report.minecraft.is_none());
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "metadata_entry_too_large"));
+    }
+
+    #[test]
+    fn directories_are_reported_without_scanning_their_contents() {
+        let path = temporary_path("directory");
+        fs::create_dir(&path).expect("create test directory");
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect directory");
+        fs::remove_dir(&path).expect("remove test directory");
+
+        assert_eq!(report.subject.kind, InspectionSubjectKind::Directory);
+        assert_eq!(report.artifact.format.value, Some(ArtifactFormat::Directory));
+        assert_eq!(report.artifact.roles[0].value, ArtifactRole::InstallationDirectory);
+    }
+
+    #[test]
+    fn optionally_calculates_a_sha256_fingerprint() {
+        let path = temporary_path("payload.bin");
+        fs::write(&path, b"abc").expect("write test file");
+        let options = InspectionOptions {
+            compute_sha256: true,
+            ..InspectionOptions::default()
+        };
+
+        let report = inspect_server_artifact(&path, &options).expect("inspect test file");
+        fs::remove_file(&path).expect("remove test file");
+
+        assert_eq!(
+            report.subject.fingerprint.expect("fingerprint").value,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/model.rs
+++ b/crates/core/src/provisioning/server_inspection/model.rs
@@ -1,0 +1,369 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const SERVER_INSPECTION_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EvidenceId(pub u32);
+
+/// 一个需要从互相竞争的候选中选出的检测结果。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Detected<T> {
+    pub value: Option<T>,
+    pub confidence: u8,
+    pub evidence: Vec<EvidenceId>,
+    pub alternatives: Vec<DetectionCandidate<T>>,
+}
+
+impl<T> Default for Detected<T> {
+    fn default() -> Self {
+        Self {
+            value: None,
+            confidence: 0,
+            evidence: Vec::new(),
+            alternatives: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectionCandidate<T> {
+    pub value: T,
+    pub confidence: u8,
+    pub evidence: Vec<EvidenceId>,
+}
+
+/// 一个允许与其他值并存的检测结果。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attributed<T> {
+    pub value: T,
+    pub confidence: u8,
+    pub evidence: Vec<EvidenceId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServerInspectionReport {
+    pub schema_version: u16,
+    pub subject: InspectionSubject,
+    pub artifact: ArtifactInfo,
+    pub identity: ServerIdentityInfo,
+    pub minecraft: Option<MinecraftVersionInfo>,
+    pub java: JavaRequirementInfo,
+    pub components: Vec<Attributed<ServerComponent>>,
+    pub launches: Vec<Attributed<LaunchProfile>>,
+    pub evidence: Vec<DetectionEvidence>,
+    pub diagnostics: Vec<InspectionDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InspectionSubject {
+    pub path: PathBuf,
+    pub kind: InspectionSubjectKind,
+    pub size_bytes: Option<u64>,
+    pub modified_at_unix_secs: Option<u64>,
+    pub fingerprint: Option<ArtifactFingerprint>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InspectionSubjectKind {
+    File,
+    Directory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactFingerprint {
+    pub algorithm: FingerprintAlgorithm,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FingerprintAlgorithm {
+    Sha256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactInfo {
+    pub format: Detected<ArtifactFormat>,
+    pub roles: Vec<Attributed<ArtifactRole>>,
+    pub main_class: Detected<String>,
+    pub premain_class: Detected<String>,
+    pub agent_class: Detected<String>,
+    pub automatic_module_name: Detected<String>,
+    pub manifest: Option<ManifestSummary>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactFormat {
+    Directory,
+    Jar,
+    Zip,
+    Script,
+    Executable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRole {
+    Runnable,
+    Bootstrapper,
+    Installer,
+    Launcher,
+    Wrapper,
+    Library,
+    InstallationDirectory,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestSummary {
+    pub main_attributes: BTreeMap<String, String>,
+    pub sections: Vec<ManifestSection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestSection {
+    pub name: Option<String>,
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerIdentityInfo {
+    pub category: Detected<ServerCategory>,
+    pub implementation: Detected<ServerProduct>,
+    pub version: Detected<String>,
+    pub release_channel: Detected<ReleaseChannel>,
+    pub ecosystems: Vec<Attributed<ServerEcosystem>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerCategory {
+    JavaGameServer,
+    BedrockGameServer,
+    Proxy,
+    Limbo,
+    Unknown,
+}
+
+/// 产品标识保持开放，新增服务端不需要修改公共枚举。
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ServerProduct {
+    pub key: String,
+    pub display_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerEcosystem {
+    Vanilla,
+    Bukkit,
+    Paper,
+    Fabric,
+    LegacyFabric,
+    Quilt,
+    Forge,
+    NeoForge,
+    Sponge,
+    Bungee,
+    Velocity,
+    Other(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseChannel {
+    Stable,
+    Beta,
+    Alpha,
+    Snapshot,
+    Development,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MinecraftVersionInfo {
+    pub version: Detected<String>,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub world_version: Option<i64>,
+    pub series_id: Option<String>,
+    pub protocol_version: Option<i64>,
+    pub pack_version: Option<MinecraftPackVersion>,
+    pub build_time: Option<String>,
+    pub java_component: Option<String>,
+    pub java_version: Option<u16>,
+    pub stable: Option<bool>,
+    pub use_editor: Option<bool>,
+    pub extra: BTreeMap<String, Value>,
+    pub evidence: Vec<EvidenceId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MinecraftPackVersion {
+    pub resource: Option<PackFormatVersion>,
+    pub data: Option<PackFormatVersion>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackFormatVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JavaRequirementInfo {
+    pub required_major: Detected<u16>,
+    pub runtime_component: Detected<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerComponent {
+    pub kind: ServerComponentKind,
+    pub key: String,
+    pub name: String,
+    pub version: Option<String>,
+    pub release_channel: Option<ReleaseChannel>,
+    pub coordinate: Option<MavenCoordinate>,
+    pub source_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerComponentKind {
+    Implementation,
+    Api,
+    ModLoader,
+    Installer,
+    Launcher,
+    Bootstrap,
+    Mapping,
+    Wrapper,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MavenCoordinate {
+    pub group: String,
+    pub artifact: String,
+    pub version: String,
+    pub classifier: Option<String>,
+    pub extension: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LaunchProfile {
+    pub id: String,
+    pub platform: LaunchPlatform,
+    pub working_directory: Option<PathBuf>,
+    pub target: LaunchTarget,
+    pub jvm_arguments: Vec<String>,
+    pub program_arguments: Vec<String>,
+    pub required_java_major: Option<u16>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchPlatform {
+    Any,
+    Windows,
+    Unix,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LaunchTarget {
+    Jar { path: PathBuf },
+    MainClass { class_name: String },
+    ArgumentFiles { paths: Vec<PathBuf> },
+    Script { path: PathBuf },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectionEvidence {
+    pub id: EvidenceId,
+    pub detector: String,
+    pub source: EvidenceSource,
+    pub location: EvidenceLocation,
+    pub target: DetectionTarget,
+    pub candidate: String,
+    pub weight: u8,
+    pub correlation_group: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceSource {
+    FileMetadata,
+    FileName,
+    ManifestMain,
+    ManifestSection,
+    JarEntry,
+    JsonField,
+    PropertiesField,
+    MavenCoordinate,
+    ArgumentFile,
+    DirectoryLayout,
+    ClassEntry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceLocation {
+    pub path: PathBuf,
+    pub archive_entry: Option<String>,
+    pub manifest_section: Option<String>,
+    pub field: Option<String>,
+}
+
+impl EvidenceLocation {
+    pub(crate) fn path(path: PathBuf) -> Self {
+        Self {
+            path,
+            archive_entry: None,
+            manifest_section: None,
+            field: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectionTarget {
+    ArtifactFormat,
+    ArtifactRole,
+    MainClass,
+    PremainClass,
+    AgentClass,
+    AutomaticModuleName,
+    ServerCategory,
+    ServerImplementation,
+    ServerVersion,
+    ServerEcosystem,
+    ReleaseChannel,
+    MinecraftVersion,
+    JavaMajor,
+    JavaRuntimeComponent,
+    Component,
+    LaunchProfile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InspectionDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub code: String,
+    pub message: String,
+    pub evidence: Vec<EvidenceId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    Info,
+    Warning,
+    Error,
+}

--- a/crates/core/src/provisioning/server_inspection/resolver.rs
+++ b/crates/core/src/provisioning/server_inspection/resolver.rs
@@ -1,0 +1,152 @@
+use super::model::{Detected, DetectionCandidate, EvidenceId};
+
+#[derive(Debug, Clone)]
+pub(crate) struct DetectionClaim<T> {
+    pub(crate) value: T,
+    pub(crate) evidence: EvidenceId,
+    pub(crate) weight: u8,
+    pub(crate) correlation_group: String,
+}
+
+struct CandidateState<T> {
+    value: T,
+    maximum_weight: u8,
+    evidence: Vec<EvidenceId>,
+    correlation_groups: Vec<String>,
+    insertion_index: usize,
+}
+
+/// 同一候选的独立来源只提供有限加分，避免同一文件中的重复字段淹没冲突证据。
+pub(crate) fn resolve<T>(claims: Vec<DetectionClaim<T>>) -> Detected<T>
+where
+    T: Clone + Eq,
+{
+    let mut candidates: Vec<CandidateState<T>> = Vec::new();
+    for claim in claims {
+        if let Some(candidate) = candidates
+            .iter_mut()
+            .find(|candidate| candidate.value == claim.value)
+        {
+            candidate.maximum_weight = candidate.maximum_weight.max(claim.weight.min(100));
+            if !candidate.evidence.contains(&claim.evidence) {
+                candidate.evidence.push(claim.evidence);
+            }
+            if !candidate
+                .correlation_groups
+                .contains(&claim.correlation_group)
+            {
+                candidate.correlation_groups.push(claim.correlation_group);
+            }
+            continue;
+        }
+
+        candidates.push(CandidateState {
+            value: claim.value,
+            maximum_weight: claim.weight.min(100),
+            evidence: vec![claim.evidence],
+            correlation_groups: vec![claim.correlation_group],
+            insertion_index: candidates.len(),
+        });
+    }
+
+    let mut candidates = candidates
+        .into_iter()
+        .map(|candidate| {
+            let independent_boost = candidate
+                .correlation_groups
+                .len()
+                .saturating_sub(1)
+                .saturating_mul(5)
+                .min(10) as u8;
+            let confidence = candidate
+                .maximum_weight
+                .saturating_add(independent_boost)
+                .min(100);
+            (
+                DetectionCandidate {
+                    value: candidate.value,
+                    confidence,
+                    evidence: candidate.evidence,
+                },
+                candidate.insertion_index,
+            )
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by(|(left, left_index), (right, right_index)| {
+        right
+            .confidence
+            .cmp(&left.confidence)
+            .then_with(|| left_index.cmp(right_index))
+    });
+
+    let Some((winner, _)) = candidates.first().cloned() else {
+        return Detected::default();
+    };
+    let conflicts = candidates.get(1).is_some_and(|(runner_up, _)| {
+        (winner.confidence >= 80 && runner_up.confidence >= 80)
+            || (runner_up.confidence >= 50
+                && winner.confidence.saturating_sub(runner_up.confidence) < 15)
+    });
+    let candidates = candidates
+        .into_iter()
+        .map(|(candidate, _)| candidate)
+        .collect::<Vec<_>>();
+
+    if conflicts {
+        return Detected {
+            value: None,
+            confidence: winner.confidence,
+            evidence: winner.evidence.clone(),
+            alternatives: candidates,
+        };
+    }
+
+    Detected {
+        value: Some(winner.value),
+        confidence: winner.confidence,
+        evidence: winner.evidence,
+        alternatives: candidates.into_iter().skip(1).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve, DetectionClaim};
+    use crate::provisioning::server_inspection::EvidenceId;
+
+    fn claim(value: &str, id: u32, weight: u8, group: &str) -> DetectionClaim<String> {
+        DetectionClaim {
+            value: value.to_string(),
+            evidence: EvidenceId(id),
+            weight,
+            correlation_group: group.to_string(),
+        }
+    }
+
+    #[test]
+    fn independent_evidence_adds_a_bounded_boost() {
+        let detected = resolve(vec![
+            claim("paper", 0, 80, "manifest"),
+            claim("paper", 1, 75, "maven-coordinate"),
+            claim("paper", 2, 70, "jar-entry"),
+            claim("paper", 3, 65, "class-entry"),
+            claim("purpur", 4, 60, "filename"),
+        ]);
+
+        assert_eq!(detected.value.as_deref(), Some("paper"));
+        assert_eq!(detected.confidence, 90);
+        assert_eq!(detected.evidence.len(), 4);
+    }
+
+    #[test]
+    fn strong_conflicting_candidates_remain_unresolved() {
+        let detected = resolve(vec![
+            claim("paper", 0, 95, "coordinate"),
+            claim("purpur", 1, 90, "patch-list"),
+        ]);
+
+        assert_eq!(detected.value, None);
+        assert_eq!(detected.confidence, 95);
+        assert_eq!(detected.alternatives.len(), 2);
+    }
+}


### PR DESCRIPTION
本 PR 仅完成服务端检查的第一阶段基础能力。

整体功能尚未完成，具体服务端类型识别及 Paper、Fabric、Forge 等 detector 将在后续 PR 补充。

## Summary by Sourcery

引入初始的服务端检查能力用于配置（provisioning），允许对服务器构件进行静态分析，在不执行它们的情况下报告结构化元数据。

New Features:
- 添加 `server_inspection` 配置模块，用于检查服务器文件或目录，并返回结构化的 `ServerInspectionReport`。
- 基于 JAR 内容和 Mojang 的 `version.json`，支持检测构件格式、角色、启动配置、Minecraft 版本元数据以及 Java 运行时需求。
- 允许可配置的检查资源限制，并为被检查的构件提供可选的 SHA-256 指纹生成。

Enhancements:
- 从核心配置 crate 中暴露服务器检查 API，供其他组件使用。

Build:
- 在核心 crate 中添加 `serde_json` 和 `sha2` 依赖，以支持 JSON 解析和指纹生成。

Tests:
- 添加单元测试，覆盖清单和 Mojang 版本解析、在元数据大小限制下的检查行为、目录处理以及指纹计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce initial server-side inspection capabilities for provisioning, allowing static analysis of server artifacts and reporting structured metadata without executing them.

New Features:
- Add a server_inspection provisioning module that inspects server files or directories and returns a structured ServerInspectionReport.
- Support detection of artifact format, roles, launch profiles, Minecraft version metadata, and Java runtime requirements based on JAR contents and Mojang version.json.
- Allow configurable inspection resource limits and optional SHA-256 fingerprinting for inspected artifacts.

Enhancements:
- Expose server inspection APIs from the core provisioning crate for use by other components.

Build:
- Add serde_json and sha2 dependencies to the core crate to support JSON parsing and fingerprinting.

Tests:
- Add unit tests covering manifest and Mojang version parsing, inspection behavior under metadata size limits, directory handling, and fingerprint computation.

</details>