### PR TITLE
feat(core): 识别 ModLoader 服务端安装

### DIFF
--- a/crates/core/src/provisioning/server_inspection/archive.rs
+++ b/crates/core/src/provisioning/server_inspection/archive.rs
@@ -13,6 +13,13 @@ const MOJANG_VERSION_ENTRY: &str = "version.json";
 pub(super) const VERSIONS_LIST_ENTRY: &str = "META-INF/versions.list";
 pub(super) const PATCHES_LIST_ENTRY: &str = "META-INF/patches.list";
 pub(super) const LIBRARIES_LIST_ENTRY: &str = "META-INF/libraries.list";
+pub(super) const INSTALL_PROPERTIES_ENTRY: &str = "install.properties";
+pub(super) const BOOTSTRAP_PROPERTIES_ENTRY: &str = "bootstrap-shim.properties";
+pub(super) const BOOTSTRAP_LIST_ENTRY: &str = "bootstrap-shim.list";
+pub(super) const WRAPPER_METADATA_ENTRY: &str = "metadata.json";
+pub(super) const FORGE_VERSION_ENTRY: &str = "forge_version.json";
+pub(super) const NEOFORGE_VERSION_PROPERTIES_ENTRY: &str =
+    "net/neoforged/neoforge/common/version.properties";
 
 pub(super) struct ArchiveMetadata {
     pub(super) manifest: Option<Vec<u8>>,
@@ -20,12 +27,27 @@ pub(super) struct ArchiveMetadata {
     pub(super) versions_list: Option<Vec<u8>>,
     pub(super) patches_list: Option<Vec<u8>>,
     pub(super) libraries_list: Option<Vec<u8>>,
+    pub(super) install_properties: Option<Vec<u8>>,
+    pub(super) bootstrap_properties: Option<Vec<u8>>,
+    pub(super) bootstrap_list: Option<Vec<u8>>,
+    pub(super) wrapper_metadata: Option<Vec<u8>>,
+    pub(super) forge_version: Option<Vec<u8>>,
+    pub(super) neoforge_version_properties: Option<Vec<u8>>,
     pub(super) diagnostics: Vec<InspectionDiagnostic>,
 }
 
 pub(super) fn read_metadata(
     path: &Path,
     options: &InspectionOptions,
+) -> Result<ArchiveMetadata, ServerInspectionError> {
+    let mut consumed = 0;
+    read_metadata_with_budget(path, options, &mut consumed)
+}
+
+pub(super) fn read_metadata_with_budget(
+    path: &Path,
+    options: &InspectionOptions,
+    consumed: &mut u64,
 ) -> Result<ArchiveMetadata, ServerInspectionError> {
     let file = File::open(path)
         .map_err(|source| ServerInspectionError::Open { path: path.to_path_buf(), source })?;
@@ -40,13 +62,12 @@ pub(super) fn read_metadata(
     }
 
     let mut diagnostics = Vec::new();
-    let mut consumed = 0_u64;
     let manifest = read_optional_entry(
         &mut archive,
         path,
         MANIFEST_ENTRY,
         options,
-        &mut consumed,
+        consumed,
         &mut diagnostics,
     )?;
     let mojang_version = read_optional_entry(
@@ -54,7 +75,7 @@ pub(super) fn read_metadata(
         path,
         MOJANG_VERSION_ENTRY,
         options,
-        &mut consumed,
+        consumed,
         &mut diagnostics,
     )?;
     let versions_list = read_optional_entry(
@@ -62,7 +83,7 @@ pub(super) fn read_metadata(
         path,
         VERSIONS_LIST_ENTRY,
         options,
-        &mut consumed,
+        consumed,
         &mut diagnostics,
     )?;
     let patches_list = read_optional_entry(
@@ -70,7 +91,7 @@ pub(super) fn read_metadata(
         path,
         PATCHES_LIST_ENTRY,
         options,
-        &mut consumed,
+        consumed,
         &mut diagnostics,
     )?;
     let libraries_list = read_optional_entry(
@@ -78,7 +99,55 @@ pub(super) fn read_metadata(
         path,
         LIBRARIES_LIST_ENTRY,
         options,
-        &mut consumed,
+        consumed,
+        &mut diagnostics,
+    )?;
+    let install_properties = read_optional_entry(
+        &mut archive,
+        path,
+        INSTALL_PROPERTIES_ENTRY,
+        options,
+        consumed,
+        &mut diagnostics,
+    )?;
+    let bootstrap_properties = read_optional_entry(
+        &mut archive,
+        path,
+        BOOTSTRAP_PROPERTIES_ENTRY,
+        options,
+        consumed,
+        &mut diagnostics,
+    )?;
+    let bootstrap_list = read_optional_entry(
+        &mut archive,
+        path,
+        BOOTSTRAP_LIST_ENTRY,
+        options,
+        consumed,
+        &mut diagnostics,
+    )?;
+    let wrapper_metadata = read_optional_entry(
+        &mut archive,
+        path,
+        WRAPPER_METADATA_ENTRY,
+        options,
+        consumed,
+        &mut diagnostics,
+    )?;
+    let forge_version = read_optional_entry(
+        &mut archive,
+        path,
+        FORGE_VERSION_ENTRY,
+        options,
+        consumed,
+        &mut diagnostics,
+    )?;
+    let neoforge_version_properties = read_optional_entry(
+        &mut archive,
+        path,
+        NEOFORGE_VERSION_PROPERTIES_ENTRY,
+        options,
+        consumed,
         &mut diagnostics,
     )?;
 
@@ -88,6 +157,12 @@ pub(super) fn read_metadata(
         versions_list,
         patches_list,
         libraries_list,
+        install_properties,
+        bootstrap_properties,
+        bootstrap_list,
+        wrapper_metadata,
+        forge_version,
+        neoforge_version_properties,
         diagnostics,
     })
 }

--- a/crates/core/src/provisioning/server_inspection/detectors/fabric.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/fabric.rs
@@ -1,0 +1,223 @@
+use std::path::{Path, PathBuf};
+
+use super::super::archive::{ArchiveMetadata, INSTALL_PROPERTIES_ENTRY};
+use super::super::formats::{java_properties, manifest};
+use super::super::model::{
+    ArtifactRole, EvidenceLocation, EvidenceSource, LaunchPlatform, LaunchProfile, LaunchTarget,
+    ServerComponent, ServerComponentKind,
+};
+use super::{
+    ecosystems_for_key, manifest_location, product_from_key, ComponentFinding, Findings,
+    ProductFinding, ProductValueFinding, Signal,
+};
+
+const FABRIC_SERVER_LAUNCHER: &str = "net.fabricmc.installer.ServerLauncher";
+
+pub(super) fn detect(
+    subject_path: &Path,
+    archive: &ArchiveMetadata,
+    directory_launch: Option<(&Path, &Path)>,
+    findings: &mut Findings,
+) {
+    let Some(manifest_bytes) = archive.manifest.as_deref() else {
+        return;
+    };
+    let parsed_manifest = manifest::parse(manifest_bytes);
+    let main_class = parsed_manifest.main_value("Main-Class");
+    let title = parsed_manifest.main_value("Implementation-Title");
+    let installer_version = parsed_manifest.main_value("Implementation-Version");
+    let properties = archive
+        .install_properties
+        .as_deref()
+        .map(java_properties::parse)
+        .unwrap_or_default();
+    let loader_version = properties.get("fabric-loader-version");
+    let game_version = properties.get("game-version");
+
+    let (product_key, product_weight, product_field) = match title {
+        Some(title) if title.eq_ignore_ascii_case("LegacyFabricInstaller") => {
+            ("legacy-fabric", 98, "Implementation-Title")
+        }
+        Some(title) if title.eq_ignore_ascii_case("FabricInstaller") => {
+            ("fabric", 98, "Implementation-Title")
+        }
+        _ if main_class == Some(FABRIC_SERVER_LAUNCHER)
+            && loader_version.is_some()
+            && game_version.is_some() =>
+        {
+            ("fabric", 90, "Main-Class")
+        }
+        _ => return,
+    };
+
+    let product_location = EvidenceLocation {
+        path: subject_path.to_path_buf(),
+        archive_entry: Some("META-INF/MANIFEST.MF".to_string()),
+        manifest_section: None,
+        field: Some(product_field.to_string()),
+    };
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key(product_key),
+            detector: "fabric-installer-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: product_location,
+            weight: product_weight,
+            correlation_group: "fabric-installer-manifest",
+        },
+        ecosystems: ecosystems_for_key(product_key, false),
+    });
+
+    if main_class == Some(FABRIC_SERVER_LAUNCHER) {
+        findings.roles.push(Signal {
+            value: ArtifactRole::Launcher,
+            detector: "fabric-server-launcher",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(subject_path, "Main-Class"),
+            weight: 95,
+            correlation_group: "fabric-installer-manifest",
+        });
+    }
+    if title.is_some_and(|title| title.to_ascii_lowercase().contains("installer")) {
+        findings.roles.push(Signal {
+            value: ArtifactRole::Installer,
+            detector: "fabric-installer-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(subject_path, "Implementation-Title"),
+            weight: 95,
+            correlation_group: "fabric-installer-manifest",
+        });
+    }
+
+    let properties_location = EvidenceLocation {
+        path: subject_path.to_path_buf(),
+        archive_entry: Some(INSTALL_PROPERTIES_ENTRY.to_string()),
+        manifest_section: None,
+        field: None,
+    };
+    if loader_version.is_some() && game_version.is_some() {
+        findings.products.push(ProductFinding {
+            signal: Signal {
+                value: product_from_key(product_key),
+                detector: "fabric-install-properties",
+                source: EvidenceSource::PropertiesField,
+                location: EvidenceLocation {
+                    field: Some("fabric-loader-version".to_string()),
+                    ..properties_location.clone()
+                },
+                weight: 90,
+                correlation_group: "fabric-install-properties",
+            },
+            ecosystems: ecosystems_for_key(product_key, false),
+        });
+    }
+    if let Some(loader_version) = loader_version {
+        let location = EvidenceLocation {
+            field: Some("fabric-loader-version".to_string()),
+            ..properties_location.clone()
+        };
+        findings.product_versions.push(ProductValueFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: loader_version.clone(),
+                detector: "fabric-install-properties",
+                source: EvidenceSource::PropertiesField,
+                location: location.clone(),
+                weight: 98,
+                correlation_group: "fabric-install-properties",
+            },
+        });
+        findings.components.push(ComponentFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: ServerComponent {
+                    kind: ServerComponentKind::ModLoader,
+                    key: product_key.to_string(),
+                    name: if product_key == "legacy-fabric" {
+                        "Legacy Fabric Loader".to_string()
+                    } else {
+                        "Fabric Loader".to_string()
+                    },
+                    version: Some(loader_version.clone()),
+                    release_channel: None,
+                    coordinate: None,
+                    source_path: Some(PathBuf::from(INSTALL_PROPERTIES_ENTRY)),
+                },
+                detector: "fabric-install-properties",
+                source: EvidenceSource::PropertiesField,
+                location,
+                weight: 98,
+                correlation_group: "fabric-install-properties",
+            },
+        });
+    }
+    if let Some(game_version) = game_version {
+        findings.minecraft_versions.push(Signal {
+            value: game_version.clone(),
+            detector: "fabric-install-properties",
+            source: EvidenceSource::PropertiesField,
+            location: EvidenceLocation {
+                field: Some("game-version".to_string()),
+                ..properties_location
+            },
+            weight: 98,
+            correlation_group: "fabric-install-properties",
+        });
+    }
+    if let Some(installer_version) = installer_version {
+        findings.components.push(ComponentFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: ServerComponent {
+                    kind: ServerComponentKind::Installer,
+                    key: "fabric-installer".to_string(),
+                    name: if product_key == "legacy-fabric" {
+                        "Legacy Fabric Installer".to_string()
+                    } else {
+                        "Fabric Installer".to_string()
+                    },
+                    version: Some(installer_version.to_string()),
+                    release_channel: None,
+                    coordinate: None,
+                    source_path: Some(PathBuf::from("META-INF/MANIFEST.MF")),
+                },
+                detector: "fabric-installer-manifest",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(subject_path, "Implementation-Version"),
+                weight: 90,
+                correlation_group: "fabric-installer-manifest",
+            },
+        });
+    }
+
+    if let Some((root, relative_jar)) = directory_launch {
+        findings.launches.push(Signal {
+            value: LaunchProfile {
+                id: format!(
+                    "{}-{}",
+                    product_key,
+                    relative_jar
+                        .to_string_lossy()
+                        .chars()
+                        .map(|character| if character.is_ascii_alphanumeric() {
+                            character.to_ascii_lowercase()
+                        } else {
+                            '-'
+                        })
+                        .collect::<String>()
+                ),
+                platform: LaunchPlatform::Any,
+                working_directory: Some(root.to_path_buf()),
+                target: LaunchTarget::Jar { path: root.join(relative_jar) },
+                jvm_arguments: Vec::new(),
+                program_arguments: Vec::new(),
+                required_java_major: None,
+            },
+            detector: "fabric-server-launcher",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(subject_path, "Main-Class"),
+            weight: 95,
+            correlation_group: "fabric-installer-manifest",
+        });
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/forge.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/forge.rs
@@ -1,0 +1,881 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::super::super::{parse_startup_script_content, CoreKind, StartupScriptKind};
+use super::super::archive::{
+    ArchiveMetadata, BOOTSTRAP_LIST_ENTRY, BOOTSTRAP_PROPERTIES_ENTRY, FORGE_VERSION_ENTRY,
+    NEOFORGE_VERSION_PROPERTIES_ENTRY, WRAPPER_METADATA_ENTRY,
+};
+use super::super::directory::{
+    MetadataFile, ModLoaderFamily, ModLoaderInstallation, StartupScript,
+};
+use super::super::formats::{java_properties, jvm_args, manifest, paperclip_list};
+use super::super::model::{
+    ArtifactRole, EvidenceLocation, EvidenceSource, LaunchPlatform, LaunchProfile, LaunchTarget,
+    MavenCoordinate, ReleaseChannel, ServerComponent, ServerComponentKind,
+};
+use super::{
+    ecosystems_for_key, product_from_key, release_channel, ComponentFinding, Findings,
+    ProductFinding, ProductValueFinding, Signal,
+};
+
+pub(super) fn detect_archive(
+    archive_path: &Path,
+    directory_launch: Option<(&Path, &Path)>,
+    archive: &ArchiveMetadata,
+    findings: &mut Findings,
+) {
+    detect_forge_bootstrap(archive_path, directory_launch, archive, findings);
+    detect_neoforge_wrapper(archive_path, directory_launch, archive, findings);
+}
+
+pub(super) fn detect_installation(
+    root: &Path,
+    installation: &ModLoaderInstallation,
+    findings: &mut Findings,
+) {
+    let (product_key, group, artifact) = match installation.family {
+        ModLoaderFamily::Forge => ("forge", "net.minecraftforge", "forge"),
+        ModLoaderFamily::NeoForge => ("neoforge", "net.neoforged", "neoforge"),
+    };
+    let coordinate_location = EvidenceLocation {
+        path: root.join(&installation.relative_directory),
+        archive_entry: None,
+        manifest_section: None,
+        field: Some("Maven coordinate directory".to_string()),
+    };
+    add_product(
+        product_key,
+        "modloader-coordinate-directory",
+        EvidenceSource::DirectoryLayout,
+        coordinate_location.clone(),
+        95,
+        "modloader-coordinate-directory",
+        findings,
+    );
+
+    let (loader_version, coordinate_minecraft) = match installation.family {
+        ModLoaderFamily::Forge => split_forge_coordinate(&installation.coordinate_version)
+            .map_or((installation.coordinate_version.as_str(), None), |(minecraft, forge)| {
+                (forge, Some(minecraft))
+            }),
+        ModLoaderFamily::NeoForge => (installation.coordinate_version.as_str(), None),
+    };
+    add_product_version(
+        product_key,
+        loader_version,
+        "modloader-coordinate-directory",
+        EvidenceSource::MavenCoordinate,
+        coordinate_location.clone(),
+        95,
+        "modloader-coordinate-directory",
+        findings,
+    );
+    if let Some(minecraft) = coordinate_minecraft {
+        add_minecraft_version(
+            minecraft,
+            "forge-coordinate-directory",
+            EvidenceSource::MavenCoordinate,
+            coordinate_location.clone(),
+            90,
+            "modloader-coordinate-directory",
+            findings,
+        );
+    }
+    if let Some(channel) = release_channel(loader_version) {
+        add_release_channel(
+            product_key,
+            channel,
+            "modloader-coordinate-directory",
+            EvidenceSource::MavenCoordinate,
+            coordinate_location.clone(),
+            90,
+            "modloader-coordinate-directory",
+            findings,
+        );
+    }
+    findings.components.push(ComponentFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: ServerComponent {
+                kind: ServerComponentKind::ModLoader,
+                key: product_key.to_string(),
+                name: if product_key == "forge" {
+                    "Forge".to_string()
+                } else {
+                    "NeoForge".to_string()
+                },
+                version: Some(loader_version.to_string()),
+                release_channel: release_channel(loader_version),
+                coordinate: Some(MavenCoordinate {
+                    group: group.to_string(),
+                    artifact: artifact.to_string(),
+                    version: installation.coordinate_version.clone(),
+                    classifier: None,
+                    extension: None,
+                }),
+                source_path: Some(installation.relative_directory.clone()),
+            },
+            detector: "modloader-coordinate-directory",
+            source: EvidenceSource::MavenCoordinate,
+            location: coordinate_location,
+            weight: 95,
+            correlation_group: "modloader-coordinate-directory",
+        },
+    });
+
+    if let (Some(nested_path), Some(metadata)) =
+        (installation.nested_archive_path.as_ref(), installation.nested_metadata.as_ref())
+    {
+        match installation.family {
+            ModLoaderFamily::Forge => {
+                detect_forge_version_json(root, nested_path, metadata, findings)
+            }
+            ModLoaderFamily::NeoForge => {
+                detect_neoforge_properties(root, nested_path, metadata, findings)
+            }
+        }
+    }
+    if let Some(arguments) = installation.windows_args.as_ref() {
+        detect_argument_file(
+            root,
+            product_key,
+            &installation.coordinate_version,
+            LaunchPlatform::Windows,
+            arguments,
+            findings,
+        );
+    }
+    if let Some(arguments) = installation.unix_args.as_ref() {
+        detect_argument_file(
+            root,
+            product_key,
+            &installation.coordinate_version,
+            LaunchPlatform::Unix,
+            arguments,
+            findings,
+        );
+    }
+}
+
+pub(super) fn detect_script(root: &Path, script: &StartupScript, findings: &mut Findings) {
+    let parsed = parse_startup_script_content(script.kind, &script.content);
+    let product_key = match parsed.inferred_core {
+        CoreKind::Forge => "forge",
+        CoreKind::NeoForge => "neoforge",
+        _ => return,
+    };
+    let location = EvidenceLocation {
+        path: root.join(&script.relative_path),
+        archive_entry: None,
+        manifest_section: None,
+        field: Some("Java launch".to_string()),
+    };
+    add_product(
+        product_key,
+        "modloader-startup-script",
+        EvidenceSource::ArgumentFile,
+        location.clone(),
+        90,
+        "startup-script",
+        findings,
+    );
+    for (index, launch) in parsed.launches.into_iter().enumerate() {
+        findings.launches.push(Signal {
+            value: LaunchProfile {
+                id: format!(
+                    "{product_key}-{}-{}",
+                    launch_id_part(&script.relative_path),
+                    index + 1
+                ),
+                platform: platform_for_script(script.kind),
+                working_directory: Some(root.to_path_buf()),
+                target: LaunchTarget::Script { path: root.join(&script.relative_path) },
+                jvm_arguments: launch.jvm_arguments,
+                program_arguments: launch.application_arguments,
+                required_java_major: None,
+            },
+            detector: "modloader-startup-script",
+            source: EvidenceSource::ArgumentFile,
+            location: location.clone(),
+            weight: 90,
+            correlation_group: "startup-script",
+        });
+    }
+}
+
+fn detect_forge_bootstrap(
+    archive_path: &Path,
+    directory_launch: Option<(&Path, &Path)>,
+    archive: &ArchiveMetadata,
+    findings: &mut Findings,
+) {
+    let Some(content) = archive.bootstrap_properties.as_deref() else {
+        return;
+    };
+    let properties = java_properties::parse(content);
+    if properties.get("Main-Class").map(String::as_str)
+        != Some("net.minecraftforge.bootstrap.ForgeBootstrap")
+    {
+        return;
+    }
+    let location = archive_location(archive_path, BOOTSTRAP_PROPERTIES_ENTRY, Some("Main-Class"));
+    add_product(
+        "forge",
+        "forge-bootstrap-properties",
+        EvidenceSource::PropertiesField,
+        location.clone(),
+        95,
+        "forge-bootstrap-properties",
+        findings,
+    );
+    findings.roles.push(Signal {
+        value: ArtifactRole::Bootstrapper,
+        detector: "forge-bootstrap-properties",
+        source: EvidenceSource::PropertiesField,
+        location: location.clone(),
+        weight: 95,
+        correlation_group: "forge-bootstrap-properties",
+    });
+    findings.roles.push(Signal {
+        value: ArtifactRole::Launcher,
+        detector: "forge-bootstrap-properties",
+        source: EvidenceSource::PropertiesField,
+        location: location.clone(),
+        weight: 90,
+        correlation_group: "forge-bootstrap-properties",
+    });
+    if let Some(java_major) = properties
+        .get("Java-Version")
+        .and_then(|version| version.parse::<u16>().ok())
+    {
+        findings.java_majors.push(Signal {
+            value: java_major,
+            detector: "forge-bootstrap-properties",
+            source: EvidenceSource::PropertiesField,
+            location: archive_location(
+                archive_path,
+                BOOTSTRAP_PROPERTIES_ENTRY,
+                Some("Java-Version"),
+            ),
+            weight: 95,
+            correlation_group: "forge-bootstrap-properties",
+        });
+    }
+    if let Some((root, relative_jar)) = directory_launch {
+        findings.launches.push(Signal {
+            value: LaunchProfile {
+                id: "forge-bootstrap-jar".to_string(),
+                platform: LaunchPlatform::Any,
+                working_directory: Some(root.to_path_buf()),
+                target: LaunchTarget::Jar { path: root.join(relative_jar) },
+                jvm_arguments: Vec::new(),
+                program_arguments: Vec::new(),
+                required_java_major: properties
+                    .get("Java-Version")
+                    .and_then(|version| version.parse().ok()),
+            },
+            detector: "forge-bootstrap-properties",
+            source: EvidenceSource::PropertiesField,
+            location,
+            weight: 95,
+            correlation_group: "forge-bootstrap-properties",
+        });
+    }
+
+    if let Some(content) = archive.bootstrap_list.as_deref() {
+        for entry in paperclip_list::parse_libraries(content) {
+            let Some(coordinate) = entry.coordinate else {
+                continue;
+            };
+            if coordinate.group != "net.minecraftforge" || coordinate.artifact != "forge" {
+                continue;
+            }
+            if let Some((minecraft, forge)) = split_forge_coordinate(&coordinate.version) {
+                let coordinate_location = archive_location(
+                    archive_path,
+                    BOOTSTRAP_LIST_ENTRY,
+                    Some(&format!("line {}", entry.line)),
+                );
+                add_product_version(
+                    "forge",
+                    forge,
+                    "forge-bootstrap-list",
+                    EvidenceSource::MavenCoordinate,
+                    coordinate_location.clone(),
+                    95,
+                    "forge-bootstrap-list",
+                    findings,
+                );
+                add_minecraft_version(
+                    minecraft,
+                    "forge-bootstrap-list",
+                    EvidenceSource::MavenCoordinate,
+                    coordinate_location,
+                    95,
+                    "forge-bootstrap-list",
+                    findings,
+                );
+            }
+        }
+    }
+
+    if let Some(manifest_bytes) = archive.manifest.as_deref() {
+        let parsed = manifest::parse(manifest_bytes);
+        for section in &parsed.summary.sections {
+            let Some(version) = attribute(&section.attributes, "Implementation-Version") else {
+                continue;
+            };
+            if attribute(&section.attributes, "Implementation-Title") != Some("bs-shim") {
+                continue;
+            }
+            findings.components.push(ComponentFinding {
+                product_key: "forge".to_string(),
+                signal: Signal {
+                    value: ServerComponent {
+                        kind: ServerComponentKind::Bootstrap,
+                        key: "forge-bootstrap-shim".to_string(),
+                        name: "Forge Bootstrap Shim".to_string(),
+                        version: Some(version.to_string()),
+                        release_channel: None,
+                        coordinate: None,
+                        source_path: Some(PathBuf::from("server.jar")),
+                    },
+                    detector: "forge-bootstrap-manifest",
+                    source: EvidenceSource::ManifestSection,
+                    location: EvidenceLocation {
+                        path: archive_path.to_path_buf(),
+                        archive_entry: Some("META-INF/MANIFEST.MF".to_string()),
+                        manifest_section: section.name.clone(),
+                        field: Some("Implementation-Version".to_string()),
+                    },
+                    weight: 85,
+                    correlation_group: "forge-bootstrap-manifest",
+                },
+            });
+        }
+    }
+}
+
+fn detect_neoforge_wrapper(
+    archive_path: &Path,
+    directory_launch: Option<(&Path, &Path)>,
+    archive: &ArchiveMetadata,
+    findings: &mut Findings,
+) {
+    let Some(content) = archive.wrapper_metadata.as_deref() else {
+        return;
+    };
+    let Ok(Value::Object(metadata)) = serde_json::from_slice::<Value>(content) else {
+        return;
+    };
+    let Some(neoforge) = metadata.get("neoforge").and_then(Value::as_str) else {
+        return;
+    };
+    let location = archive_location(archive_path, WRAPPER_METADATA_ENTRY, Some("neoforge"));
+    add_product(
+        "neoforge",
+        "neoforge-wrapper-metadata",
+        EvidenceSource::JsonField,
+        location.clone(),
+        85,
+        "neoforge-wrapper-metadata",
+        findings,
+    );
+    add_product_version(
+        "neoforge",
+        neoforge,
+        "neoforge-wrapper-metadata",
+        EvidenceSource::JsonField,
+        location.clone(),
+        85,
+        "neoforge-wrapper-metadata",
+        findings,
+    );
+    if let Some(channel) = release_channel(neoforge) {
+        add_release_channel(
+            "neoforge",
+            channel,
+            "neoforge-wrapper-metadata",
+            EvidenceSource::JsonField,
+            location.clone(),
+            85,
+            "neoforge-wrapper-metadata",
+            findings,
+        );
+    }
+    if let Some(minecraft) = metadata.get("version").and_then(Value::as_str) {
+        add_minecraft_version(
+            minecraft,
+            "neoforge-wrapper-metadata",
+            EvidenceSource::JsonField,
+            archive_location(archive_path, WRAPPER_METADATA_ENTRY, Some("version")),
+            85,
+            "neoforge-wrapper-metadata",
+            findings,
+        );
+    }
+    findings.roles.push(Signal {
+        value: ArtifactRole::Wrapper,
+        detector: "neoforge-wrapper-metadata",
+        source: EvidenceSource::JsonField,
+        location: location.clone(),
+        weight: 90,
+        correlation_group: "neoforge-wrapper-metadata",
+    });
+    findings.roles.push(Signal {
+        value: ArtifactRole::Launcher,
+        detector: "neoforge-wrapper-metadata",
+        source: EvidenceSource::JsonField,
+        location: location.clone(),
+        weight: 85,
+        correlation_group: "neoforge-wrapper-metadata",
+    });
+    if let Some((root, relative_jar)) = directory_launch {
+        findings.launches.push(Signal {
+            value: LaunchProfile {
+                id: "neoforge-wrapper-jar".to_string(),
+                platform: LaunchPlatform::Any,
+                working_directory: Some(root.to_path_buf()),
+                target: LaunchTarget::Jar { path: root.join(relative_jar) },
+                jvm_arguments: Vec::new(),
+                program_arguments: Vec::new(),
+                required_java_major: None,
+            },
+            detector: "neoforge-wrapper-metadata",
+            source: EvidenceSource::JsonField,
+            location,
+            weight: 85,
+            correlation_group: "neoforge-wrapper-metadata",
+        });
+    }
+}
+
+fn detect_forge_version_json(
+    root: &Path,
+    nested_path: &Path,
+    metadata: &ArchiveMetadata,
+    findings: &mut Findings,
+) {
+    let Some(content) = metadata.forge_version.as_deref() else {
+        return;
+    };
+    let Ok(Value::Object(version)) = serde_json::from_slice::<Value>(content) else {
+        return;
+    };
+    let archive_path = root.join(nested_path);
+    if let Some(forge) = version.get("forge").and_then(Value::as_str) {
+        add_product(
+            "forge",
+            "forge-version-json",
+            EvidenceSource::JsonField,
+            archive_location(&archive_path, FORGE_VERSION_ENTRY, Some("forge")),
+            98,
+            "forge-version-json",
+            findings,
+        );
+        add_product_version(
+            "forge",
+            forge,
+            "forge-version-json",
+            EvidenceSource::JsonField,
+            archive_location(&archive_path, FORGE_VERSION_ENTRY, Some("forge")),
+            98,
+            "forge-version-json",
+            findings,
+        );
+    }
+    if let Some(minecraft) = version.get("mc").and_then(Value::as_str) {
+        add_minecraft_version(
+            minecraft,
+            "forge-version-json",
+            EvidenceSource::JsonField,
+            archive_location(&archive_path, FORGE_VERSION_ENTRY, Some("mc")),
+            98,
+            "forge-version-json",
+            findings,
+        );
+    }
+    if let Some(mapping) = version.get("mcp").and_then(Value::as_str) {
+        findings.components.push(ComponentFinding {
+            product_key: "forge".to_string(),
+            signal: Signal {
+                value: ServerComponent {
+                    kind: ServerComponentKind::Mapping,
+                    key: "mcp".to_string(),
+                    name: "MCP Mappings".to_string(),
+                    version: Some(mapping.to_string()),
+                    release_channel: None,
+                    coordinate: None,
+                    source_path: Some(nested_path.to_path_buf()),
+                },
+                detector: "forge-version-json",
+                source: EvidenceSource::JsonField,
+                location: archive_location(&archive_path, FORGE_VERSION_ENTRY, Some("mcp")),
+                weight: 95,
+                correlation_group: "forge-version-json",
+            },
+        });
+    }
+}
+
+fn detect_neoforge_properties(
+    root: &Path,
+    nested_path: &Path,
+    metadata: &ArchiveMetadata,
+    findings: &mut Findings,
+) {
+    let Some(content) = metadata.neoforge_version_properties.as_deref() else {
+        return;
+    };
+    let properties = java_properties::parse(content);
+    let archive_path = root.join(nested_path);
+    if let Some(neoforge) = properties.get("neoforge_version") {
+        add_product(
+            "neoforge",
+            "neoforge-version-properties",
+            EvidenceSource::PropertiesField,
+            archive_location(
+                &archive_path,
+                NEOFORGE_VERSION_PROPERTIES_ENTRY,
+                Some("neoforge_version"),
+            ),
+            98,
+            "neoforge-version-properties",
+            findings,
+        );
+        add_product_version(
+            "neoforge",
+            neoforge,
+            "neoforge-version-properties",
+            EvidenceSource::PropertiesField,
+            archive_location(
+                &archive_path,
+                NEOFORGE_VERSION_PROPERTIES_ENTRY,
+                Some("neoforge_version"),
+            ),
+            98,
+            "neoforge-version-properties",
+            findings,
+        );
+    }
+    if let Some(minecraft) = properties.get("minecraft_version") {
+        add_minecraft_version(
+            minecraft,
+            "neoforge-version-properties",
+            EvidenceSource::PropertiesField,
+            archive_location(
+                &archive_path,
+                NEOFORGE_VERSION_PROPERTIES_ENTRY,
+                Some("minecraft_version"),
+            ),
+            98,
+            "neoforge-version-properties",
+            findings,
+        );
+    }
+    if let Some(channel) = properties
+        .get("build_type")
+        .and_then(|build_type| release_channel(build_type))
+    {
+        add_release_channel(
+            "neoforge",
+            channel,
+            "neoforge-version-properties",
+            EvidenceSource::PropertiesField,
+            archive_location(&archive_path, NEOFORGE_VERSION_PROPERTIES_ENTRY, Some("build_type")),
+            95,
+            "neoforge-version-properties",
+            findings,
+        );
+    }
+    if let Some(mapping) = properties.get("neoform_version") {
+        findings.components.push(ComponentFinding {
+            product_key: "neoforge".to_string(),
+            signal: Signal {
+                value: ServerComponent {
+                    kind: ServerComponentKind::Mapping,
+                    key: "neoform".to_string(),
+                    name: "NeoForm".to_string(),
+                    version: Some(mapping.clone()),
+                    release_channel: None,
+                    coordinate: None,
+                    source_path: Some(nested_path.to_path_buf()),
+                },
+                detector: "neoforge-version-properties",
+                source: EvidenceSource::PropertiesField,
+                location: archive_location(
+                    &archive_path,
+                    NEOFORGE_VERSION_PROPERTIES_ENTRY,
+                    Some("neoform_version"),
+                ),
+                weight: 95,
+                correlation_group: "neoforge-version-properties",
+            },
+        });
+    }
+}
+
+fn detect_argument_file(
+    root: &Path,
+    product_key: &'static str,
+    coordinate_version: &str,
+    platform: LaunchPlatform,
+    arguments: &MetadataFile,
+    findings: &mut Findings,
+) {
+    let parsed = jvm_args::parse(&arguments.content);
+    if parsed.arguments.is_empty() {
+        return;
+    }
+    let location = EvidenceLocation {
+        path: root.join(&arguments.relative_path),
+        archive_entry: None,
+        manifest_section: None,
+        field: None,
+    };
+    let version_flag = if product_key == "forge" {
+        "--fml.forgeVersion"
+    } else {
+        "--fml.neoForgeVersion"
+    };
+    if let Some(version) = parsed.value_after(version_flag) {
+        add_product_version(
+            product_key,
+            version,
+            "modloader-argument-file",
+            EvidenceSource::ArgumentFile,
+            EvidenceLocation {
+                field: Some(version_flag.to_string()),
+                ..location.clone()
+            },
+            98,
+            "modloader-argument-file",
+            findings,
+        );
+        if let Some(channel) = release_channel(version) {
+            add_release_channel(
+                product_key,
+                channel,
+                "modloader-argument-file",
+                EvidenceSource::ArgumentFile,
+                EvidenceLocation {
+                    field: Some(version_flag.to_string()),
+                    ..location.clone()
+                },
+                95,
+                "modloader-argument-file",
+                findings,
+            );
+        }
+    }
+    if let Some(minecraft) = parsed.value_after("--fml.mcVersion") {
+        add_minecraft_version(
+            minecraft,
+            "modloader-argument-file",
+            EvidenceSource::ArgumentFile,
+            EvidenceLocation {
+                field: Some("--fml.mcVersion".to_string()),
+                ..location.clone()
+            },
+            98,
+            "modloader-argument-file",
+            findings,
+        );
+    }
+    if parsed.value_after(version_flag).is_some() || parsed.jar_target().is_some() {
+        add_product(
+            product_key,
+            "modloader-argument-file",
+            EvidenceSource::ArgumentFile,
+            location.clone(),
+            95,
+            "modloader-argument-file",
+            findings,
+        );
+    }
+    findings.launches.push(Signal {
+        value: LaunchProfile {
+            id: format!(
+                "{product_key}-{coordinate_version}-{}-args",
+                match platform {
+                    LaunchPlatform::Windows => "windows",
+                    LaunchPlatform::Unix => "unix",
+                    LaunchPlatform::Any => "any",
+                }
+            ),
+            platform,
+            working_directory: Some(root.to_path_buf()),
+            target: LaunchTarget::ArgumentFiles {
+                paths: vec![root.join(&arguments.relative_path)],
+            },
+            jvm_arguments: Vec::new(),
+            program_arguments: Vec::new(),
+            required_java_major: None,
+        },
+        detector: "modloader-argument-file",
+        source: EvidenceSource::ArgumentFile,
+        location,
+        weight: 98,
+        correlation_group: "modloader-argument-file",
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_product(
+    key: &str,
+    detector: &'static str,
+    source: EvidenceSource,
+    location: EvidenceLocation,
+    weight: u8,
+    correlation_group: &'static str,
+    findings: &mut Findings,
+) {
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key(key),
+            detector,
+            source,
+            location,
+            weight,
+            correlation_group,
+        },
+        ecosystems: ecosystems_for_key(key, false),
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_product_version(
+    product_key: &str,
+    version: &str,
+    detector: &'static str,
+    source: EvidenceSource,
+    location: EvidenceLocation,
+    weight: u8,
+    correlation_group: &'static str,
+    findings: &mut Findings,
+) {
+    findings.product_versions.push(ProductValueFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: version.to_string(),
+            detector,
+            source,
+            location,
+            weight,
+            correlation_group,
+        },
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_minecraft_version(
+    version: &str,
+    detector: &'static str,
+    source: EvidenceSource,
+    location: EvidenceLocation,
+    weight: u8,
+    correlation_group: &'static str,
+    findings: &mut Findings,
+) {
+    findings.minecraft_versions.push(Signal {
+        value: version.to_string(),
+        detector,
+        source,
+        location,
+        weight,
+        correlation_group,
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_release_channel(
+    product_key: &str,
+    channel: ReleaseChannel,
+    detector: &'static str,
+    source: EvidenceSource,
+    location: EvidenceLocation,
+    weight: u8,
+    correlation_group: &'static str,
+    findings: &mut Findings,
+) {
+    findings.release_channels.push(ProductValueFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: channel,
+            detector,
+            source,
+            location,
+            weight,
+            correlation_group,
+        },
+    });
+}
+
+fn split_forge_coordinate(version: &str) -> Option<(&str, &str)> {
+    version.match_indices('-').find_map(|(separator, _)| {
+        let minecraft = &version[..separator];
+        let forge = &version[separator + 1..];
+        let numeric_prefix = forge.split_once('-').map_or(forge, |(prefix, _)| prefix);
+        (!minecraft.is_empty()
+            && numeric_prefix
+                .bytes()
+                .next()
+                .is_some_and(|byte| byte.is_ascii_digit())
+            && numeric_prefix.matches('.').count() >= 2)
+            .then_some((minecraft, forge))
+    })
+}
+
+fn launch_id_part(path: &Path) -> String {
+    path.to_string_lossy()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn archive_location(path: &Path, entry: &str, field: Option<&str>) -> EvidenceLocation {
+    EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some(entry.to_string()),
+        manifest_section: None,
+        field: field.map(str::to_string),
+    }
+}
+
+fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+}
+
+fn platform_for_script(kind: StartupScriptKind) -> LaunchPlatform {
+    match kind {
+        StartupScriptKind::Batch | StartupScriptKind::PowerShell => LaunchPlatform::Windows,
+        StartupScriptKind::Shell => LaunchPlatform::Unix,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_forge_coordinate;
+
+    #[test]
+    fn splits_forge_coordinate_at_the_final_separator() {
+        assert_eq!(split_forge_coordinate("1.20.1-47.2.0"), Some(("1.20.1", "47.2.0")));
+        assert_eq!(split_forge_coordinate("26.2-65.1.0"), Some(("26.2", "65.1.0")));
+        assert_eq!(
+            split_forge_coordinate("1.20.2-pre1-48.0.0-beta"),
+            Some(("1.20.2-pre1", "48.0.0-beta"))
+        );
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -1,88 +1,115 @@
+mod fabric;
+mod forge;
 mod paperclip;
 mod vanilla;
 
 use std::path::{Path, PathBuf};
 
 use super::archive::ArchiveMetadata;
+use super::directory::DirectoryMetadata;
 use super::evidence::{EvidenceCollector, NewEvidence};
 use super::model::{
     ArtifactInfo, ArtifactRole, Attributed, Detected, DetectionTarget, DiagnosticSeverity,
-    EvidenceLocation, EvidenceSource, InspectionDiagnostic, MavenCoordinate, MinecraftVersionInfo,
-    ReleaseChannel, ServerCategory, ServerComponent, ServerEcosystem, ServerIdentityInfo,
-    ServerProduct,
+    EvidenceLocation, EvidenceSource, InspectionDiagnostic, LaunchProfile, MavenCoordinate,
+    MinecraftVersionInfo, ReleaseChannel, ServerCategory, ServerComponent, ServerComponentKind,
+    ServerEcosystem, ServerIdentityInfo, ServerProduct,
 };
 use super::resolver::{resolve, resolve_attributed, DetectionClaim};
 
+const PAPER_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Paper, ServerEcosystem::Bukkit];
+const VANILLA_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Vanilla];
+const BUKKIT_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Bukkit];
+const FABRIC_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Fabric];
+const LEGACY_FABRIC_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::LegacyFabric];
+const FORGE_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Forge];
+const NEOFORGE_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::NeoForge];
+
 const PRODUCTS: &[ProductDefinition] = &[
-    ProductDefinition::paper(
+    ProductDefinition::new(
         "pufferfish",
         "Pufferfish",
+        PAPER_ECOSYSTEMS,
         "gg.pufferfish.pufferfish",
         "pufferfish-api",
     ),
-    ProductDefinition::paper("divinemc", "DivineMC", "org.bxteam.divinemc", "divinemc-api"),
-    ProductDefinition::paper("aspaper", "AsPaper", "com.infernalsuite.asp", "aspaper-api"),
-    ProductDefinition::paper("purpur", "Purpur", "org.purpurmc.purpur", "purpur-api"),
-    ProductDefinition::paper("canvas", "Canvas", "io.canvasmc.canvas", "canvas-api"),
-    ProductDefinition::paper("leaves", "Leaves", "org.leavesmc.leaves", "leaves-api"),
-    ProductDefinition::vanilla(),
-    ProductDefinition::bukkit("spigot", "Spigot"),
-    ProductDefinition::paper("paper", "Paper", "io.papermc.paper", "paper-api"),
-    ProductDefinition::paper("folia", "Folia", "dev.folia", "folia-api"),
-    ProductDefinition::paper("pluto", "Pluto", "dev.yive.pluto", "pluto-api"),
-    ProductDefinition::paper("leaf", "Leaf", "cn.dreeam.leaf", "leaf-api"),
+    ProductDefinition::new("legacy-fabric", "Legacy Fabric", LEGACY_FABRIC_ECOSYSTEMS, "", ""),
+    ProductDefinition::new(
+        "divinemc",
+        "DivineMC",
+        PAPER_ECOSYSTEMS,
+        "org.bxteam.divinemc",
+        "divinemc-api",
+    ),
+    ProductDefinition::new(
+        "aspaper",
+        "AsPaper",
+        PAPER_ECOSYSTEMS,
+        "com.infernalsuite.asp",
+        "aspaper-api",
+    ),
+    ProductDefinition::new(
+        "purpur",
+        "Purpur",
+        PAPER_ECOSYSTEMS,
+        "org.purpurmc.purpur",
+        "purpur-api",
+    ),
+    ProductDefinition::new(
+        "canvas",
+        "Canvas",
+        PAPER_ECOSYSTEMS,
+        "io.canvasmc.canvas",
+        "canvas-api",
+    ),
+    ProductDefinition::new(
+        "leaves",
+        "Leaves",
+        PAPER_ECOSYSTEMS,
+        "org.leavesmc.leaves",
+        "leaves-api",
+    ),
+    ProductDefinition::new("vanilla", "Vanilla", VANILLA_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("neoforge", "NeoForge", NEOFORGE_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("fabric", "Fabric", FABRIC_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("spigot", "Spigot", BUKKIT_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("paper", "Paper", PAPER_ECOSYSTEMS, "io.papermc.paper", "paper-api"),
+    ProductDefinition::new("folia", "Folia", PAPER_ECOSYSTEMS, "dev.folia", "folia-api"),
+    ProductDefinition::new("pluto", "Pluto", PAPER_ECOSYSTEMS, "dev.yive.pluto", "pluto-api"),
+    ProductDefinition::new("forge", "Forge", FORGE_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("leaf", "Leaf", PAPER_ECOSYSTEMS, "cn.dreeam.leaf", "leaf-api"),
 ];
 
 #[derive(Debug, Clone, Copy)]
 struct ProductDefinition {
     key: &'static str,
     display_name: &'static str,
-    paper: bool,
-    bukkit: bool,
-    vanilla: bool,
+    ecosystems: &'static [ServerEcosystem],
     api_group: Option<&'static str>,
     api_artifact: Option<&'static str>,
 }
 
 impl ProductDefinition {
-    const fn paper(
+    const fn new(
         key: &'static str,
         display_name: &'static str,
+        ecosystems: &'static [ServerEcosystem],
         api_group: &'static str,
         api_artifact: &'static str,
     ) -> Self {
         Self {
             key,
             display_name,
-            paper: true,
-            bukkit: true,
-            vanilla: false,
-            api_group: Some(api_group),
-            api_artifact: Some(api_artifact),
-        }
-    }
-
-    const fn bukkit(key: &'static str, display_name: &'static str) -> Self {
-        Self {
-            key,
-            display_name,
-            paper: false,
-            bukkit: true,
-            vanilla: false,
-            api_group: None,
-            api_artifact: None,
-        }
-    }
-
-    const fn vanilla() -> Self {
-        Self {
-            key: "vanilla",
-            display_name: "Vanilla",
-            paper: false,
-            bukkit: false,
-            vanilla: true,
-            api_group: None,
-            api_artifact: None,
+            ecosystems,
+            api_group: if api_group.is_empty() {
+                None
+            } else {
+                Some(api_group)
+            },
+            api_artifact: if api_artifact.is_empty() {
+                None
+            } else {
+                Some(api_artifact)
+            },
         }
     }
 }
@@ -124,6 +151,8 @@ pub(super) struct Findings {
     pub(super) release_channels: Vec<ProductValueFinding<ReleaseChannel>>,
     pub(super) roles: Vec<Signal<ArtifactRole>>,
     pub(super) components: Vec<ComponentFinding>,
+    pub(super) launches: Vec<Signal<LaunchProfile>>,
+    pub(super) java_majors: Vec<Signal<u16>>,
 }
 
 impl Findings {
@@ -139,6 +168,8 @@ pub(super) struct DetectorOutput {
     pub(super) minecraft_version: Detected<String>,
     pub(super) roles: Vec<Attributed<ArtifactRole>>,
     pub(super) components: Vec<Attributed<ServerComponent>>,
+    pub(super) launches: Vec<Attributed<LaunchProfile>>,
+    pub(super) java_major: Detected<u16>,
     pub(super) diagnostics: Vec<InspectionDiagnostic>,
 }
 
@@ -147,19 +178,54 @@ pub(super) fn detect_jar(
     artifact: &ArtifactInfo,
     archive: &ArchiveMetadata,
     minecraft: Option<&MinecraftVersionInfo>,
+    java_major: Option<&Detected<u16>>,
     evidence: &mut EvidenceCollector,
 ) -> DetectorOutput {
     let mut findings = Findings::default();
     detect_filename(path, &mut findings);
+    fabric::detect(path, archive, None, &mut findings);
+    forge::detect_archive(path, None, archive, &mut findings);
     paperclip::detect(path, artifact, archive, &mut findings);
     vanilla::detect(path, artifact, minecraft, &mut findings);
-    finalize(path, findings, minecraft, evidence)
+    finalize(path, findings, minecraft, java_major, evidence)
+}
+
+pub(super) fn detect_directory(
+    path: &Path,
+    directory: &DirectoryMetadata,
+    evidence: &mut EvidenceCollector,
+) -> DetectorOutput {
+    let mut findings = Findings::default();
+    detect_filename(path, &mut findings);
+    for root_archive in &directory.root_archives {
+        let archive_path = path.join(&root_archive.relative_path);
+        fabric::detect(
+            &archive_path,
+            &root_archive.metadata,
+            Some((path, &root_archive.relative_path)),
+            &mut findings,
+        );
+        forge::detect_archive(
+            &archive_path,
+            Some((path, &root_archive.relative_path)),
+            &root_archive.metadata,
+            &mut findings,
+        );
+    }
+    for installation in &directory.installations {
+        forge::detect_installation(path, installation, &mut findings);
+    }
+    for script in &directory.scripts {
+        forge::detect_script(path, script, &mut findings);
+    }
+    finalize(path, findings, None, None, evidence)
 }
 
 fn finalize(
     path: &Path,
     findings: Findings,
     minecraft: Option<&MinecraftVersionInfo>,
+    existing_java_major: Option<&Detected<u16>>,
     evidence: &mut EvidenceCollector,
 ) -> DetectorOutput {
     let implementation = resolve(
@@ -254,23 +320,20 @@ fn finalize(
         resolve_attributed(claims)
     });
 
-    let components = selected_key.map_or_else(Vec::new, |selected_key| {
-        resolve_attributed(
-            findings
-                .components
-                .iter()
-                .filter(|finding| finding.product_key == selected_key)
-                .map(|finding| {
-                    push_claim(
-                        &finding.signal,
-                        DetectionTarget::Component,
-                        finding.signal.value.key.clone(),
-                        evidence,
-                    )
-                })
-                .collect(),
-        )
-    });
+    let components = resolve_attributed(
+        findings
+            .components
+            .iter()
+            .map(|finding| {
+                push_claim(
+                    &finding.signal,
+                    DetectionTarget::Component,
+                    format!("{}:{}", finding.product_key, finding.signal.value.key),
+                    evidence,
+                )
+            })
+            .collect(),
+    );
     let roles = resolve_attributed(
         findings
             .roles
@@ -286,6 +349,31 @@ fn finalize(
             .collect(),
     );
     let minecraft_version = resolve_minecraft_version(&findings, minecraft, evidence);
+    let launches = resolve_attributed(
+        findings
+            .launches
+            .iter()
+            .map(|signal| {
+                push_claim(
+                    signal,
+                    DetectionTarget::LaunchProfile,
+                    signal.value.id.clone(),
+                    evidence,
+                )
+            })
+            .collect(),
+    );
+    let mut java_claims = findings
+        .java_majors
+        .iter()
+        .map(|signal| {
+            push_claim(signal, DetectionTarget::JavaMajor, signal.value.to_string(), evidence)
+        })
+        .collect::<Vec<_>>();
+    if let Some(existing) = existing_java_major {
+        java_claims.extend(existing_detected_claims(existing, "existing-java-requirement"));
+    }
+    let java_major = resolve(java_claims);
 
     let mut diagnostics = Vec::new();
     add_conflict_diagnostic(
@@ -321,6 +409,8 @@ fn finalize(
         minecraft_version,
         roles,
         components,
+        launches,
+        java_major,
         diagnostics,
     }
 }
@@ -492,17 +582,7 @@ pub(super) fn ecosystems_for_key(key: &str, paperclip_context: bool) -> Vec<Serv
             Vec::new()
         };
     };
-    let mut ecosystems = Vec::new();
-    if definition.vanilla {
-        ecosystems.push(ServerEcosystem::Vanilla);
-    }
-    if definition.paper {
-        ecosystems.push(ServerEcosystem::Paper);
-    }
-    if definition.bukkit {
-        ecosystems.push(ServerEcosystem::Bukkit);
-    }
-    ecosystems
+    definition.ecosystems.to_vec()
 }
 
 pub(super) fn product_key_from_coordinate(coordinate: &MavenCoordinate) -> Option<String> {
@@ -673,7 +753,7 @@ pub(super) fn api_component(
     let product = product_from_key(product_key);
     let release_channel = release_channel(&version);
     ServerComponent {
-        kind: super::model::ServerComponentKind::Api,
+        kind: ServerComponentKind::Api,
         key: format!("{product_key}-api"),
         name: format!("{} API", product.display_name),
         version: Some(version),

--- a/crates/core/src/provisioning/server_inspection/directory.rs
+++ b/crates/core/src/provisioning/server_inspection/directory.rs
@@ -1,0 +1,355 @@
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use super::archive::{self, ArchiveMetadata};
+use super::error::ServerInspectionError;
+use super::model::{DiagnosticSeverity, InspectionDiagnostic};
+use super::InspectionOptions;
+use crate::provisioning::StartupScriptKind;
+
+const ROOT_SCRIPT_NAMES: &[&str] =
+    &["run.bat", "run.sh", "run.ps1", "start.bat", "start.sh", "start.ps1"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ModLoaderFamily {
+    Forge,
+    NeoForge,
+}
+
+pub(super) struct MetadataFile {
+    pub(super) relative_path: PathBuf,
+    pub(super) content: Vec<u8>,
+}
+
+pub(super) struct RootArchive {
+    pub(super) relative_path: PathBuf,
+    pub(super) metadata: ArchiveMetadata,
+}
+
+pub(super) struct ModLoaderInstallation {
+    pub(super) family: ModLoaderFamily,
+    pub(super) coordinate_version: String,
+    pub(super) relative_directory: PathBuf,
+    pub(super) windows_args: Option<MetadataFile>,
+    pub(super) unix_args: Option<MetadataFile>,
+    pub(super) nested_archive_path: Option<PathBuf>,
+    pub(super) nested_metadata: Option<ArchiveMetadata>,
+}
+
+pub(super) struct StartupScript {
+    pub(super) relative_path: PathBuf,
+    pub(super) kind: StartupScriptKind,
+    pub(super) content: String,
+}
+
+pub(super) struct DirectoryMetadata {
+    pub(super) root_archives: Vec<RootArchive>,
+    pub(super) installations: Vec<ModLoaderInstallation>,
+    pub(super) scripts: Vec<StartupScript>,
+    pub(super) diagnostics: Vec<InspectionDiagnostic>,
+}
+
+pub(super) fn read_metadata(
+    path: &Path,
+    options: &InspectionOptions,
+) -> Result<DirectoryMetadata, ServerInspectionError> {
+    let mut consumed = 0_u64;
+    let mut diagnostics = Vec::new();
+    let root_entries = sorted_entries(path, options)?;
+    let mut root_archives = Vec::new();
+    for entry in &root_entries {
+        let file_type = entry
+            .file_type()
+            .map_err(|source| ServerInspectionError::Metadata { path: entry.path(), source })?;
+        if !file_type.is_file() || !is_relevant_root_jar(&entry.file_name().to_string_lossy()) {
+            continue;
+        }
+        let relative_path = PathBuf::from(entry.file_name());
+        if options.max_archive_depth == 0
+            || !nested_archive_allowed(&entry.path(), options, &mut diagnostics)?
+        {
+            continue;
+        }
+        let mut metadata =
+            archive::read_metadata_with_budget(&entry.path(), options, &mut consumed)?;
+        diagnostics.append(&mut metadata.diagnostics);
+        root_archives.push(RootArchive { relative_path, metadata });
+    }
+
+    let mut scripts = Vec::new();
+    for name in ROOT_SCRIPT_NAMES {
+        let relative_path = PathBuf::from(name);
+        let Some(content) =
+            read_optional_file(path, &relative_path, options, &mut consumed, &mut diagnostics)?
+        else {
+            continue;
+        };
+        let Some(kind) = StartupScriptKind::from_path(&relative_path) else {
+            continue;
+        };
+        scripts.push(StartupScript {
+            relative_path,
+            kind,
+            content: String::from_utf8_lossy(&content).into_owned(),
+        });
+    }
+
+    let mut installations = Vec::new();
+    scan_installations(
+        path,
+        ModLoaderFamily::Forge,
+        Path::new("libraries/net/minecraftforge/forge"),
+        options,
+        &mut consumed,
+        &mut diagnostics,
+        &mut installations,
+    )?;
+    scan_installations(
+        path,
+        ModLoaderFamily::NeoForge,
+        Path::new("libraries/net/neoforged/neoforge"),
+        options,
+        &mut consumed,
+        &mut diagnostics,
+        &mut installations,
+    )?;
+
+    Ok(DirectoryMetadata {
+        root_archives,
+        installations,
+        scripts,
+        diagnostics,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scan_installations(
+    root: &Path,
+    family: ModLoaderFamily,
+    relative_base: &Path,
+    options: &InspectionOptions,
+    consumed: &mut u64,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+    installations: &mut Vec<ModLoaderInstallation>,
+) -> Result<(), ServerInspectionError> {
+    let base = root.join(relative_base);
+    let entries = match sorted_entries(&base, options) {
+        Ok(entries) => entries,
+        Err(ServerInspectionError::Open { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
+
+    for entry in entries {
+        if !entry
+            .file_type()
+            .map_err(|source| ServerInspectionError::Metadata { path: entry.path(), source })?
+            .is_dir()
+        {
+            continue;
+        }
+        let coordinate_version = entry.file_name().to_string_lossy().into_owned();
+        if coordinate_version.is_empty() {
+            continue;
+        }
+        let relative_directory = relative_base.join(&coordinate_version);
+        let windows_args = read_metadata_file(
+            root,
+            &relative_directory.join("win_args.txt"),
+            options,
+            consumed,
+            diagnostics,
+        )?;
+        let unix_args = read_metadata_file(
+            root,
+            &relative_directory.join("unix_args.txt"),
+            options,
+            consumed,
+            diagnostics,
+        )?;
+
+        let nested_relative = match family {
+            ModLoaderFamily::Forge => PathBuf::from(format!(
+                "libraries/net/minecraftforge/fmlloader/{0}/fmlloader-{0}.jar",
+                coordinate_version
+            )),
+            ModLoaderFamily::NeoForge => {
+                relative_directory.join(format!("neoforge-{coordinate_version}-universal.jar"))
+            }
+        };
+        let nested_path = root.join(&nested_relative);
+        let nested_metadata = if options.max_archive_depth == 0
+            || !nested_archive_allowed(&nested_path, options, diagnostics)?
+        {
+            None
+        } else {
+            match archive::read_metadata_with_budget(&nested_path, options, consumed) {
+                Ok(mut metadata) => {
+                    diagnostics.append(&mut metadata.diagnostics);
+                    Some(metadata)
+                }
+                Err(ServerInspectionError::Open { source, .. })
+                    if source.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    None
+                }
+                Err(error) => return Err(error),
+            }
+        };
+
+        if windows_args.is_some() || unix_args.is_some() || nested_metadata.is_some() {
+            let nested_archive_path = nested_metadata.is_some().then_some(nested_relative);
+            installations.push(ModLoaderInstallation {
+                family,
+                coordinate_version,
+                relative_directory,
+                windows_args,
+                unix_args,
+                nested_archive_path,
+                nested_metadata,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn sorted_entries(
+    path: &Path,
+    options: &InspectionOptions,
+) -> Result<Vec<fs::DirEntry>, ServerInspectionError> {
+    let mut entries = fs::read_dir(path)
+        .map_err(|source| ServerInspectionError::Open { path: path.to_path_buf(), source })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| ServerInspectionError::Open { path: path.to_path_buf(), source })?;
+    if entries.len() > options.max_archive_entries {
+        return Err(ServerInspectionError::TooManyDirectoryEntries {
+            path: path.to_path_buf(),
+            count: entries.len(),
+            limit: options.max_archive_entries,
+        });
+    }
+    entries.sort_by_key(fs::DirEntry::file_name);
+    Ok(entries)
+}
+
+fn read_metadata_file(
+    root: &Path,
+    relative_path: &Path,
+    options: &InspectionOptions,
+    consumed: &mut u64,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Result<Option<MetadataFile>, ServerInspectionError> {
+    read_optional_file(root, relative_path, options, consumed, diagnostics).map(|content| {
+        content.map(|content| MetadataFile {
+            relative_path: relative_path.to_path_buf(),
+            content,
+        })
+    })
+}
+
+fn read_optional_file(
+    root: &Path,
+    relative_path: &Path,
+    options: &InspectionOptions,
+    consumed: &mut u64,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Result<Option<Vec<u8>>, ServerInspectionError> {
+    let path = root.join(relative_path);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.is_file() => metadata,
+        Ok(_) => return Ok(None),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(ServerInspectionError::Metadata { path, source }),
+    };
+    if metadata.len() > options.max_metadata_entry_bytes {
+        diagnostics.push(limit_diagnostic(
+            "metadata_entry_too_large",
+            format!(
+                "metadata file {} is {} bytes; the inspection limit is {} bytes",
+                path.display(),
+                metadata.len(),
+                options.max_metadata_entry_bytes
+            ),
+        ));
+        return Ok(None);
+    }
+    let remaining = options.max_total_metadata_bytes.saturating_sub(*consumed);
+    if metadata.len() > remaining {
+        diagnostics.push(limit_diagnostic(
+            "metadata_budget_exceeded",
+            format!(
+                "reading metadata file {} would exceed the remaining inspection budget of {remaining} bytes",
+                path.display()
+            ),
+        ));
+        return Ok(None);
+    }
+
+    let mut file = File::open(&path)
+        .map_err(|source| ServerInspectionError::Open { path: path.clone(), source })?;
+    let mut content = Vec::new();
+    file.by_ref()
+        .take(
+            options
+                .max_metadata_entry_bytes
+                .min(remaining)
+                .saturating_add(1),
+        )
+        .read_to_end(&mut content)
+        .map_err(|source| ServerInspectionError::MetadataRead { path: path.clone(), source })?;
+    if content.len() as u64 > options.max_metadata_entry_bytes || content.len() as u64 > remaining {
+        diagnostics.push(limit_diagnostic(
+            "metadata_budget_exceeded",
+            format!("metadata file {} expanded beyond its inspection budget", path.display()),
+        ));
+        return Ok(None);
+    }
+    *consumed = consumed.saturating_add(content.len() as u64);
+    Ok(Some(content))
+}
+
+fn nested_archive_allowed(
+    path: &Path,
+    options: &InspectionOptions,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Result<bool, ServerInspectionError> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => metadata,
+        Ok(_) => return Ok(false),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(source) => {
+            return Err(ServerInspectionError::Metadata { path: path.to_path_buf(), source });
+        }
+    };
+    if metadata.len() <= options.max_nested_archive_bytes {
+        return Ok(true);
+    }
+    diagnostics.push(limit_diagnostic(
+        "nested_archive_too_large",
+        format!(
+            "nested archive {} is {} bytes; the inspection limit is {} bytes",
+            path.display(),
+            metadata.len(),
+            options.max_nested_archive_bytes
+        ),
+    ));
+    Ok(false)
+}
+
+fn is_relevant_root_jar(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    name == "server.jar" || (name.ends_with(".jar") && name.contains("fabric"))
+}
+
+fn limit_diagnostic(code: &str, message: String) -> InspectionDiagnostic {
+    InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: code.to_string(),
+        message,
+        evidence: Vec::new(),
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/error.rs
+++ b/crates/core/src/provisioning/server_inspection/error.rs
@@ -34,7 +34,16 @@ pub enum ServerInspectionError {
         entry: String,
         source: io::Error,
     },
+    MetadataRead {
+        path: PathBuf,
+        source: io::Error,
+    },
     TooManyArchiveEntries {
+        path: PathBuf,
+        count: usize,
+        limit: usize,
+    },
+    TooManyDirectoryEntries {
         path: PathBuf,
         count: usize,
         limit: usize,
@@ -75,9 +84,17 @@ impl fmt::Display for ServerInspectionError {
                 "could not read metadata entry {entry} in {}: {source}",
                 path.display()
             ),
+            Self::MetadataRead { path, source } => {
+                write!(formatter, "could not read metadata file {}: {source}", path.display())
+            }
             Self::TooManyArchiveEntries { path, count, limit } => write!(
                 formatter,
                 "JAR archive {} contains {count} entries, exceeding the inspection limit of {limit}",
+                path.display()
+            ),
+            Self::TooManyDirectoryEntries { path, count, limit } => write!(
+                formatter,
+                "directory {} contains {count} immediate entries, exceeding the inspection limit of {limit}",
                 path.display()
             ),
             Self::FingerprintRead { path, source } => write!(
@@ -94,10 +111,12 @@ impl std::error::Error for ServerInspectionError {
         match self {
             Self::InvalidOptions { .. }
             | Self::UnsupportedSubject { .. }
-            | Self::TooManyArchiveEntries { .. } => None,
+            | Self::TooManyArchiveEntries { .. }
+            | Self::TooManyDirectoryEntries { .. } => None,
             Self::Metadata { source, .. }
             | Self::Open { source, .. }
             | Self::ArchiveEntryRead { source, .. }
+            | Self::MetadataRead { source, .. }
             | Self::FingerprintRead { source, .. } => Some(source),
             Self::Archive { source, .. } | Self::ArchiveEntry { source, .. } => Some(source),
         }

--- a/crates/core/src/provisioning/server_inspection/formats/java_properties.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/java_properties.rs
@@ -1,0 +1,117 @@
+use std::collections::BTreeMap;
+
+pub(crate) fn parse(content: &[u8]) -> BTreeMap<String, String> {
+    let content = String::from_utf8_lossy(content);
+    logical_lines(&content)
+        .into_iter()
+        .filter_map(|line| split_property(&line))
+        .collect()
+}
+
+fn logical_lines(content: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for line in content.lines() {
+        let line = line.trim_end_matches('\r');
+        current.push_str(line);
+        let backslashes = current
+            .chars()
+            .rev()
+            .take_while(|character| *character == '\\')
+            .count();
+        if backslashes % 2 == 1 {
+            current.pop();
+            continue;
+        }
+        lines.push(std::mem::take(&mut current));
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+fn split_property(line: &str) -> Option<(String, String)> {
+    let line = line.trim_start();
+    if line.is_empty() || line.starts_with(['#', '!']) {
+        return None;
+    }
+
+    let mut escaped = false;
+    let mut separator = None;
+    for (index, character) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if matches!(character, '=' | ':') || character.is_whitespace() {
+            separator = Some(index);
+            break;
+        }
+    }
+
+    let (key, value) = separator.map_or((line, ""), |separator| {
+        let key = &line[..separator];
+        let value = line[separator..].trim_start_matches(|character: char| {
+            character.is_whitespace() || matches!(character, '=' | ':')
+        });
+        (key, value)
+    });
+    let key = unescape(key.trim());
+    (!key.is_empty()).then(|| (key, unescape(value.trim())))
+}
+
+fn unescape(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut characters = value.chars();
+    while let Some(character) = characters.next() {
+        if character != '\\' {
+            output.push(character);
+            continue;
+        }
+        match characters.next() {
+            Some('t') => output.push('\t'),
+            Some('n') => output.push('\n'),
+            Some('r') => output.push('\r'),
+            Some('f') => output.push('\u{000c}'),
+            Some(character) => output.push(character),
+            None => output.push('\\'),
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn parses_installer_and_bootstrap_properties() {
+        let properties = parse(
+            concat!(
+                "# installer\n",
+                "fabric-loader-version=0.19.3\n",
+                "game-version: 26.2\n",
+                "Main-Class net.minecraftforge.bootstrap.ForgeBootstrap\n",
+                "Arguments=--launchTarget \\\n",
+                "forge_server\n",
+            )
+            .as_bytes(),
+        );
+
+        assert_eq!(properties.get("fabric-loader-version").map(String::as_str), Some("0.19.3"));
+        assert_eq!(properties.get("game-version").map(String::as_str), Some("26.2"));
+        assert_eq!(
+            properties.get("Main-Class").map(String::as_str),
+            Some("net.minecraftforge.bootstrap.ForgeBootstrap")
+        );
+        assert_eq!(
+            properties.get("Arguments").map(String::as_str),
+            Some("--launchTarget forge_server")
+        );
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/formats/jvm_args.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/jvm_args.rs
@@ -1,0 +1,88 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JvmArgumentFile {
+    pub(crate) arguments: Vec<String>,
+}
+
+impl JvmArgumentFile {
+    pub(crate) fn value_after(&self, flag: &str) -> Option<&str> {
+        self.arguments
+            .windows(2)
+            .find(|arguments| arguments[0] == flag)
+            .map(|arguments| arguments[1].as_str())
+    }
+
+    pub(crate) fn jar_target(&self) -> Option<&str> {
+        self.value_after("-jar")
+    }
+}
+
+pub(crate) fn parse(content: &[u8]) -> JvmArgumentFile {
+    let content = String::from_utf8_lossy(content);
+    let arguments = content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .flat_map(tokenize)
+        .collect();
+    JvmArgumentFile { arguments }
+}
+
+fn tokenize(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for character in input.chars() {
+        if escaped {
+            token.push(character);
+            escaped = false;
+            continue;
+        }
+        if character == '\\' && quote.is_some() {
+            escaped = true;
+            continue;
+        }
+        if matches!(character, '\'' | '"') {
+            if quote == Some(character) {
+                quote = None;
+            } else if quote.is_none() {
+                quote = Some(character);
+            } else {
+                token.push(character);
+            }
+            continue;
+        }
+        if quote.is_none() && character.is_whitespace() {
+            if !token.is_empty() {
+                tokens.push(std::mem::take(&mut token));
+            }
+            continue;
+        }
+        token.push(character);
+    }
+    if escaped {
+        token.push('\\');
+    }
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn parses_modloader_values_and_forge_shim_targets() {
+        let modern = parse(
+            b"-classpath\nlibraries/example.jar\nnet.neoforged.fml.startup.Server\n--fml.neoForgeVersion 26.2.0.41-beta\n--fml.mcVersion 26.2\n",
+        );
+        assert_eq!(modern.value_after("--fml.neoForgeVersion"), Some("26.2.0.41-beta"));
+        assert_eq!(modern.value_after("--fml.mcVersion"), Some("26.2"));
+
+        let forge = parse(b"-Dexample=true -jar forge-26.2-65.1.0-shim.jar\n");
+        assert_eq!(forge.jar_target(), Some("forge-26.2-65.1.0-shim.jar"));
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/formats/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/lib.rs
@@ -1,3 +1,5 @@
+pub(super) mod java_properties;
+pub(super) mod jvm_args;
 pub(super) mod manifest;
 pub(super) mod maven_coordinate;
 pub(super) mod mojang_version;

--- a/crates/core/src/provisioning/server_inspection/formats/maven_coordinate.rs
+++ b/crates/core/src/provisioning/server_inspection/formats/maven_coordinate.rs
@@ -14,12 +14,12 @@ pub(crate) fn parse(value: &str) -> Option<MavenCoordinate> {
             classifier: None,
             extension: None,
         }),
-        [group, artifact, extension, version] => Some(MavenCoordinate {
+        [group, artifact, version, classifier] => Some(MavenCoordinate {
             group: (*group).to_string(),
             artifact: (*artifact).to_string(),
             version: (*version).to_string(),
-            classifier: None,
-            extension: Some((*extension).to_string()),
+            classifier: Some((*classifier).to_string()),
+            extension: None,
         }),
         [group, artifact, extension, classifier, version] => Some(MavenCoordinate {
             group: (*group).to_string(),
@@ -47,6 +47,11 @@ mod tests {
         let extended = parse("example:server:jar:mojmap:1.0").expect("extended coordinate");
         assert_eq!(extended.extension.as_deref(), Some("jar"));
         assert_eq!(extended.classifier.as_deref(), Some("mojmap"));
+
+        let classified =
+            parse("net.minecraftforge:forge:26.2-65.1.0:server").expect("classified coordinate");
+        assert_eq!(classified.version, "26.2-65.1.0");
+        assert_eq!(classified.classifier.as_deref(), Some("server"));
     }
 
     #[test]

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -1,6 +1,7 @@
 mod archive;
 #[path = "detectors/lib.rs"]
 mod detectors;
+mod directory;
 mod error;
 mod evidence;
 #[path = "formats/lib.rs"]
@@ -131,6 +132,20 @@ pub fn inspect_server_artifact(
             confidence: 100,
             evidence: vec![role_evidence],
         });
+
+        let mut directory_metadata = directory::read_metadata(path, options)?;
+        diagnostics.append(&mut directory_metadata.diagnostics);
+        let detector_output = detectors::detect_directory(path, &directory_metadata, &mut evidence);
+        apply_detector_output(
+            detector_output,
+            &mut identity,
+            &mut minecraft,
+            &mut java,
+            &mut roles,
+            &mut components,
+            &mut launches,
+            &mut diagnostics,
+        );
     } else {
         let format = format_from_path(path);
         let format_weight = if format == ArtifactFormat::Unknown {
@@ -227,30 +242,19 @@ pub fn inspect_server_artifact(
                 &artifact,
                 &archive_metadata,
                 minecraft.as_ref(),
+                Some(&java.required_major),
                 &mut evidence,
             );
-            identity = detector_output.identity;
-            if detector_output.minecraft_version.confidence > 0 {
-                let minecraft_info = minecraft.get_or_insert_with(MinecraftVersionInfo::default);
-                for evidence_id in detector_output.minecraft_version.evidence.iter().chain(
-                    detector_output
-                        .minecraft_version
-                        .alternatives
-                        .iter()
-                        .flat_map(|candidate| candidate.evidence.iter()),
-                ) {
-                    if !minecraft_info.evidence.contains(evidence_id) {
-                        minecraft_info.evidence.push(*evidence_id);
-                    }
-                }
-                minecraft_info.version = detector_output.minecraft_version;
-            }
-            roles.extend(detector_output.roles);
-            components = detector_output.components;
-            for diagnostic in detector_output.diagnostics {
-                diagnostics.retain(|existing| existing.code != diagnostic.code);
-                diagnostics.push(diagnostic);
-            }
+            apply_detector_output(
+                detector_output,
+                &mut identity,
+                &mut minecraft,
+                &mut java,
+                &mut roles,
+                &mut components,
+                &mut launches,
+                &mut diagnostics,
+            );
         }
     }
 
@@ -269,6 +273,43 @@ pub fn inspect_server_artifact(
         evidence: evidence.into_entries(),
         diagnostics,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_detector_output(
+    detector_output: detectors::DetectorOutput,
+    identity: &mut ServerIdentityInfo,
+    minecraft: &mut Option<MinecraftVersionInfo>,
+    java: &mut JavaRequirementInfo,
+    roles: &mut Vec<Attributed<ArtifactRole>>,
+    components: &mut Vec<Attributed<ServerComponent>>,
+    launches: &mut Vec<Attributed<LaunchProfile>>,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) {
+    *identity = detector_output.identity;
+    if detector_output.minecraft_version.confidence > 0 {
+        let minecraft_info = minecraft.get_or_insert_with(MinecraftVersionInfo::default);
+        for evidence_id in detector_output.minecraft_version.evidence.iter().chain(
+            detector_output
+                .minecraft_version
+                .alternatives
+                .iter()
+                .flat_map(|candidate| candidate.evidence.iter()),
+        ) {
+            if !minecraft_info.evidence.contains(evidence_id) {
+                minecraft_info.evidence.push(*evidence_id);
+            }
+        }
+        minecraft_info.version = detector_output.minecraft_version;
+    }
+    roles.extend(detector_output.roles);
+    *components = detector_output.components;
+    launches.extend(detector_output.launches);
+    java.required_major = detector_output.java_major;
+    for diagnostic in detector_output.diagnostics {
+        diagnostics.retain(|existing| existing.code != diagnostic.code);
+        diagnostics.push(diagnostic);
+    }
 }
 
 fn validate_options(options: &InspectionOptions) -> Result<(), ServerInspectionError> {
@@ -656,7 +697,8 @@ mod tests {
 
     use super::{
         inspect_server_artifact, ArtifactFormat, ArtifactRole, InspectionOptions,
-        InspectionSubjectKind, LaunchTarget, ReleaseChannel, ServerCategory, ServerEcosystem,
+        InspectionSubjectKind, LaunchPlatform, LaunchTarget, ReleaseChannel, ServerCategory,
+        ServerComponentKind, ServerEcosystem,
     };
 
     fn temporary_path(suffix: &str) -> PathBuf {
@@ -678,6 +720,9 @@ mod tests {
     }
 
     fn write_test_jar_entries(path: &Path, entries: &[(&str, &str)]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create test JAR parent directory");
+        }
         let file = File::create(path).expect("create test JAR");
         let mut archive = zip::ZipWriter::new(file);
         for (name, content) in entries {
@@ -689,6 +734,334 @@ mod tests {
                 .expect("write metadata entry");
         }
         archive.finish().expect("finish test JAR");
+    }
+
+    #[test]
+    fn distinguishes_fabric_loader_from_installer_version() {
+        let cases = [
+            ("fabric", "FabricInstaller", "26.2"),
+            ("legacy-fabric", "LegacyFabricInstaller", "1.13.2"),
+        ];
+
+        for (product_key, title, minecraft_version) in cases {
+            let path = temporary_path(&format!("{product_key}.jar"));
+            let manifest = format!(
+                "Manifest-Version: 1.0\r\nImplementation-Title: {title}\r\nImplementation-Version: 1.1.1\r\nMain-Class: net.fabricmc.installer.ServerLauncher\r\n\r\n"
+            );
+            let properties =
+                format!("fabric-loader-version=0.19.3\ngame-version={minecraft_version}\n");
+            write_test_jar_entries(
+                &path,
+                &[("META-INF/MANIFEST.MF", &manifest), ("install.properties", &properties)],
+            );
+
+            let report = inspect_server_artifact(&path, &InspectionOptions::default())
+                .expect("inspect Fabric launcher");
+            fs::remove_file(&path).expect("remove Fabric fixture");
+
+            assert_eq!(
+                report
+                    .identity
+                    .implementation
+                    .value
+                    .as_ref()
+                    .map(|product| product.key.as_str()),
+                Some(product_key)
+            );
+            assert_eq!(report.identity.version.value.as_deref(), Some("0.19.3"));
+            assert_ne!(report.identity.version.value.as_deref(), Some("1.1.1"));
+            assert_eq!(
+                report
+                    .minecraft
+                    .as_ref()
+                    .and_then(|minecraft| minecraft.version.value.as_deref()),
+                Some(minecraft_version)
+            );
+            assert!(report
+                .artifact
+                .roles
+                .iter()
+                .any(|role| role.value == ArtifactRole::Installer));
+            assert!(report
+                .artifact
+                .roles
+                .iter()
+                .any(|role| role.value == ArtifactRole::Launcher));
+            assert!(report.components.iter().any(|component| {
+                component.value.kind == ServerComponentKind::ModLoader
+                    && component.value.version.as_deref() == Some("0.19.3")
+            }));
+            assert!(report.components.iter().any(|component| {
+                component.value.kind == ServerComponentKind::Installer
+                    && component.value.version.as_deref() == Some("1.1.1")
+            }));
+        }
+    }
+
+    #[test]
+    fn discovers_a_fabric_launcher_in_an_installation_directory() {
+        let root = temporary_path("fabric-installation");
+        fs::create_dir_all(&root).expect("create Fabric installation directory");
+        write_test_jar_entries(
+            &root.join("fabric-server-launch.jar"),
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Implementation-Title: FabricInstaller\r\nImplementation-Version: 1.1.1\r\nMain-Class: net.fabricmc.installer.ServerLauncher\r\n\r\n",
+                ),
+                (
+                    "install.properties",
+                    "fabric-loader-version=0.19.3\ngame-version=26.2\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect Fabric installation directory");
+        fs::remove_dir_all(&root).expect("remove Fabric installation fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("fabric")
+        );
+        assert_eq!(report.identity.version.value.as_deref(), Some("0.19.3"));
+        assert!(report.launches.iter().any(|launch| {
+            matches!(
+                &launch.value.target,
+                LaunchTarget::Jar { path }
+                    if path.file_name().and_then(|name| name.to_str())
+                        == Some("fabric-server-launch.jar")
+            )
+        }));
+    }
+
+    #[test]
+    fn inspects_a_forge_installation_directory_and_launch_profiles() {
+        let root = temporary_path("forge-installation");
+        fs::create_dir_all(&root).expect("create Forge fixture directory");
+        write_test_jar_entries(
+            &root.join("server.jar"),
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.bootstrap.shim.Main\r\n\r\nName: net/minecraftforge/bootstrap/shim/\r\nImplementation-Title: bs-shim\r\nImplementation-Version: 2.1.8\r\n\r\n",
+                ),
+                (
+                    "bootstrap-shim.properties",
+                    "Arguments=--launchTarget forge_server\nJava-Version=25\nMain-Class=net.minecraftforge.bootstrap.ForgeBootstrap\n",
+                ),
+                (
+                    "bootstrap-shim.list",
+                    "hash\tnet.minecraftforge:forge:26.2-65.1.0:server\tnet/minecraftforge/forge/26.2-65.1.0/forge-server.jar\n",
+                ),
+            ],
+        );
+        let version_directory = root.join("libraries/net/minecraftforge/forge/26.2-65.1.0");
+        fs::create_dir_all(&version_directory).expect("create Forge version directory");
+        fs::write(
+            version_directory.join("win_args.txt"),
+            "-Dexample=true -jar forge-26.2-65.1.0-shim.jar\n",
+        )
+        .expect("write Forge Windows args");
+        fs::write(
+            version_directory.join("unix_args.txt"),
+            "-Dexample=true -jar forge-26.2-65.1.0-shim.jar\n",
+        )
+        .expect("write Forge Unix args");
+        fs::write(
+            root.join("run.bat"),
+            "java @libraries/net/minecraftforge/forge/26.2-65.1.0/win_args.txt %*\n",
+        )
+        .expect("write Forge startup script");
+        write_test_jar_entries(
+            &root.join(
+                "libraries/net/minecraftforge/fmlloader/26.2-65.1.0/fmlloader-26.2-65.1.0.jar",
+            ),
+            &[(
+                "forge_version.json",
+                r#"{"forge":"65.1.0","mc":"26.2","mcp":"20260616.103818"}"#,
+            )],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect Forge directory");
+        fs::remove_dir_all(&root).expect("remove Forge fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("forge")
+        );
+        assert_eq!(report.identity.version.value.as_deref(), Some("65.1.0"));
+        assert_eq!(
+            report
+                .minecraft
+                .as_ref()
+                .and_then(|minecraft| minecraft.version.value.as_deref()),
+            Some("26.2")
+        );
+        assert_eq!(report.java.required_major.value, Some(25));
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "forge"));
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "mcp"));
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "forge-bootstrap-shim"));
+        assert!(report
+            .launches
+            .iter()
+            .any(|launch| launch.value.platform == LaunchPlatform::Windows));
+        assert!(report
+            .launches
+            .iter()
+            .any(|launch| launch.value.platform == LaunchPlatform::Unix));
+        assert!(report
+            .launches
+            .iter()
+            .any(|launch| matches!(launch.value.target, LaunchTarget::Script { .. })));
+    }
+
+    #[test]
+    fn keeps_multiple_installed_forge_versions_ambiguous() {
+        let root = temporary_path("forge-multiple-versions");
+        for version in ["1.20.1-47.2.0", "1.20.1-47.3.0"] {
+            let directory = root
+                .join("libraries/net/minecraftforge/forge")
+                .join(version);
+            fs::create_dir_all(&directory).expect("create Forge version directory");
+            fs::write(directory.join("win_args.txt"), format!("-jar forge-{version}-shim.jar\n"))
+                .expect("write Forge args");
+        }
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect multi-version Forge directory");
+        fs::remove_dir_all(&root).expect("remove multi-version Forge fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("forge")
+        );
+        assert!(report.identity.version.value.is_none());
+        assert_eq!(report.identity.version.alternatives.len(), 2);
+        assert_eq!(
+            report
+                .components
+                .iter()
+                .filter(|component| component.value.kind == ServerComponentKind::ModLoader)
+                .count(),
+            2
+        );
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "conflicting_server_versions"));
+    }
+
+    #[test]
+    fn inspects_a_neoforge_installation_directory_and_wrapper() {
+        let root = temporary_path("neoforge-server.jar");
+        fs::create_dir_all(&root).expect("create NeoForge fixture directory");
+        write_test_jar_entries(
+            &root.join("server.jar"),
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Manifest-Version: 1.0\r\nMain-Class: app.mcjars.serverstarter.ServerStarter\r\n\r\n",
+                ),
+                (
+                    "metadata.json",
+                    r#"{"version":"26.2","neoforge":"26.2.0.41-beta"}"#,
+                ),
+            ],
+        );
+        let version_directory = root.join("libraries/net/neoforged/neoforge/26.2.0.41-beta");
+        fs::create_dir_all(&version_directory).expect("create NeoForge version directory");
+        let arguments = concat!(
+            "-classpath\n",
+            "libraries/net/neoforged/loader.jar\n",
+            "net.neoforged.fml.startup.Server\n",
+            "--fml.neoForgeVersion 26.2.0.41-beta\n",
+            "--fml.mcVersion 26.2\n",
+        );
+        fs::write(version_directory.join("win_args.txt"), arguments)
+            .expect("write NeoForge Windows args");
+        fs::write(version_directory.join("unix_args.txt"), arguments)
+            .expect("write NeoForge Unix args");
+        write_test_jar_entries(
+            &version_directory.join("neoforge-26.2.0.41-beta-universal.jar"),
+            &[(
+                "net/neoforged/neoforge/common/version.properties",
+                "neoforge_version=26.2.0.41-beta\nneoform_version=26.2-2\nminecraft_version=26.2\nbuild_type=BETA\n",
+            )],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect NeoForge directory");
+        fs::remove_dir_all(&root).expect("remove NeoForge fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("neoforge")
+        );
+        assert_eq!(report.identity.version.value.as_deref(), Some("26.2.0.41-beta"));
+        assert_eq!(report.identity.release_channel.value, Some(ReleaseChannel::Beta));
+        assert_eq!(
+            report
+                .minecraft
+                .as_ref()
+                .and_then(|minecraft| minecraft.version.value.as_deref()),
+            Some("26.2")
+        );
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "neoforge"));
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "neoform"));
+        assert!(report
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::Wrapper));
+        assert!(report.launches.iter().any(|launch| {
+            matches!(launch.value.target, LaunchTarget::Jar { .. })
+                && launch.value.id == "neoforge-wrapper-jar"
+        }));
+        assert_eq!(
+            report
+                .launches
+                .iter()
+                .filter(|launch| matches!(launch.value.target, LaunchTarget::ArgumentFiles { .. }))
+                .count(),
+            2
+        );
     }
 
     #[test]
@@ -1093,7 +1466,7 @@ mod tests {
     }
 
     #[test]
-    fn directories_are_reported_without_scanning_their_contents() {
+    fn empty_directories_are_reported_without_false_identity_claims() {
         let path = temporary_path("directory");
         fs::create_dir(&path).expect("create test directory");
 


### PR DESCRIPTION
本 PR 完成服务端检查的第三阶段，增加 Fabric、Legacy Fabric、Forge 与 NeoForge 识别。

整体功能尚未完成，Hybrid、Proxy、Sponge、Limbo 等服务端类型将在后续 PR 补充。

## Summary by Sourcery

扩展服务器检查功能，以检测基于模组加载器（modloader）的安装，并为 JAR 构件和安装目录记录更丰富的启动信息和 Java 需求元数据。

新功能：
- 为服务器安装添加目录元数据扫描，包括根归档文件、模组加载器安装和启动脚本。
- 引入对 Fabric、Legacy Fabric、Forge 和 NeoForge 模组加载器服务器的检测器，包括安装器、包装器和引导（bootstrap）构件。
- 在检查过程中，从归档文件、参数文件和启动脚本中捕获启动配置以及所需的 Java 主版本。

错误修复：
- 修正 Maven 坐标解析，以正确处理带分类器的 Forge 坐标（例如 server 分类器），避免误解版本组件。

改进：
- 统一归档与目录检查时的检测器输出应用逻辑，集中更新标识信息、Minecraft 信息、Java 信息、角色、组件、启动配置和诊断信息。
- 泛化产品生态系统定义，以支持每个产品的多个生态系统，并扩展产品目录以涵盖 Fabric、Legacy Fabric、Forge 和 NeoForge。
- 扩展归档元数据读取能力，以支持更多与模组加载器相关的条目，例如安装属性、引导元数据、包装器元数据和版本描述符。
- 改善诊断信息，通过报告超大元数据和嵌套归档，并区分空目录与有效安装。

测试：
- 添加全面测试，覆盖 Fabric 和 Legacy Fabric 安装器检测、Fabric 安装目录扫描、Forge 安装及多版本歧义处理，以及 NeoForge 安装和包装器检查。
- 更新现有目录检查测试，以验证空目录不会产生错误的身份识别声明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend server inspection to detect modloader-based installations and record richer launch and Java requirement metadata for both JAR artifacts and installation directories.

New Features:
- Add directory metadata scanning for server installations, including root archives, modloader installations, and startup scripts.
- Introduce detectors for Fabric, Legacy Fabric, Forge, and NeoForge modloader servers, including installers, wrappers, and bootstrap artifacts.
- Capture launch profiles and required Java major versions from archives, argument files, and startup scripts during inspection.

Bug Fixes:
- Correct Maven coordinate parsing to handle classified Forge coordinates (e.g. server classifier) without misinterpreting version components.

Enhancements:
- Unify detector output application for both archive and directory inspection, centralizing identity, Minecraft, Java, roles, components, launches, and diagnostics updates.
- Generalize product ecosystem definitions to support multiple ecosystems per product and extend product catalog with Fabric, Legacy Fabric, Forge, and NeoForge.
- Expand archive metadata reading to support additional modloader-related entries such as install properties, bootstrap metadata, wrapper metadata, and version descriptors.
- Improve diagnostics by reporting oversized metadata and nested archives and distinguishing empty directories from valid installations.

Tests:
- Add comprehensive tests covering Fabric and Legacy Fabric installer detection, Fabric installation directory scanning, Forge installation and multi-version ambiguity handling, and NeoForge installation and wrapper inspection.
- Update existing directory inspection tests to validate that empty directories do not produce false identity claims.

</details>