### PR TITLE
feat(core): 识别 Vanilla 与 Paperclip 服务端

### DIFF
--- a/crates/core/src/provisioning/server_inspection/archive.rs
+++ b/crates/core/src/provisioning/server_inspection/archive.rs
@@ -10,10 +10,16 @@ use super::InspectionOptions;
 
 const MANIFEST_ENTRY: &str = "META-INF/MANIFEST.MF";
 const MOJANG_VERSION_ENTRY: &str = "version.json";
+pub(super) const VERSIONS_LIST_ENTRY: &str = "META-INF/versions.list";
+pub(super) const PATCHES_LIST_ENTRY: &str = "META-INF/patches.list";
+pub(super) const LIBRARIES_LIST_ENTRY: &str = "META-INF/libraries.list";
 
 pub(super) struct ArchiveMetadata {
     pub(super) manifest: Option<Vec<u8>>,
     pub(super) mojang_version: Option<Vec<u8>>,
+    pub(super) versions_list: Option<Vec<u8>>,
+    pub(super) patches_list: Option<Vec<u8>>,
+    pub(super) libraries_list: Option<Vec<u8>>,
     pub(super) diagnostics: Vec<InspectionDiagnostic>,
 }
 
@@ -51,8 +57,39 @@ pub(super) fn read_metadata(
         &mut consumed,
         &mut diagnostics,
     )?;
+    let versions_list = read_optional_entry(
+        &mut archive,
+        path,
+        VERSIONS_LIST_ENTRY,
+        options,
+        &mut consumed,
+        &mut diagnostics,
+    )?;
+    let patches_list = read_optional_entry(
+        &mut archive,
+        path,
+        PATCHES_LIST_ENTRY,
+        options,
+        &mut consumed,
+        &mut diagnostics,
+    )?;
+    let libraries_list = read_optional_entry(
+        &mut archive,
+        path,
+        LIBRARIES_LIST_ENTRY,
+        options,
+        &mut consumed,
+        &mut diagnostics,
+    )?;
 
-    Ok(ArchiveMetadata { manifest, mojang_version, diagnostics })
+    Ok(ArchiveMetadata {
+        manifest,
+        mojang_version,
+        versions_list,
+        patches_list,
+        libraries_list,
+        diagnostics,
+    })
 }
 
 fn read_optional_entry(

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -1,0 +1,710 @@
+mod paperclip;
+mod vanilla;
+
+use std::path::{Path, PathBuf};
+
+use super::archive::ArchiveMetadata;
+use super::evidence::{EvidenceCollector, NewEvidence};
+use super::model::{
+    ArtifactInfo, ArtifactRole, Attributed, Detected, DetectionTarget, DiagnosticSeverity,
+    EvidenceLocation, EvidenceSource, InspectionDiagnostic, MavenCoordinate, MinecraftVersionInfo,
+    ReleaseChannel, ServerCategory, ServerComponent, ServerEcosystem, ServerIdentityInfo,
+    ServerProduct,
+};
+use super::resolver::{resolve, resolve_attributed, DetectionClaim};
+
+const PRODUCTS: &[ProductDefinition] = &[
+    ProductDefinition::paper(
+        "pufferfish",
+        "Pufferfish",
+        "gg.pufferfish.pufferfish",
+        "pufferfish-api",
+    ),
+    ProductDefinition::paper("divinemc", "DivineMC", "org.bxteam.divinemc", "divinemc-api"),
+    ProductDefinition::paper("aspaper", "AsPaper", "com.infernalsuite.asp", "aspaper-api"),
+    ProductDefinition::paper("purpur", "Purpur", "org.purpurmc.purpur", "purpur-api"),
+    ProductDefinition::paper("canvas", "Canvas", "io.canvasmc.canvas", "canvas-api"),
+    ProductDefinition::paper("leaves", "Leaves", "org.leavesmc.leaves", "leaves-api"),
+    ProductDefinition::vanilla(),
+    ProductDefinition::bukkit("spigot", "Spigot"),
+    ProductDefinition::paper("paper", "Paper", "io.papermc.paper", "paper-api"),
+    ProductDefinition::paper("folia", "Folia", "dev.folia", "folia-api"),
+    ProductDefinition::paper("pluto", "Pluto", "dev.yive.pluto", "pluto-api"),
+    ProductDefinition::paper("leaf", "Leaf", "cn.dreeam.leaf", "leaf-api"),
+];
+
+#[derive(Debug, Clone, Copy)]
+struct ProductDefinition {
+    key: &'static str,
+    display_name: &'static str,
+    paper: bool,
+    bukkit: bool,
+    vanilla: bool,
+    api_group: Option<&'static str>,
+    api_artifact: Option<&'static str>,
+}
+
+impl ProductDefinition {
+    const fn paper(
+        key: &'static str,
+        display_name: &'static str,
+        api_group: &'static str,
+        api_artifact: &'static str,
+    ) -> Self {
+        Self {
+            key,
+            display_name,
+            paper: true,
+            bukkit: true,
+            vanilla: false,
+            api_group: Some(api_group),
+            api_artifact: Some(api_artifact),
+        }
+    }
+
+    const fn bukkit(key: &'static str, display_name: &'static str) -> Self {
+        Self {
+            key,
+            display_name,
+            paper: false,
+            bukkit: true,
+            vanilla: false,
+            api_group: None,
+            api_artifact: None,
+        }
+    }
+
+    const fn vanilla() -> Self {
+        Self {
+            key: "vanilla",
+            display_name: "Vanilla",
+            paper: false,
+            bukkit: false,
+            vanilla: true,
+            api_group: None,
+            api_artifact: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct Signal<T> {
+    pub(super) value: T,
+    pub(super) detector: &'static str,
+    pub(super) source: EvidenceSource,
+    pub(super) location: EvidenceLocation,
+    pub(super) weight: u8,
+    pub(super) correlation_group: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ProductFinding {
+    pub(super) signal: Signal<ServerProduct>,
+    pub(super) ecosystems: Vec<ServerEcosystem>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ProductValueFinding<T> {
+    pub(super) product_key: String,
+    pub(super) signal: Signal<T>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ComponentFinding {
+    pub(super) product_key: String,
+    pub(super) signal: Signal<ServerComponent>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct Findings {
+    pub(super) products: Vec<ProductFinding>,
+    pub(super) categories: Vec<Signal<ServerCategory>>,
+    pub(super) minecraft_versions: Vec<Signal<String>>,
+    pub(super) product_versions: Vec<ProductValueFinding<String>>,
+    pub(super) release_channels: Vec<ProductValueFinding<ReleaseChannel>>,
+    pub(super) roles: Vec<Signal<ArtifactRole>>,
+    pub(super) components: Vec<ComponentFinding>,
+}
+
+impl Findings {
+    pub(super) fn has_product(&self, key: &str) -> bool {
+        self.products
+            .iter()
+            .any(|finding| finding.signal.value.key == key)
+    }
+}
+
+pub(super) struct DetectorOutput {
+    pub(super) identity: ServerIdentityInfo,
+    pub(super) minecraft_version: Detected<String>,
+    pub(super) roles: Vec<Attributed<ArtifactRole>>,
+    pub(super) components: Vec<Attributed<ServerComponent>>,
+    pub(super) diagnostics: Vec<InspectionDiagnostic>,
+}
+
+pub(super) fn detect_jar(
+    path: &Path,
+    artifact: &ArtifactInfo,
+    archive: &ArchiveMetadata,
+    minecraft: Option<&MinecraftVersionInfo>,
+    evidence: &mut EvidenceCollector,
+) -> DetectorOutput {
+    let mut findings = Findings::default();
+    detect_filename(path, &mut findings);
+    paperclip::detect(path, artifact, archive, &mut findings);
+    vanilla::detect(path, artifact, minecraft, &mut findings);
+    finalize(path, findings, minecraft, evidence)
+}
+
+fn finalize(
+    path: &Path,
+    findings: Findings,
+    minecraft: Option<&MinecraftVersionInfo>,
+    evidence: &mut EvidenceCollector,
+) -> DetectorOutput {
+    let implementation = resolve(
+        findings
+            .products
+            .iter()
+            .map(|finding| {
+                push_claim(
+                    &finding.signal,
+                    DetectionTarget::ServerImplementation,
+                    finding.signal.value.key.clone(),
+                    evidence,
+                )
+            })
+            .collect(),
+    );
+    let selected_key = implementation
+        .value
+        .as_ref()
+        .map(|product| product.key.as_str());
+
+    let mut category_claims = findings
+        .categories
+        .iter()
+        .map(|signal| {
+            push_claim(
+                signal,
+                DetectionTarget::ServerCategory,
+                category_name(signal.value).to_string(),
+                evidence,
+            )
+        })
+        .collect::<Vec<_>>();
+    category_claims.extend(findings.products.iter().map(|finding| {
+        let signal = Signal {
+            value: ServerCategory::JavaGameServer,
+            detector: finding.signal.detector,
+            source: finding.signal.source,
+            location: finding.signal.location.clone(),
+            weight: finding.signal.weight,
+            correlation_group: finding.signal.correlation_group,
+        };
+        push_claim(
+            &signal,
+            DetectionTarget::ServerCategory,
+            "java_game_server".to_string(),
+            evidence,
+        )
+    }));
+    let category = resolve(category_claims);
+
+    let version = resolve_product_values(
+        &findings.product_versions,
+        selected_key,
+        DetectionTarget::ServerVersion,
+        |value| value.clone(),
+        evidence,
+    );
+    let release_channel = resolve_product_values(
+        &findings.release_channels,
+        selected_key,
+        DetectionTarget::ReleaseChannel,
+        |value| release_channel_name(*value).to_string(),
+        evidence,
+    );
+
+    let ecosystems = selected_key.map_or_else(Vec::new, |selected_key| {
+        let mut claims = Vec::new();
+        for finding in findings
+            .products
+            .iter()
+            .filter(|finding| finding.signal.value.key == selected_key)
+        {
+            for ecosystem in &finding.ecosystems {
+                let signal = Signal {
+                    value: ecosystem.clone(),
+                    detector: finding.signal.detector,
+                    source: finding.signal.source,
+                    location: finding.signal.location.clone(),
+                    weight: finding.signal.weight,
+                    correlation_group: finding.signal.correlation_group,
+                };
+                let candidate = ecosystem_name(&signal.value);
+                claims.push(push_claim(
+                    &signal,
+                    DetectionTarget::ServerEcosystem,
+                    candidate,
+                    evidence,
+                ));
+            }
+        }
+        resolve_attributed(claims)
+    });
+
+    let components = selected_key.map_or_else(Vec::new, |selected_key| {
+        resolve_attributed(
+            findings
+                .components
+                .iter()
+                .filter(|finding| finding.product_key == selected_key)
+                .map(|finding| {
+                    push_claim(
+                        &finding.signal,
+                        DetectionTarget::Component,
+                        finding.signal.value.key.clone(),
+                        evidence,
+                    )
+                })
+                .collect(),
+        )
+    });
+    let roles = resolve_attributed(
+        findings
+            .roles
+            .iter()
+            .map(|signal| {
+                push_claim(
+                    signal,
+                    DetectionTarget::ArtifactRole,
+                    artifact_role_name(signal.value).to_string(),
+                    evidence,
+                )
+            })
+            .collect(),
+    );
+    let minecraft_version = resolve_minecraft_version(&findings, minecraft, evidence);
+
+    let mut diagnostics = Vec::new();
+    add_conflict_diagnostic(
+        path,
+        "conflicting_server_implementations",
+        "server implementation",
+        &implementation,
+        &mut diagnostics,
+    );
+    add_conflict_diagnostic(
+        path,
+        "conflicting_server_versions",
+        "server implementation version",
+        &version,
+        &mut diagnostics,
+    );
+    add_conflict_diagnostic(
+        path,
+        "conflicting_minecraft_versions",
+        "Minecraft version",
+        &minecraft_version,
+        &mut diagnostics,
+    );
+
+    DetectorOutput {
+        identity: ServerIdentityInfo {
+            category,
+            implementation,
+            version,
+            release_channel,
+            ecosystems,
+        },
+        minecraft_version,
+        roles,
+        components,
+        diagnostics,
+    }
+}
+
+fn resolve_product_values<T, F>(
+    findings: &[ProductValueFinding<T>],
+    selected_key: Option<&str>,
+    target: DetectionTarget,
+    candidate: F,
+    evidence: &mut EvidenceCollector,
+) -> Detected<T>
+where
+    T: Clone + Eq,
+    F: Fn(&T) -> String,
+{
+    let Some(selected_key) = selected_key else {
+        return Detected::default();
+    };
+    resolve(
+        findings
+            .iter()
+            .filter(|finding| finding.product_key == selected_key)
+            .map(|finding| {
+                push_claim(&finding.signal, target, candidate(&finding.signal.value), evidence)
+            })
+            .collect(),
+    )
+}
+
+fn resolve_minecraft_version(
+    findings: &Findings,
+    minecraft: Option<&MinecraftVersionInfo>,
+    evidence: &mut EvidenceCollector,
+) -> Detected<String> {
+    let mut claims = findings
+        .minecraft_versions
+        .iter()
+        .map(|signal| {
+            push_claim(signal, DetectionTarget::MinecraftVersion, signal.value.clone(), evidence)
+        })
+        .collect::<Vec<_>>();
+    if let Some(minecraft) = minecraft {
+        claims.extend(existing_detected_claims(&minecraft.version, "mojang-version-json"));
+    }
+    resolve(claims)
+}
+
+fn existing_detected_claims<T: Clone>(
+    detected: &Detected<T>,
+    correlation_group: &str,
+) -> Vec<DetectionClaim<T>> {
+    let mut claims = Vec::new();
+    if let Some(value) = detected.value.as_ref() {
+        claims.extend(detected.evidence.iter().map(|evidence| DetectionClaim {
+            value: value.clone(),
+            evidence: *evidence,
+            weight: detected.confidence,
+            correlation_group: correlation_group.to_string(),
+        }));
+    }
+    claims.extend(detected.alternatives.iter().flat_map(|candidate| {
+        candidate.evidence.iter().map(|evidence| DetectionClaim {
+            value: candidate.value.clone(),
+            evidence: *evidence,
+            weight: candidate.confidence,
+            correlation_group: correlation_group.to_string(),
+        })
+    }));
+    claims
+}
+
+fn push_claim<T: Clone>(
+    signal: &Signal<T>,
+    target: DetectionTarget,
+    candidate: String,
+    evidence: &mut EvidenceCollector,
+) -> DetectionClaim<T> {
+    let evidence_id = evidence.push(NewEvidence {
+        detector: signal.detector,
+        source: signal.source,
+        location: signal.location.clone(),
+        target,
+        candidate,
+        weight: signal.weight,
+        correlation_group: signal.correlation_group,
+    });
+    DetectionClaim {
+        value: signal.value.clone(),
+        evidence: evidence_id,
+        weight: signal.weight,
+        correlation_group: signal.correlation_group.to_string(),
+    }
+}
+
+fn add_conflict_diagnostic<T>(
+    path: &Path,
+    code: &str,
+    label: &str,
+    detected: &Detected<T>,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) {
+    if detected.value.is_some() || detected.alternatives.len() < 2 {
+        return;
+    }
+    diagnostics.push(InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: code.to_string(),
+        message: format!("conflicting {label} evidence found in {}", path.display()),
+        evidence: detected
+            .alternatives
+            .iter()
+            .flat_map(|candidate| candidate.evidence.iter().copied())
+            .collect(),
+    });
+}
+
+fn detect_filename(path: &Path, findings: &mut Findings) {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return;
+    };
+    let stem = stem.to_ascii_lowercase();
+    let Some(definition) = PRODUCTS
+        .iter()
+        .filter(|definition| contains_key_with_boundaries(&stem, definition.key))
+        .max_by_key(|definition| definition.key.len())
+    else {
+        return;
+    };
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key(definition.key),
+            detector: "server-file-name",
+            source: EvidenceSource::FileName,
+            location: EvidenceLocation::path(path.to_path_buf()),
+            weight: 25,
+            correlation_group: "file-name",
+        },
+        ecosystems: ecosystems_for_key(definition.key, false),
+    });
+}
+
+fn contains_key_with_boundaries(value: &str, key: &str) -> bool {
+    value.match_indices(key).any(|(index, matched)| {
+        let before = value[..index].chars().next_back();
+        let after = value[index + matched.len()..].chars().next();
+        !before.is_some_and(|character| character.is_ascii_alphanumeric())
+            && !after.is_some_and(|character| character.is_ascii_alphanumeric())
+    })
+}
+
+pub(super) fn product_from_key(key: &str) -> ServerProduct {
+    if let Some(definition) = product_definition(key) {
+        return ServerProduct {
+            key: definition.key.to_string(),
+            display_name: definition.display_name.to_string(),
+        };
+    }
+    ServerProduct {
+        key: key.to_string(),
+        display_name: display_name_from_key(key),
+    }
+}
+
+pub(super) fn ecosystems_for_key(key: &str, paperclip_context: bool) -> Vec<ServerEcosystem> {
+    let Some(definition) = product_definition(key) else {
+        return if paperclip_context {
+            vec![ServerEcosystem::Paper, ServerEcosystem::Bukkit]
+        } else {
+            Vec::new()
+        };
+    };
+    let mut ecosystems = Vec::new();
+    if definition.vanilla {
+        ecosystems.push(ServerEcosystem::Vanilla);
+    }
+    if definition.paper {
+        ecosystems.push(ServerEcosystem::Paper);
+    }
+    if definition.bukkit {
+        ecosystems.push(ServerEcosystem::Bukkit);
+    }
+    ecosystems
+}
+
+pub(super) fn product_key_from_coordinate(coordinate: &MavenCoordinate) -> Option<String> {
+    PRODUCTS
+        .iter()
+        .find(|definition| {
+            definition.api_group == Some(coordinate.group.as_str())
+                && definition.api_artifact == Some(coordinate.artifact.as_str())
+        })
+        .map(|definition| definition.key.to_string())
+}
+
+pub(super) fn target_product_key(path: &str, minecraft_version: &str) -> Option<String> {
+    let filename = path.rsplit(['/', '\\']).next()?;
+    let stem = strip_jar_suffix(filename)?;
+    if stem.eq_ignore_ascii_case(&format!("server-{minecraft_version}")) {
+        return Some("vanilla".to_string());
+    }
+    let suffix = format!("-{minecraft_version}");
+    let key = stem.strip_suffix(&suffix)?.to_ascii_lowercase();
+    is_valid_product_key(&key).then_some(key)
+}
+
+pub(super) fn release_channel(version: &str) -> Option<ReleaseChannel> {
+    let version = version.to_ascii_lowercase();
+    if has_version_label(&version, "snapshot") {
+        Some(ReleaseChannel::Snapshot)
+    } else if has_version_label(&version, "alpha") {
+        Some(ReleaseChannel::Alpha)
+    } else if has_version_label(&version, "beta") {
+        Some(ReleaseChannel::Beta)
+    } else if has_version_label(&version, "stable") {
+        Some(ReleaseChannel::Stable)
+    } else {
+        None
+    }
+}
+
+pub(super) fn strip_jar_suffix(filename: &str) -> Option<&str> {
+    let suffix_start = filename.len().checked_sub(4)?;
+    filename
+        .get(suffix_start..)?
+        .eq_ignore_ascii_case(".jar")
+        .then(|| filename.get(..suffix_start))
+        .flatten()
+}
+
+fn has_version_label(version: &str, label: &str) -> bool {
+    version
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|token| {
+            token == label
+                || token.strip_prefix(label).is_some_and(|suffix| {
+                    !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit())
+                })
+        })
+}
+
+pub(super) fn list_location(path: &Path, entry: &str, line: usize) -> EvidenceLocation {
+    EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some(entry.to_string()),
+        manifest_section: None,
+        field: Some(format!("line {line}")),
+    }
+}
+
+pub(super) fn manifest_location(path: &Path, field: &str) -> EvidenceLocation {
+    EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some("META-INF/MANIFEST.MF".to_string()),
+        manifest_section: None,
+        field: Some(field.to_string()),
+    }
+}
+
+pub(super) fn version_json_location(path: &Path, field: &str) -> EvidenceLocation {
+    EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some("version.json".to_string()),
+        manifest_section: None,
+        field: Some(field.to_string()),
+    }
+}
+
+fn product_definition(key: &str) -> Option<&'static ProductDefinition> {
+    PRODUCTS.iter().find(|definition| definition.key == key)
+}
+
+fn is_valid_product_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 64
+        && key
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn display_name_from_key(key: &str) -> String {
+    key.split(['-', '_', '.'])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut characters = part.chars();
+            characters.next().map_or_else(String::new, |first| {
+                first.to_ascii_uppercase().to_string() + characters.as_str()
+            })
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn ecosystem_name(ecosystem: &ServerEcosystem) -> String {
+    match ecosystem {
+        ServerEcosystem::Vanilla => "vanilla".to_string(),
+        ServerEcosystem::Bukkit => "bukkit".to_string(),
+        ServerEcosystem::Paper => "paper".to_string(),
+        ServerEcosystem::Fabric => "fabric".to_string(),
+        ServerEcosystem::LegacyFabric => "legacy_fabric".to_string(),
+        ServerEcosystem::Quilt => "quilt".to_string(),
+        ServerEcosystem::Forge => "forge".to_string(),
+        ServerEcosystem::NeoForge => "neoforge".to_string(),
+        ServerEcosystem::Sponge => "sponge".to_string(),
+        ServerEcosystem::Bungee => "bungee".to_string(),
+        ServerEcosystem::Velocity => "velocity".to_string(),
+        ServerEcosystem::Other(value) => value.clone(),
+    }
+}
+
+fn category_name(category: ServerCategory) -> &'static str {
+    match category {
+        ServerCategory::JavaGameServer => "java_game_server",
+        ServerCategory::BedrockGameServer => "bedrock_game_server",
+        ServerCategory::Proxy => "proxy",
+        ServerCategory::Limbo => "limbo",
+        ServerCategory::Unknown => "unknown",
+    }
+}
+
+fn release_channel_name(channel: ReleaseChannel) -> &'static str {
+    match channel {
+        ReleaseChannel::Stable => "stable",
+        ReleaseChannel::Beta => "beta",
+        ReleaseChannel::Alpha => "alpha",
+        ReleaseChannel::Snapshot => "snapshot",
+        ReleaseChannel::Development => "development",
+        ReleaseChannel::Unknown => "unknown",
+    }
+}
+
+fn artifact_role_name(role: ArtifactRole) -> &'static str {
+    match role {
+        ArtifactRole::Runnable => "runnable",
+        ArtifactRole::Bootstrapper => "bootstrapper",
+        ArtifactRole::Installer => "installer",
+        ArtifactRole::Launcher => "launcher",
+        ArtifactRole::Wrapper => "wrapper",
+        ArtifactRole::Library => "library",
+        ArtifactRole::InstallationDirectory => "installation_directory",
+        ArtifactRole::Unknown => "unknown",
+    }
+}
+
+pub(super) fn api_component(
+    product_key: &str,
+    version: String,
+    coordinate: Option<MavenCoordinate>,
+    source_path: PathBuf,
+) -> ServerComponent {
+    let product = product_from_key(product_key);
+    let release_channel = release_channel(&version);
+    ServerComponent {
+        kind: super::model::ServerComponentKind::Api,
+        key: format!("{product_key}-api"),
+        name: format!("{} API", product.display_name),
+        version: Some(version),
+        release_channel,
+        coordinate,
+        source_path: Some(source_path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_key_with_boundaries, release_channel, target_product_key};
+    use crate::provisioning::server_inspection::ReleaseChannel;
+
+    #[test]
+    fn filename_boundaries_do_not_treat_aspaper_as_paper() {
+        assert!(contains_key_with_boundaries("aspaper-26.2", "aspaper"));
+        assert!(!contains_key_with_boundaries("aspaper-26.2", "paper"));
+        assert!(!contains_key_with_boundaries("paperclip", "paper"));
+    }
+
+    #[test]
+    fn target_paths_produce_open_product_keys() {
+        assert_eq!(target_product_key("26.2/canvas-26.2.jar", "26.2").as_deref(), Some("canvas"));
+        assert_eq!(target_product_key("26.2/server-26.2.jar", "26.2").as_deref(), Some("vanilla"));
+        assert_eq!(target_product_key("26.2/Paper-26.2.Jar", "26.2").as_deref(), Some("paper"));
+    }
+
+    #[test]
+    fn release_channel_requires_a_version_label_boundary() {
+        assert_eq!(release_channel("26.2.build.1-beta2"), Some(ReleaseChannel::Beta));
+        assert_eq!(release_channel("26.2-unstable"), None);
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/paperclip.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/paperclip.rs
@@ -1,0 +1,298 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use super::super::archive::{
+    ArchiveMetadata, LIBRARIES_LIST_ENTRY, PATCHES_LIST_ENTRY, VERSIONS_LIST_ENTRY,
+};
+use super::super::formats::paperclip_list;
+use super::super::model::{ArtifactInfo, ArtifactRole, EvidenceSource, ServerCategory};
+use super::{
+    api_component, ecosystems_for_key, list_location, manifest_location, product_from_key,
+    product_key_from_coordinate, release_channel, strip_jar_suffix, target_product_key,
+    ComponentFinding, Findings, ProductFinding, ProductValueFinding, Signal,
+};
+
+const SHARED_PAPERCLIP_MAIN_CLASSES: &[&str] =
+    &["io.papermc.paperclip.Main", "com.destroystokyo.paperclip.Paperclip"];
+
+pub(super) fn detect(
+    path: &Path,
+    artifact: &ArtifactInfo,
+    archive: &ArchiveMetadata,
+    findings: &mut Findings,
+) {
+    let main_class = artifact.main_class.value.as_deref();
+    let paperclip_main = main_class.is_some_and(|main_class| {
+        SHARED_PAPERCLIP_MAIN_CLASSES.contains(&main_class)
+            || matches!(main_class, "cn.dreeam.leaper.Main" | "org.leavesmc.leavesclip.Main")
+    });
+    if paperclip_main {
+        findings.roles.push(Signal {
+            value: ArtifactRole::Bootstrapper,
+            detector: "paperclip-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 95,
+            correlation_group: "paperclip-main-class",
+        });
+        findings.categories.push(Signal {
+            value: ServerCategory::JavaGameServer,
+            detector: "paperclip-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 90,
+            correlation_group: "paperclip-main-class",
+        });
+    }
+    if let Some(key) = match main_class {
+        Some("cn.dreeam.leaper.Main") => Some("leaf"),
+        Some("org.leavesmc.leavesclip.Main") => Some("leaves"),
+        _ => None,
+    } {
+        findings.products.push(ProductFinding {
+            signal: Signal {
+                value: product_from_key(key),
+                detector: "paperclip-main-class",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 90,
+                correlation_group: "paperclip-main-class",
+            },
+            ecosystems: ecosystems_for_key(key, true),
+        });
+    }
+
+    let mut target_keys = BTreeSet::new();
+    if let Some(content) = archive.versions_list.as_deref() {
+        for entry in paperclip_list::parse_versions(content) {
+            if let Some(key) = target_product_key(&entry.target_path, &entry.minecraft_version) {
+                let paper_context = key != "vanilla" && paperclip_main;
+                add_target_finding(
+                    path,
+                    VERSIONS_LIST_ENTRY,
+                    entry.line,
+                    &key,
+                    &entry.minecraft_version,
+                    95,
+                    "versions-list",
+                    paper_context,
+                    findings,
+                );
+                target_keys.insert(key);
+            }
+        }
+    }
+
+    if let Some(content) = archive.patches_list.as_deref() {
+        let patches = paperclip_list::parse_version_patches(content);
+        if !patches.is_empty() && !paperclip_main {
+            findings.roles.push(Signal {
+                value: ArtifactRole::Bootstrapper,
+                detector: "paperclip-patches-list",
+                source: EvidenceSource::JarEntry,
+                location: list_location(path, PATCHES_LIST_ENTRY, patches[0].line),
+                weight: 90,
+                correlation_group: "patches-list",
+            });
+        }
+        for entry in patches {
+            if let Some(key) = target_product_key(&entry.target_path, &entry.minecraft_version) {
+                add_target_finding(
+                    path,
+                    PATCHES_LIST_ENTRY,
+                    entry.line,
+                    &key,
+                    &entry.minecraft_version,
+                    95,
+                    "patches-list",
+                    key != "vanilla",
+                    findings,
+                );
+                target_keys.insert(key);
+            }
+        }
+    }
+
+    if let Some(content) = archive.libraries_list.as_deref() {
+        for entry in paperclip_list::parse_libraries(content) {
+            if let Some(coordinate) = entry.coordinate.as_ref() {
+                let key = product_key_from_coordinate(coordinate).or_else(|| {
+                    coordinate
+                        .artifact
+                        .strip_suffix("-api")
+                        .filter(|key| target_keys.contains(*key))
+                        .map(str::to_string)
+                });
+                if let Some(key) = key {
+                    let location = list_location(path, LIBRARIES_LIST_ENTRY, entry.line);
+                    findings.products.push(ProductFinding {
+                        signal: Signal {
+                            value: product_from_key(&key),
+                            detector: "paperclip-api-coordinate",
+                            source: EvidenceSource::MavenCoordinate,
+                            location: location.clone(),
+                            weight: 98,
+                            correlation_group: "libraries-list-coordinate",
+                        },
+                        ecosystems: ecosystems_for_key(&key, key != "spigot"),
+                    });
+                    findings.product_versions.push(ProductValueFinding {
+                        product_key: key.clone(),
+                        signal: Signal {
+                            value: coordinate.version.clone(),
+                            detector: "paperclip-api-coordinate",
+                            source: EvidenceSource::MavenCoordinate,
+                            location: location.clone(),
+                            weight: 98,
+                            correlation_group: "libraries-list-coordinate",
+                        },
+                    });
+                    if let Some(channel) = release_channel(&coordinate.version) {
+                        findings.release_channels.push(ProductValueFinding {
+                            product_key: key.clone(),
+                            signal: Signal {
+                                value: channel,
+                                detector: "paperclip-api-coordinate",
+                                source: EvidenceSource::MavenCoordinate,
+                                location: location.clone(),
+                                weight: 95,
+                                correlation_group: "libraries-list-coordinate",
+                            },
+                        });
+                    }
+                    findings.components.push(ComponentFinding {
+                        product_key: key.clone(),
+                        signal: Signal {
+                            value: api_component(
+                                &key,
+                                coordinate.version.clone(),
+                                Some(coordinate.clone()),
+                                PathBuf::from(&entry.target_path),
+                            ),
+                            detector: "paperclip-api-coordinate",
+                            source: EvidenceSource::MavenCoordinate,
+                            location,
+                            weight: 98,
+                            correlation_group: "libraries-list-coordinate",
+                        },
+                    });
+                    continue;
+                }
+            }
+
+            for key in &target_keys {
+                let Some(version) = version_from_api_path(key, &entry.target_path) else {
+                    continue;
+                };
+                let location = list_location(path, LIBRARIES_LIST_ENTRY, entry.line);
+                findings.product_versions.push(ProductValueFinding {
+                    product_key: key.clone(),
+                    signal: Signal {
+                        value: version.clone(),
+                        detector: "paperclip-api-path",
+                        source: EvidenceSource::JarEntry,
+                        location: location.clone(),
+                        weight: 85,
+                        correlation_group: "libraries-list-path",
+                    },
+                });
+                if let Some(channel) = release_channel(&version) {
+                    findings.release_channels.push(ProductValueFinding {
+                        product_key: key.clone(),
+                        signal: Signal {
+                            value: channel,
+                            detector: "paperclip-api-path",
+                            source: EvidenceSource::JarEntry,
+                            location: location.clone(),
+                            weight: 85,
+                            correlation_group: "libraries-list-path",
+                        },
+                    });
+                }
+                findings.components.push(ComponentFinding {
+                    product_key: key.clone(),
+                    signal: Signal {
+                        value: api_component(key, version, None, PathBuf::from(&entry.target_path)),
+                        detector: "paperclip-api-path",
+                        source: EvidenceSource::JarEntry,
+                        location,
+                        weight: 85,
+                        correlation_group: "libraries-list-path",
+                    },
+                });
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_target_finding(
+    path: &Path,
+    archive_entry: &str,
+    line: usize,
+    key: &str,
+    minecraft_version: &str,
+    weight: u8,
+    correlation_group: &'static str,
+    paperclip_context: bool,
+    findings: &mut Findings,
+) {
+    let location = list_location(path, archive_entry, line);
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key(key),
+            detector: "paperclip-target-list",
+            source: EvidenceSource::JarEntry,
+            location: location.clone(),
+            weight,
+            correlation_group,
+        },
+        ecosystems: ecosystems_for_key(key, paperclip_context),
+    });
+    findings.minecraft_versions.push(Signal {
+        value: minecraft_version.to_string(),
+        detector: "paperclip-target-list",
+        source: EvidenceSource::JarEntry,
+        location: location.clone(),
+        weight: 95,
+        correlation_group,
+    });
+    if key == "vanilla" {
+        findings.product_versions.push(ProductValueFinding {
+            product_key: key.to_string(),
+            signal: Signal {
+                value: minecraft_version.to_string(),
+                detector: "vanilla-version-list",
+                source: EvidenceSource::JarEntry,
+                location,
+                weight: 95,
+                correlation_group,
+            },
+        });
+    }
+}
+
+fn version_from_api_path(product_key: &str, path: &str) -> Option<String> {
+    let filename = path.rsplit(['/', '\\']).next()?;
+    let stem = strip_jar_suffix(filename)?;
+    let prefix = format!("{product_key}-api-");
+    stem.to_ascii_lowercase()
+        .starts_with(&prefix)
+        .then(|| stem.get(prefix.len()..))
+        .flatten()
+        .filter(|version| !version.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::version_from_api_path;
+
+    #[test]
+    fn extracts_version_from_wildcard_api_paths() {
+        assert_eq!(
+            version_from_api_path("spigot", "spigot-api-26.2-R0.1-SNAPSHOT.jar").as_deref(),
+            Some("26.2-R0.1-SNAPSHOT")
+        );
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/vanilla.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/vanilla.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use super::super::model::{ArtifactInfo, EvidenceSource, MinecraftVersionInfo, ReleaseChannel};
+use super::{
+    ecosystems_for_key, manifest_location, product_from_key, version_json_location, Findings,
+    ProductFinding, ProductValueFinding, Signal,
+};
+
+pub(super) fn detect(
+    path: &Path,
+    artifact: &ArtifactInfo,
+    minecraft: Option<&MinecraftVersionInfo>,
+    findings: &mut Findings,
+) {
+    let vanilla_main = matches!(
+        artifact.main_class.value.as_deref(),
+        Some("net.minecraft.bundler.Main" | "net.minecraft.server.MinecraftServer")
+    );
+    if vanilla_main {
+        findings.products.push(ProductFinding {
+            signal: Signal {
+                value: product_from_key("vanilla"),
+                detector: "vanilla-main-class",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 90,
+                correlation_group: "vanilla-main-class",
+            },
+            ecosystems: ecosystems_for_key("vanilla", false),
+        });
+    }
+    if !findings.has_product("vanilla") {
+        return;
+    }
+    let Some(minecraft) = minecraft else {
+        return;
+    };
+    if let Some(version) = minecraft.version.value.as_ref() {
+        findings.product_versions.push(ProductValueFinding {
+            product_key: "vanilla".to_string(),
+            signal: Signal {
+                value: version.clone(),
+                detector: "vanilla-version-json",
+                source: EvidenceSource::JsonField,
+                location: version_json_location(path, "id"),
+                weight: 95,
+                correlation_group: "mojang-version-json",
+            },
+        });
+    }
+    if minecraft.stable == Some(true) {
+        findings.release_channels.push(ProductValueFinding {
+            product_key: "vanilla".to_string(),
+            signal: Signal {
+                value: ReleaseChannel::Stable,
+                detector: "vanilla-version-json",
+                source: EvidenceSource::JsonField,
+                location: version_json_location(path, "stable"),
+                weight: 90,
+                correlation_group: "mojang-version-json",
+            },
+        });
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/formats/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/lib.rs
@@ -1,2 +1,4 @@
 pub(super) mod manifest;
+pub(super) mod maven_coordinate;
 pub(super) mod mojang_version;
+pub(super) mod paperclip_list;

--- a/crates/core/src/provisioning/server_inspection/formats/maven_coordinate.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/maven_coordinate.rs
@@ -1,0 +1,58 @@
+use super::super::model::MavenCoordinate;
+
+pub(crate) fn parse(value: &str) -> Option<MavenCoordinate> {
+    let fields = value.split(':').collect::<Vec<_>>();
+    if fields.iter().any(|field| field.trim().is_empty()) {
+        return None;
+    }
+
+    match fields.as_slice() {
+        [group, artifact, version] => Some(MavenCoordinate {
+            group: (*group).to_string(),
+            artifact: (*artifact).to_string(),
+            version: (*version).to_string(),
+            classifier: None,
+            extension: None,
+        }),
+        [group, artifact, extension, version] => Some(MavenCoordinate {
+            group: (*group).to_string(),
+            artifact: (*artifact).to_string(),
+            version: (*version).to_string(),
+            classifier: None,
+            extension: Some((*extension).to_string()),
+        }),
+        [group, artifact, extension, classifier, version] => Some(MavenCoordinate {
+            group: (*group).to_string(),
+            artifact: (*artifact).to_string(),
+            version: (*version).to_string(),
+            classifier: Some((*classifier).to_string()),
+            extension: Some((*extension).to_string()),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn parses_standard_and_extended_coordinates() {
+        let standard =
+            parse("io.papermc.paper:paper-api:26.2.build.87-stable").expect("standard coordinate");
+        assert_eq!(standard.group, "io.papermc.paper");
+        assert_eq!(standard.artifact, "paper-api");
+        assert_eq!(standard.version, "26.2.build.87-stable");
+
+        let extended = parse("example:server:jar:mojmap:1.0").expect("extended coordinate");
+        assert_eq!(extended.extension.as_deref(), Some("jar"));
+        assert_eq!(extended.classifier.as_deref(), Some("mojmap"));
+    }
+
+    #[test]
+    fn rejects_wildcards_and_incomplete_coordinates() {
+        assert!(parse("*").is_none());
+        assert!(parse("paper-api:1.0").is_none());
+        assert!(parse("group::1.0").is_none());
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/formats/paperclip_list.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/paperclip_list.rs
@@ -1,0 +1,134 @@
+use super::super::model::MavenCoordinate;
+use super::maven_coordinate;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VersionListEntry {
+    pub(crate) line: usize,
+    pub(crate) minecraft_version: String,
+    pub(crate) target_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VersionPatchEntry {
+    pub(crate) line: usize,
+    pub(crate) minecraft_version: String,
+    pub(crate) target_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LibraryListEntry {
+    pub(crate) line: usize,
+    pub(crate) coordinate: Option<MavenCoordinate>,
+    pub(crate) declared_coordinate: String,
+    pub(crate) target_path: String,
+}
+
+pub(crate) fn parse_versions(content: &[u8]) -> Vec<VersionListEntry> {
+    lines(content)
+        .into_iter()
+        .filter_map(|(line, value)| {
+            let fields = split_fields(&value);
+            (fields.len() >= 3).then(|| VersionListEntry {
+                line,
+                minecraft_version: fields[1].to_string(),
+                target_path: fields[2].to_string(),
+            })
+        })
+        .filter(|entry| !entry.minecraft_version.is_empty() && !entry.target_path.is_empty())
+        .collect()
+}
+
+pub(crate) fn parse_version_patches(content: &[u8]) -> Vec<VersionPatchEntry> {
+    lines(content)
+        .into_iter()
+        .filter_map(|(line, value)| {
+            let fields = split_fields(&value);
+            if fields.len() < 7 || !fields[0].eq_ignore_ascii_case("versions") {
+                return None;
+            }
+            let target_path = fields[6].to_string();
+            let minecraft_version = target_path
+                .split(['/', '\\'])
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            (!minecraft_version.is_empty() && !target_path.is_empty())
+                .then_some(VersionPatchEntry { line, minecraft_version, target_path })
+        })
+        .collect()
+}
+
+pub(crate) fn parse_libraries(content: &[u8]) -> Vec<LibraryListEntry> {
+    lines(content)
+        .into_iter()
+        .filter_map(|(line, value)| {
+            let fields = split_fields(&value);
+            (fields.len() >= 3).then(|| LibraryListEntry {
+                line,
+                coordinate: maven_coordinate::parse(fields[1]),
+                declared_coordinate: fields[1].to_string(),
+                target_path: fields[2].to_string(),
+            })
+        })
+        .filter(|entry| !entry.target_path.is_empty())
+        .collect()
+}
+
+fn lines(content: &[u8]) -> Vec<(usize, String)> {
+    String::from_utf8_lossy(content)
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            let line = line.trim();
+            (!line.is_empty()).then_some((index + 1, line.to_string()))
+        })
+        .collect()
+}
+
+fn split_fields(line: &str) -> Vec<&str> {
+    let tab_fields = line.split('\t').collect::<Vec<_>>();
+    if tab_fields.len() > 1 {
+        tab_fields
+    } else {
+        line.split_whitespace().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_libraries, parse_version_patches, parse_versions};
+
+    #[test]
+    fn parses_current_paperclip_lists() {
+        let versions = parse_versions(b"hash\t26.2\t26.2/purpur-26.2.jar\ninvalid\n");
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].minecraft_version, "26.2");
+        assert_eq!(versions[0].target_path, "26.2/purpur-26.2.jar");
+
+        let patches = parse_version_patches(
+            b"versions\tinput-hash\tpatch-hash\toutput-hash\t26.2/server-26.2.jar\t26.2/server.patch\t26.2/purpur-26.2.jar\n",
+        );
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].minecraft_version, "26.2");
+
+        let libraries = parse_libraries(
+            b"hash\torg.purpurmc.purpur:purpur-api:26.2.build.2618-stable\torg/purpurmc/purpur-api.jar\n",
+        );
+        assert_eq!(libraries.len(), 1);
+        assert_eq!(
+            libraries[0]
+                .coordinate
+                .as_ref()
+                .map(|coordinate| coordinate.artifact.as_str()),
+            Some("purpur-api")
+        );
+    }
+
+    #[test]
+    fn keeps_wildcard_library_entries_for_path_based_fallbacks() {
+        let libraries = parse_libraries(b"hash\t*\tspigot-api-26.2-R0.1-SNAPSHOT.jar\n");
+
+        assert_eq!(libraries[0].declared_coordinate, "*");
+        assert!(libraries[0].coordinate.is_none());
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -1,4 +1,6 @@
 mod archive;
+#[path = "detectors/lib.rs"]
+mod detectors;
 mod error;
 mod evidence;
 #[path = "formats/lib.rs"]
@@ -100,6 +102,8 @@ pub fn inspect_server_artifact(
     };
     let mut minecraft = None;
     let mut java = JavaRequirementInfo::default();
+    let mut identity = ServerIdentityInfo::default();
+    let mut components = Vec::new();
 
     if metadata.is_dir() {
         let format_evidence = evidence.push(NewEvidence {
@@ -146,8 +150,8 @@ pub fn inspect_server_artifact(
         format_claims.push(claim(format, format_evidence, format_weight, "file-name"));
 
         if format == ArtifactFormat::Jar {
-            let archive_metadata = archive::read_metadata(path, options)?;
-            diagnostics.extend(archive_metadata.diagnostics);
+            let mut archive_metadata = archive::read_metadata(path, options)?;
+            diagnostics.append(&mut archive_metadata.diagnostics);
             let archive_evidence = evidence.push(NewEvidence {
                 detector: "jar-container",
                 source: EvidenceSource::JarEntry,
@@ -164,8 +168,8 @@ pub fn inspect_server_artifact(
                 "archive-container",
             ));
 
-            if let Some(bytes) = archive_metadata.manifest {
-                let parsed = formats::manifest::parse(&bytes);
+            if let Some(bytes) = archive_metadata.manifest.as_deref() {
+                let parsed = formats::manifest::parse(bytes);
                 if parsed.used_lossy_utf8 {
                     diagnostics.push(InspectionDiagnostic {
                         severity: DiagnosticSeverity::Warning,
@@ -188,8 +192,8 @@ pub fn inspect_server_artifact(
                 artifact.manifest = Some(parsed.summary);
             }
 
-            if let Some(bytes) = archive_metadata.mojang_version {
-                match formats::mojang_version::parse(&bytes) {
+            if let Some(bytes) = archive_metadata.mojang_version.as_deref() {
+                match formats::mojang_version::parse(bytes) {
                     Ok(Some(document)) => {
                         let (minecraft_info, java_info, mut version_diagnostics) =
                             apply_mojang_version(path, document, &mut evidence);
@@ -217,6 +221,36 @@ pub fn inspect_server_artifact(
                     }),
                 }
             }
+
+            let detector_output = detectors::detect_jar(
+                path,
+                &artifact,
+                &archive_metadata,
+                minecraft.as_ref(),
+                &mut evidence,
+            );
+            identity = detector_output.identity;
+            if detector_output.minecraft_version.confidence > 0 {
+                let minecraft_info = minecraft.get_or_insert_with(MinecraftVersionInfo::default);
+                for evidence_id in detector_output.minecraft_version.evidence.iter().chain(
+                    detector_output
+                        .minecraft_version
+                        .alternatives
+                        .iter()
+                        .flat_map(|candidate| candidate.evidence.iter()),
+                ) {
+                    if !minecraft_info.evidence.contains(evidence_id) {
+                        minecraft_info.evidence.push(*evidence_id);
+                    }
+                }
+                minecraft_info.version = detector_output.minecraft_version;
+            }
+            roles.extend(detector_output.roles);
+            components = detector_output.components;
+            for diagnostic in detector_output.diagnostics {
+                diagnostics.retain(|existing| existing.code != diagnostic.code);
+                diagnostics.push(diagnostic);
+            }
         }
     }
 
@@ -227,10 +261,10 @@ pub fn inspect_server_artifact(
         schema_version: SERVER_INSPECTION_SCHEMA_VERSION,
         subject,
         artifact,
-        identity: ServerIdentityInfo::default(),
+        identity,
         minecraft,
         java,
-        components: Vec::new(),
+        components,
         launches,
         evidence: evidence.into_entries(),
         diagnostics,
@@ -622,7 +656,7 @@ mod tests {
 
     use super::{
         inspect_server_artifact, ArtifactFormat, ArtifactRole, InspectionOptions,
-        InspectionSubjectKind, LaunchTarget,
+        InspectionSubjectKind, LaunchTarget, ReleaseChannel, ServerCategory, ServerEcosystem,
     };
 
     fn temporary_path(suffix: &str) -> PathBuf {
@@ -637,21 +671,345 @@ mod tests {
     }
 
     fn write_test_jar(path: &Path, manifest: &str, version_json: &str) {
+        write_test_jar_entries(
+            path,
+            &[("META-INF/MANIFEST.MF", manifest), ("version.json", version_json)],
+        );
+    }
+
+    fn write_test_jar_entries(path: &Path, entries: &[(&str, &str)]) {
         let file = File::create(path).expect("create test JAR");
         let mut archive = zip::ZipWriter::new(file);
-        archive
-            .start_file("META-INF/MANIFEST.MF", FileOptions::<()>::default())
-            .expect("create manifest entry");
-        archive
-            .write_all(manifest.as_bytes())
-            .expect("write manifest");
-        archive
-            .start_file("version.json", FileOptions::<()>::default())
-            .expect("create version entry");
-        archive
-            .write_all(version_json.as_bytes())
-            .expect("write version JSON");
+        for (name, content) in entries {
+            archive
+                .start_file(*name, FileOptions::<()>::default())
+                .expect("create metadata entry");
+            archive
+                .write_all(content.as_bytes())
+                .expect("write metadata entry");
+        }
         archive.finish().expect("finish test JAR");
+    }
+
+    #[test]
+    fn distinguishes_paperclip_products_from_content_evidence() {
+        struct Case {
+            key: &'static str,
+            minecraft: &'static str,
+            main_class: &'static str,
+            coordinate: &'static str,
+            version: &'static str,
+            channel: ReleaseChannel,
+        }
+
+        let cases = [
+            Case {
+                key: "paper",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "io.papermc.paper:paper-api:26.2.build.87-stable",
+                version: "26.2.build.87-stable",
+                channel: ReleaseChannel::Stable,
+            },
+            Case {
+                key: "purpur",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "org.purpurmc.purpur:purpur-api:26.2.build.2618-stable",
+                version: "26.2.build.2618-stable",
+                channel: ReleaseChannel::Stable,
+            },
+            Case {
+                key: "folia",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "dev.folia:folia-api:26.2.build.1-beta",
+                version: "26.2.build.1-beta",
+                channel: ReleaseChannel::Beta,
+            },
+            Case {
+                key: "pufferfish",
+                minecraft: "1.21.10",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "gg.pufferfish.pufferfish:pufferfish-api:1.21.10-R0.1-SNAPSHOT",
+                version: "1.21.10-R0.1-SNAPSHOT",
+                channel: ReleaseChannel::Snapshot,
+            },
+            Case {
+                key: "aspaper",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "com.infernalsuite.asp:aspaper-api:26.2.build.62-beta",
+                version: "26.2.build.62-beta",
+                channel: ReleaseChannel::Beta,
+            },
+            Case {
+                key: "canvas",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "io.canvasmc.canvas:canvas-api:26.2.build.890-stable",
+                version: "26.2.build.890-stable",
+                channel: ReleaseChannel::Stable,
+            },
+            Case {
+                key: "divinemc",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "org.bxteam.divinemc:divinemc-api:26.2.build.4-stable",
+                version: "26.2.build.4-stable",
+                channel: ReleaseChannel::Stable,
+            },
+            Case {
+                key: "pluto",
+                minecraft: "26.2",
+                main_class: "io.papermc.paperclip.Main",
+                coordinate: "dev.yive.pluto:pluto-api:26.2-R0.1-SNAPSHOT",
+                version: "26.2-R0.1-SNAPSHOT",
+                channel: ReleaseChannel::Snapshot,
+            },
+            Case {
+                key: "leaf",
+                minecraft: "26.2",
+                main_class: "cn.dreeam.leaper.Main",
+                coordinate: "cn.dreeam.leaf:leaf-api:26.2.build.45-alpha",
+                version: "26.2.build.45-alpha",
+                channel: ReleaseChannel::Alpha,
+            },
+            Case {
+                key: "leaves",
+                minecraft: "1.21.11",
+                main_class: "org.leavesmc.leavesclip.Main",
+                coordinate: "org.leavesmc.leaves:leaves-api:1.21.11-R0.1-SNAPSHOT",
+                version: "1.21.11-R0.1-SNAPSHOT",
+                channel: ReleaseChannel::Snapshot,
+            },
+        ];
+
+        for case in cases {
+            let path = temporary_path(&format!("{}-server.jar", case.key));
+            let manifest = format!("Main-Class: {}\r\n\r\n", case.main_class);
+            let versions = format!(
+                "version-hash\t{}\t{}/{}-{}.jar\n",
+                case.minecraft, case.minecraft, case.key, case.minecraft
+            );
+            let patches = format!(
+                "versions\tinput\tpatch\toutput\t{0}/server-{0}.jar\t{0}/server.patch\t{0}/{1}-{0}.jar\n",
+                case.minecraft, case.key
+            );
+            let artifact = case
+                .coordinate
+                .split(':')
+                .nth(1)
+                .expect("API artifact in coordinate");
+            let libraries =
+                format!("library-hash\t{}\t{artifact}-{}.jar\n", case.coordinate, case.version);
+            let version_json = format!(
+                r#"{{"id":"{}","name":"{}","world_version":4903,"stable":true}}"#,
+                case.minecraft, case.minecraft
+            );
+            write_test_jar_entries(
+                &path,
+                &[
+                    ("META-INF/MANIFEST.MF", &manifest),
+                    ("META-INF/versions.list", &versions),
+                    ("META-INF/patches.list", &patches),
+                    ("META-INF/libraries.list", &libraries),
+                    ("version.json", &version_json),
+                ],
+            );
+
+            let report = inspect_server_artifact(&path, &InspectionOptions::default())
+                .expect("inspect Paperclip fixture");
+            fs::remove_file(&path).expect("remove Paperclip fixture");
+
+            assert_eq!(
+                report
+                    .identity
+                    .implementation
+                    .value
+                    .as_ref()
+                    .map(|product| product.key.as_str()),
+                Some(case.key)
+            );
+            assert_eq!(report.identity.implementation.confidence, 100);
+            assert_eq!(report.identity.version.value.as_deref(), Some(case.version));
+            assert_eq!(report.identity.release_channel.value, Some(case.channel));
+            assert_eq!(report.identity.category.value, Some(ServerCategory::JavaGameServer));
+            assert!(report
+                .identity
+                .ecosystems
+                .iter()
+                .any(|ecosystem| ecosystem.value == ServerEcosystem::Paper));
+            assert!(report
+                .identity
+                .ecosystems
+                .iter()
+                .any(|ecosystem| ecosystem.value == ServerEcosystem::Bukkit));
+            assert!(report
+                .artifact
+                .roles
+                .iter()
+                .any(|role| role.value == ArtifactRole::Bootstrapper));
+            assert_eq!(report.components.len(), 1);
+            assert_eq!(
+                report.components[0]
+                    .value
+                    .coordinate
+                    .as_ref()
+                    .map(|coordinate| coordinate.version.as_str()),
+                Some(case.version)
+            );
+            assert_eq!(
+                report
+                    .minecraft
+                    .as_ref()
+                    .and_then(|minecraft| minecraft.version.value.as_deref()),
+                Some(case.minecraft)
+            );
+            let minecraft = report.minecraft.as_ref().expect("Minecraft metadata");
+            assert!(minecraft
+                .version
+                .evidence
+                .iter()
+                .all(|evidence_id| minecraft.evidence.contains(evidence_id)));
+        }
+    }
+
+    #[test]
+    fn detects_vanilla_content_even_when_the_file_is_named_quilt() {
+        let path = temporary_path("quilt-server.jar");
+        write_test_jar_entries(
+            &path,
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: net.minecraft.bundler.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/server-26.2.jar\n"),
+                (
+                    "version.json",
+                    r#"{"id":"26.2","name":"26.2","world_version":4903,"stable":true}"#,
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect renamed vanilla JAR");
+        fs::remove_file(&path).expect("remove vanilla fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("vanilla")
+        );
+        assert_eq!(report.identity.implementation.confidence, 100);
+        assert_eq!(report.identity.version.value.as_deref(), Some("26.2"));
+        assert_eq!(report.identity.release_channel.value, Some(ReleaseChannel::Stable));
+        assert_eq!(report.identity.ecosystems[0].value, ServerEcosystem::Vanilla);
+    }
+
+    #[test]
+    fn supports_spigot_paperclip_with_a_wildcard_api_coordinate() {
+        let path = temporary_path("spigot.jar");
+        write_test_jar_entries(
+            &path,
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/spigot-26.2.jar\n"),
+                (
+                    "META-INF/patches.list",
+                    "versions\tinput\tpatch\toutput\t26.2/server-26.2.jar\t26.2/server.patch\t26.2/spigot-26.2.jar\n",
+                ),
+                (
+                    "META-INF/libraries.list",
+                    "hash\t*\tspigot-api-26.2-R0.1-SNAPSHOT.jar\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect Spigot Paperclip fixture");
+        fs::remove_file(&path).expect("remove Spigot fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("spigot")
+        );
+        assert_eq!(report.identity.version.value.as_deref(), Some("26.2-R0.1-SNAPSHOT"));
+        assert_eq!(report.identity.release_channel.value, Some(ReleaseChannel::Snapshot));
+        assert_eq!(report.identity.ecosystems.len(), 1);
+        assert_eq!(report.identity.ecosystems[0].value, ServerEcosystem::Bukkit);
+        assert!(report.components[0].value.coordinate.is_none());
+    }
+
+    #[test]
+    fn accepts_an_unknown_paperclip_product_without_expanding_an_enum() {
+        let path = temporary_path("custom-fork.jar");
+        write_test_jar_entries(
+            &path,
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: io.papermc.paperclip.Main\r\n\r\n",
+                ),
+                (
+                    "META-INF/versions.list",
+                    "hash\t26.2\t26.2/custom-fork-26.2.jar\n",
+                ),
+                (
+                    "META-INF/libraries.list",
+                    "hash\texample.server:custom-fork-api:26.2.build.1-stable\tcustom-fork-api.jar\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect unknown Paperclip fixture");
+        fs::remove_file(&path).expect("remove unknown Paperclip fixture");
+
+        let product = report
+            .identity
+            .implementation
+            .value
+            .expect("open product identity");
+        assert_eq!(product.key, "custom-fork");
+        assert_eq!(product.display_name, "Custom Fork");
+        assert_eq!(report.identity.version.value.as_deref(), Some("26.2.build.1-stable"));
+        assert_eq!(report.identity.ecosystems.len(), 2);
+    }
+
+    #[test]
+    fn leaves_strong_conflicting_product_evidence_unresolved() {
+        let path = temporary_path("server.jar");
+        write_test_jar_entries(
+            &path,
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/purpur-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\tio.papermc.paper:paper-api:26.2.build.87-stable\tpaper-api.jar\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect conflicting Paperclip fixture");
+        fs::remove_file(&path).expect("remove conflicting fixture");
+
+        assert!(report.identity.implementation.value.is_none());
+        assert_eq!(report.identity.implementation.alternatives.len(), 2);
+        assert!(report.identity.ecosystems.is_empty());
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "conflicting_server_implementations"));
     }
 
     #[test]

--- a/crates/core/src/provisioning/server_inspection/model.rs
+++ b/crates/core/src/provisioning/server_inspection/model.rs
@@ -187,7 +187,7 @@ pub enum ReleaseChannel {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct MinecraftVersionInfo {
     pub version: Detected<String>,
     pub id: Option<String>,

--- a/crates/core/src/provisioning/server_inspection/resolver.rs
+++ b/crates/core/src/provisioning/server_inspection/resolver.rs
@@ -1,4 +1,4 @@
-use super::model::{Detected, DetectionCandidate, EvidenceId};
+use super::model::{Attributed, Detected, DetectionCandidate, EvidenceId};
 
 #[derive(Debug, Clone)]
 pub(crate) struct DetectionClaim<T> {
@@ -18,6 +18,51 @@ struct CandidateState<T> {
 
 /// 同一候选的独立来源只提供有限加分，避免同一文件中的重复字段淹没冲突证据。
 pub(crate) fn resolve<T>(claims: Vec<DetectionClaim<T>>) -> Detected<T>
+where
+    T: Clone + Eq,
+{
+    let candidates = rank_candidates(claims);
+    let Some(winner) = candidates.first().cloned() else {
+        return Detected::default();
+    };
+    let conflicts = candidates.get(1).is_some_and(|runner_up| {
+        (winner.confidence >= 80 && runner_up.confidence >= 80)
+            || (runner_up.confidence >= 50
+                && winner.confidence.saturating_sub(runner_up.confidence) < 15)
+    });
+
+    if conflicts {
+        return Detected {
+            value: None,
+            confidence: winner.confidence,
+            evidence: winner.evidence.clone(),
+            alternatives: candidates,
+        };
+    }
+
+    Detected {
+        value: Some(winner.value),
+        confidence: winner.confidence,
+        evidence: winner.evidence,
+        alternatives: candidates.into_iter().skip(1).collect(),
+    }
+}
+
+pub(crate) fn resolve_attributed<T>(claims: Vec<DetectionClaim<T>>) -> Vec<Attributed<T>>
+where
+    T: Clone + Eq,
+{
+    rank_candidates(claims)
+        .into_iter()
+        .map(|candidate| Attributed {
+            value: candidate.value,
+            confidence: candidate.confidence,
+            evidence: candidate.evidence,
+        })
+        .collect()
+}
+
+fn rank_candidates<T>(claims: Vec<DetectionClaim<T>>) -> Vec<DetectionCandidate<T>>
 where
     T: Clone + Eq,
 {
@@ -79,34 +124,10 @@ where
             .then_with(|| left_index.cmp(right_index))
     });
 
-    let Some((winner, _)) = candidates.first().cloned() else {
-        return Detected::default();
-    };
-    let conflicts = candidates.get(1).is_some_and(|(runner_up, _)| {
-        (winner.confidence >= 80 && runner_up.confidence >= 80)
-            || (runner_up.confidence >= 50
-                && winner.confidence.saturating_sub(runner_up.confidence) < 15)
-    });
-    let candidates = candidates
+    candidates
         .into_iter()
         .map(|(candidate, _)| candidate)
-        .collect::<Vec<_>>();
-
-    if conflicts {
-        return Detected {
-            value: None,
-            confidence: winner.confidence,
-            evidence: winner.evidence.clone(),
-            alternatives: candidates,
-        };
-    }
-
-    Detected {
-        value: Some(winner.value),
-        confidence: winner.confidence,
-        evidence: winner.evidence,
-        alternatives: candidates.into_iter().skip(1).collect(),
-    }
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
本 PR 完成服务端检查的第二阶段，增加 Vanilla 与 Paperclip 系服务端识别。

整体功能尚未完成，Fabric、Forge、NeoForge 及其他服务端类型将在后续 PR 补充。

## Summary by Sourcery

为基于 Vanilla 和 Paperclip 的 Java 服务器添加服务端实现检测，并将其集成到核心服务器检查流水线中。

New Features:
- 基于 manifest 主类和 Mojang 版本元数据检测 Vanilla 服务器。
- 根据 JAR 内容检测基于 Paperclip 的服务器产品（Paper、Purpur、Folia、Spigot 及其他分叉），包括 API 坐标和版本列表。
- 从版本字符串和已知产品映射中推断服务器发布渠道及关联生态系统。
- 使用新的检测器输出，在检查报告中填充服务器身份、角色、组件以及 Minecraft 版本信息。

Enhancements:
- 重构检测解析逻辑，以支持带属性的结果，并在多个候选之间进行冲突报告。
- 扩展归档元数据读取，以支持更多与 Paperclip 相关的列表条目。
- 引入用于新检测器的 Maven 坐标与 Paperclip 列表格式解析器。
- 默认 Minecraft 版本信息，以便在 Mojang 元数据可用之前累积证据。

Tests:
- 添加全面测试，覆盖 Paperclip 产品检测、针对重命名 JAR 的 Vanilla 检测、通配符 Spigot 坐标、未知 Paperclip 分叉以及相互冲突的实现证据等场景。
- 为检测器工具添加单元测试，例如文件名匹配、目标产品键派生、发布渠道推断、Paperclip 列表解析以及 Maven 坐标解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add server implementation detection for Vanilla and Paperclip-based Java servers and integrate it into the core server inspection pipeline.

New Features:
- Detect Vanilla servers based on manifest main class and Mojang version metadata.
- Detect Paperclip-based server products (Paper, Purpur, Folia, Spigot, and other forks) from JAR contents, including API coordinates and version lists.
- Infer server release channel and associated ecosystems from version strings and known product mappings.
- Populate server identity, roles, components, and Minecraft version in inspection reports using new detector outputs.

Enhancements:
- Refactor detection resolution logic to support attributed results and conflict reporting across multiple candidates.
- Extend archive metadata reading to support additional Paperclip-related list entries.
- Introduce parsers for Maven coordinates and Paperclip list formats used by the new detectors.
- Default Minecraft version info to allow accumulating evidence before Mojang metadata is available.

Tests:
- Add comprehensive tests covering Paperclip product detection, Vanilla detection for renamed JARs, wildcard Spigot coordinates, unknown Paperclip forks, and conflicting implementation evidence.
- Add unit tests for detector utilities such as filename matching, target product key derivation, release channel inference, Paperclip list parsing, and Maven coordinate parsing.

</details>