### PR TITLE
feat(core): detect remaining server families

### DIFF
--- a/crates/core/src/provisioning/server_inspection/archive.rs
+++ b/crates/core/src/provisioning/server_inspection/archive.rs
@@ -17,6 +17,7 @@ pub(super) const INSTALL_PROPERTIES_ENTRY: &str = "install.properties";
 pub(super) const BOOTSTRAP_PROPERTIES_ENTRY: &str = "bootstrap-shim.properties";
 pub(super) const BOOTSTRAP_LIST_ENTRY: &str = "bootstrap-shim.list";
 pub(super) const WRAPPER_METADATA_ENTRY: &str = "metadata.json";
+pub(super) const ARCLIGHT_LAUNCH_PROPERTIES_ENTRY: &str = "arclight-server-launch.properties";
 pub(super) const FORGE_VERSION_ENTRY: &str = "forge_version.json";
 pub(super) const NEOFORGE_VERSION_PROPERTIES_ENTRY: &str =
     "net/neoforged/neoforge/common/version.properties";
@@ -31,6 +32,7 @@ pub(super) struct ArchiveMetadata {
     pub(super) bootstrap_properties: Option<Vec<u8>>,
     pub(super) bootstrap_list: Option<Vec<u8>>,
     pub(super) wrapper_metadata: Option<Vec<u8>>,
+    pub(super) arclight_launch_properties: Option<Vec<u8>>,
     pub(super) forge_version: Option<Vec<u8>>,
     pub(super) neoforge_version_properties: Option<Vec<u8>>,
     pub(super) diagnostics: Vec<InspectionDiagnostic>,
@@ -134,6 +136,14 @@ pub(super) fn read_metadata_with_budget(
         consumed,
         &mut diagnostics,
     )?;
+    let arclight_launch_properties = read_optional_entry(
+        &mut archive,
+        path,
+        ARCLIGHT_LAUNCH_PROPERTIES_ENTRY,
+        options,
+        consumed,
+        &mut diagnostics,
+    )?;
     let forge_version = read_optional_entry(
         &mut archive,
         path,
@@ -161,6 +171,7 @@ pub(super) fn read_metadata_with_budget(
         bootstrap_properties,
         bootstrap_list,
         wrapper_metadata,
+        arclight_launch_properties,
         forge_version,
         neoforge_version_properties,
         diagnostics,

--- a/crates/core/src/provisioning/server_inspection/detectors/forge.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/forge.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -16,6 +15,7 @@ use super::super::model::{
     ArtifactRole, EvidenceLocation, EvidenceSource, LaunchPlatform, LaunchProfile, LaunchTarget,
     MavenCoordinate, ReleaseChannel, ServerComponent, ServerComponentKind,
 };
+use super::manifest_attributes::attribute;
 use super::{
     ecosystems_for_key, product_from_key, release_channel, ComponentFinding, Findings,
     ProductFinding, ProductValueFinding, Signal,
@@ -849,13 +849,6 @@ fn archive_location(path: &Path, entry: &str, field: Option<&str>) -> EvidenceLo
         manifest_section: None,
         field: field.map(str::to_string),
     }
-}
-
-fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
-    attributes
-        .iter()
-        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.as_str())
 }
 
 fn platform_for_script(kind: StartupScriptKind) -> LaunchPlatform {

--- a/crates/core/src/provisioning/server_inspection/detectors/generic.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/generic.rs
@@ -30,6 +30,7 @@ pub(super) fn detect(
             manifest_location(path, "Main-Class"),
             90,
             "craftbukkit-main-class",
+            "craftbukkit-main-class",
             findings,
         );
         findings.roles.push(Signal {
@@ -49,6 +50,7 @@ pub(super) fn detect(
                 EvidenceSource::JarEntry,
                 location.clone(),
                 95,
+                "craftbukkit-versions-list",
                 "craftbukkit-versions-list",
                 findings,
             );
@@ -140,13 +142,14 @@ fn add_craftbukkit_product(
     source: EvidenceSource,
     location: super::super::model::EvidenceLocation,
     weight: u8,
+    detector: &'static str,
     correlation_group: &'static str,
     findings: &mut Findings,
 ) {
     findings.products.push(ProductFinding {
         signal: Signal {
             value: product_from_key("craftbukkit"),
-            detector: "craftbukkit-bundler",
+            detector,
             source,
             location,
             weight,

--- a/crates/core/src/provisioning/server_inspection/detectors/generic.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/generic.rs
@@ -1,0 +1,217 @@
+use std::path::{Path, PathBuf};
+
+use super::super::archive::{ArchiveMetadata, VERSIONS_LIST_ENTRY};
+use super::super::formats::manifest;
+use super::super::model::{
+    ArtifactRole, EvidenceSource, LaunchPlatform, LaunchProfile, LaunchTarget, ServerComponent,
+    ServerComponentKind,
+};
+use super::{
+    ecosystems_for_key, list_location, manifest_location, product_from_key, release_channel,
+    ComponentFinding, Findings, ProductFinding, ProductValueFinding, Signal,
+};
+
+const CRAFTBUKKIT_MAIN: &str = "org.bukkit.craftbukkit.bootstrap.Main";
+const FABRIC_SERVER_LAUNCHER: &str = "net.fabricmc.installer.ServerLauncher";
+
+pub(super) fn detect(
+    path: &Path,
+    archive: &ArchiveMetadata,
+    directory_launch: Option<(&Path, &Path)>,
+    findings: &mut Findings,
+) {
+    let parsed_manifest = archive.manifest.as_deref().map(manifest::parse);
+    let main_class = parsed_manifest
+        .as_ref()
+        .and_then(|manifest| manifest.main_value("Main-Class"));
+    if main_class == Some(CRAFTBUKKIT_MAIN) {
+        add_craftbukkit_product(
+            EvidenceSource::ManifestMain,
+            manifest_location(path, "Main-Class"),
+            90,
+            "craftbukkit-main-class",
+            findings,
+        );
+        findings.roles.push(Signal {
+            value: ArtifactRole::Bootstrapper,
+            detector: "craftbukkit-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 90,
+            correlation_group: "craftbukkit-main-class",
+        });
+    }
+
+    if let Some(content) = archive.versions_list.as_deref() {
+        for entry in craftbukkit_versions(content) {
+            let location = list_location(path, VERSIONS_LIST_ENTRY, entry.line);
+            add_craftbukkit_product(
+                EvidenceSource::JarEntry,
+                location.clone(),
+                95,
+                "craftbukkit-versions-list",
+                findings,
+            );
+            findings.product_versions.push(ProductValueFinding {
+                product_key: "craftbukkit".to_string(),
+                signal: Signal {
+                    value: entry.product_version.clone(),
+                    detector: "craftbukkit-versions-list",
+                    source: EvidenceSource::JarEntry,
+                    location: location.clone(),
+                    weight: 95,
+                    correlation_group: "craftbukkit-versions-list",
+                },
+            });
+            findings.minecraft_versions.push(Signal {
+                value: entry.minecraft_version,
+                detector: "craftbukkit-versions-list",
+                source: EvidenceSource::JarEntry,
+                location: location.clone(),
+                weight: 95,
+                correlation_group: "craftbukkit-versions-list",
+            });
+            if let Some(channel) = release_channel(&entry.product_version) {
+                findings.release_channels.push(ProductValueFinding {
+                    product_key: "craftbukkit".to_string(),
+                    signal: Signal {
+                        value: channel,
+                        detector: "craftbukkit-versions-list",
+                        source: EvidenceSource::JarEntry,
+                        location: location.clone(),
+                        weight: 95,
+                        correlation_group: "craftbukkit-versions-list",
+                    },
+                });
+            }
+            findings.components.push(ComponentFinding {
+                product_key: "craftbukkit".to_string(),
+                signal: Signal {
+                    value: ServerComponent {
+                        kind: ServerComponentKind::Implementation,
+                        key: "craftbukkit".to_string(),
+                        name: "CraftBukkit".to_string(),
+                        version: Some(entry.product_version.clone()),
+                        release_channel: release_channel(&entry.product_version),
+                        coordinate: None,
+                        source_path: Some(PathBuf::from(entry.target_path)),
+                    },
+                    detector: "craftbukkit-versions-list",
+                    source: EvidenceSource::JarEntry,
+                    location,
+                    weight: 95,
+                    correlation_group: "craftbukkit-versions-list",
+                },
+            });
+        }
+    }
+
+    if let Some((root, relative_jar)) = directory_launch {
+        if main_class.is_some() && main_class != Some(FABRIC_SERVER_LAUNCHER) {
+            findings.roles.push(Signal {
+                value: ArtifactRole::Runnable,
+                detector: "directory-root-jar-manifest",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 95,
+                correlation_group: "directory-root-jar-manifest",
+            });
+            findings.launches.push(Signal {
+                value: LaunchProfile {
+                    id: format!("root-jar-{}", launch_id(relative_jar)),
+                    platform: LaunchPlatform::Any,
+                    working_directory: Some(root.to_path_buf()),
+                    target: LaunchTarget::Jar { path: root.join(relative_jar) },
+                    jvm_arguments: Vec::new(),
+                    program_arguments: Vec::new(),
+                    required_java_major: None,
+                },
+                detector: "directory-root-jar-manifest",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 95,
+                correlation_group: "directory-root-jar-manifest",
+            });
+        }
+    }
+}
+
+fn add_craftbukkit_product(
+    source: EvidenceSource,
+    location: super::super::model::EvidenceLocation,
+    weight: u8,
+    correlation_group: &'static str,
+    findings: &mut Findings,
+) {
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key("craftbukkit"),
+            detector: "craftbukkit-bundler",
+            source,
+            location,
+            weight,
+            correlation_group,
+        },
+        ecosystems: ecosystems_for_key("craftbukkit", false),
+    });
+}
+
+fn craftbukkit_versions(content: &[u8]) -> Vec<CraftBukkitVersion> {
+    String::from_utf8_lossy(content)
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            let target_path = line.split_whitespace().next_back()?.trim_start_matches('*');
+            let filename = target_path.rsplit(['/', '\\']).next()?;
+            let stem = super::strip_jar_suffix(filename)?;
+            let prefix = "craftbukkit-";
+            if stem.len() <= prefix.len() || !stem[..prefix.len()].eq_ignore_ascii_case(prefix) {
+                return None;
+            }
+            let product_version = stem[prefix.len()..].to_string();
+            let lower = product_version.to_ascii_lowercase();
+            let minecraft_end = lower.find("-r")?;
+            let minecraft_version = product_version[..minecraft_end].to_string();
+            (!minecraft_version.is_empty()).then_some(CraftBukkitVersion {
+                line: index + 1,
+                target_path: target_path.to_string(),
+                product_version,
+                minecraft_version,
+            })
+        })
+        .collect()
+}
+
+fn launch_id(path: &Path) -> String {
+    path.to_string_lossy()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+struct CraftBukkitVersion {
+    line: usize,
+    target_path: String,
+    product_version: String,
+    minecraft_version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::craftbukkit_versions;
+
+    #[test]
+    fn parses_two_field_craftbukkit_version_lists() {
+        let entries = craftbukkit_versions(b"hash *craftbukkit-26.2-R0.1-SNAPSHOT.jar\n");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].minecraft_version, "26.2");
+        assert_eq!(entries[0].product_version, "26.2-R0.1-SNAPSHOT");
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/hybrid.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/hybrid.rs
@@ -11,6 +11,7 @@ use super::super::model::{
     ArtifactRole, EvidenceLocation, EvidenceSource, MavenCoordinate, ServerComponent,
     ServerComponentKind, ServerEcosystem,
 };
+use super::manifest_attributes::{attribute, section_by_title};
 use super::{
     ecosystems_for_key, manifest_location, manifest_section_location, product_from_key,
     release_channel, ComponentFinding, Findings, ProductFinding, ProductValueFinding, Signal,
@@ -118,6 +119,7 @@ fn detect_arclight(
             Some(version),
             PathBuf::from("META-INF/MANIFEST.MF"),
             "arclight-manifest",
+            "arclight-manifest",
             EvidenceSource::ManifestMain,
             manifest_location(path, "Implementation-Version"),
             90,
@@ -138,6 +140,7 @@ fn detect_arclight(
             name,
             None,
             PathBuf::from(ARCLIGHT_LAUNCH_PROPERTIES_ENTRY),
+            "arclight-launch-properties",
             "arclight-launch-properties",
             EvidenceSource::PropertiesField,
             location,
@@ -223,6 +226,7 @@ fn detect_mohist(
             "Mohist",
             Some(version),
             PathBuf::from("META-INF/MANIFEST.MF"),
+            "mohist-manifest-section",
             "mohist-product-section",
             EvidenceSource::ManifestSection,
             version_location,
@@ -239,6 +243,7 @@ fn detect_mohist(
         ServerComponentKind::ModLoader,
         "forge",
         "Forge",
+        "mohist-forge-section",
         findings,
     );
     add_section_component(
@@ -249,6 +254,7 @@ fn detect_mohist(
         ServerComponentKind::Api,
         "spigot",
         "Spigot",
+        "mohist-spigot-section",
         findings,
     );
     if let Some(mcp) = section_by_title(sections, "MCP") {
@@ -274,6 +280,7 @@ fn detect_mohist(
                 "MCP",
                 Some(version),
                 PathBuf::from("META-INF/MANIFEST.MF"),
+                "mohist-mcp-section",
                 "mohist-mcp-section",
                 EvidenceSource::ManifestSection,
                 manifest_section_location(path, mcp.name.as_deref(), "Implementation-Version"),
@@ -364,6 +371,7 @@ fn detect_youer(
             "Youer",
             Some(version),
             PathBuf::from("META-INF/MANIFEST.MF"),
+            "youer-manifest-section",
             "youer-product-section",
             EvidenceSource::ManifestSection,
             location,
@@ -480,6 +488,7 @@ fn add_section_component(
     kind: ServerComponentKind,
     key: &str,
     name: &str,
+    detector: &'static str,
     findings: &mut Findings,
 ) {
     let Some(section) = section_by_title(sections, title) else {
@@ -495,7 +504,8 @@ fn add_section_component(
         name,
         Some(version),
         PathBuf::from("META-INF/MANIFEST.MF"),
-        "hybrid-component-section",
+        detector,
+        detector,
         EvidenceSource::ManifestSection,
         manifest_section_location(path, section.name.as_deref(), "Implementation-Version"),
         85,
@@ -511,6 +521,7 @@ fn add_component(
     name: &str,
     version: Option<&str>,
     source_path: PathBuf,
+    detector: &'static str,
     correlation_group: &'static str,
     source: EvidenceSource,
     location: EvidenceLocation,
@@ -529,7 +540,7 @@ fn add_component(
                 coordinate: None,
                 source_path: Some(source_path),
             },
-            detector: "hybrid-server-metadata",
+            detector,
             source,
             location,
             weight,
@@ -572,24 +583,6 @@ fn add_product_version(
             },
         });
     }
-}
-
-fn section_by_title<'a>(
-    sections: &'a [super::super::model::ManifestSection],
-    title: &str,
-) -> Option<&'a super::super::model::ManifestSection> {
-    sections.iter().find(|section| {
-        attribute(&section.attributes, "Implementation-Title")
-            .is_some_and(|value| value.eq_ignore_ascii_case(title))
-    })
-}
-
-fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
-    attributes
-        .iter()
-        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.as_str())
-        .filter(|value| !value.trim().is_empty())
 }
 
 fn arclight_minecraft_version(version: &str) -> Option<&str> {

--- a/crates/core/src/provisioning/server_inspection/detectors/hybrid.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/hybrid.rs
@@ -1,0 +1,620 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use super::super::archive::{
+    ArchiveMetadata, ARCLIGHT_LAUNCH_PROPERTIES_ENTRY, WRAPPER_METADATA_ENTRY,
+};
+use super::super::formats::{java_properties, manifest};
+use super::super::model::{
+    ArtifactRole, EvidenceLocation, EvidenceSource, MavenCoordinate, ServerComponent,
+    ServerComponentKind, ServerEcosystem,
+};
+use super::{
+    ecosystems_for_key, manifest_location, manifest_section_location, product_from_key,
+    release_channel, ComponentFinding, Findings, ProductFinding, ProductValueFinding, Signal,
+};
+
+pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Findings) {
+    if let Some(manifest_bytes) = archive.manifest.as_deref() {
+        let parsed = manifest::parse(manifest_bytes);
+        detect_arclight(path, archive, &parsed.summary.main_attributes, findings);
+        detect_mohist(path, &parsed.summary.main_attributes, &parsed.summary.sections, findings);
+        detect_youer(path, &parsed.summary.main_attributes, &parsed.summary.sections, findings);
+    }
+    detect_magma(path, archive.wrapper_metadata.as_deref(), findings);
+}
+
+fn detect_arclight(
+    path: &Path,
+    archive: &ArchiveMetadata,
+    attributes: &BTreeMap<String, String>,
+    findings: &mut Findings,
+) {
+    let title = attribute(attributes, "Implementation-Title");
+    let main_class = attribute(attributes, "Main-Class");
+    if !title.is_some_and(|title| title.eq_ignore_ascii_case("Arclight"))
+        && main_class != Some("io.izzel.arclight.server.Launcher")
+    {
+        return;
+    }
+
+    let launch_properties = archive
+        .arclight_launch_properties
+        .as_deref()
+        .map(java_properties::parse)
+        .unwrap_or_default();
+    let launch_main = launch_properties.get("launch.mainClass");
+    let mut ecosystems = vec![ServerEcosystem::Bukkit];
+    let loader = launch_main.and_then(|main| {
+        let main = main.to_ascii_lowercase();
+        if main.contains(".neoforge.") {
+            Some((ServerEcosystem::NeoForge, "neoforge", "NeoForge"))
+        } else if main.contains(".forge.") {
+            Some((ServerEcosystem::Forge, "forge", "Forge"))
+        } else if main.contains(".fabric.") {
+            Some((ServerEcosystem::Fabric, "fabric", "Fabric Loader"))
+        } else {
+            None
+        }
+    });
+    if let Some((ecosystem, _, _)) = loader.as_ref() {
+        ecosystems.push(ecosystem.clone());
+    }
+
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key("arclight"),
+            detector: "arclight-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(
+                path,
+                if title.is_some() {
+                    "Implementation-Title"
+                } else {
+                    "Main-Class"
+                },
+            ),
+            weight: 90,
+            correlation_group: "arclight-manifest",
+        },
+        ecosystems,
+    });
+    findings.roles.push(Signal {
+        value: ArtifactRole::Launcher,
+        detector: "arclight-manifest",
+        source: EvidenceSource::ManifestMain,
+        location: manifest_location(path, "Main-Class"),
+        weight: 95,
+        correlation_group: "arclight-manifest",
+    });
+
+    if let Some(version) = attribute(attributes, "Implementation-Version") {
+        add_product_version(
+            "arclight",
+            version,
+            "arclight-manifest",
+            EvidenceSource::ManifestMain,
+            manifest_location(path, "Implementation-Version"),
+            90,
+            findings,
+        );
+        if let Some(minecraft_version) = arclight_minecraft_version(version) {
+            findings.minecraft_versions.push(Signal {
+                value: minecraft_version.to_string(),
+                detector: "arclight-manifest",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Implementation-Version"),
+                weight: 85,
+                correlation_group: "arclight-manifest",
+            });
+        }
+        add_component(
+            "arclight",
+            ServerComponentKind::Implementation,
+            "arclight",
+            "Arclight",
+            Some(version),
+            PathBuf::from("META-INF/MANIFEST.MF"),
+            "arclight-manifest",
+            EvidenceSource::ManifestMain,
+            manifest_location(path, "Implementation-Version"),
+            90,
+            findings,
+        );
+    }
+    if let Some((_, key, name)) = loader {
+        let location = EvidenceLocation {
+            path: path.to_path_buf(),
+            archive_entry: Some(ARCLIGHT_LAUNCH_PROPERTIES_ENTRY.to_string()),
+            manifest_section: None,
+            field: Some("launch.mainClass".to_string()),
+        };
+        add_component(
+            "arclight",
+            ServerComponentKind::ModLoader,
+            key,
+            name,
+            None,
+            PathBuf::from(ARCLIGHT_LAUNCH_PROPERTIES_ENTRY),
+            "arclight-launch-properties",
+            EvidenceSource::PropertiesField,
+            location,
+            95,
+            findings,
+        );
+    }
+}
+
+fn detect_mohist(
+    path: &Path,
+    attributes: &BTreeMap<String, String>,
+    sections: &[super::super::model::ManifestSection],
+    findings: &mut Findings,
+) {
+    let main_class = attribute(attributes, "Main-Class");
+    let unique_main =
+        matches!(main_class, Some("com.mohistmc.MohistMCStart" | "com.mohistmc.MohistMC"));
+    let product_section = section_by_title(sections, "Mohist");
+    if !unique_main && product_section.is_none() {
+        return;
+    }
+    if unique_main {
+        findings.products.push(ProductFinding {
+            signal: Signal {
+                value: product_from_key("mohist"),
+                detector: "mohist-main-class",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 90,
+                correlation_group: "mohist-main-class",
+            },
+            ecosystems: ecosystems_for_key("mohist", false),
+        });
+        if main_class == Some("com.mohistmc.MohistMCStart") {
+            findings.roles.push(Signal {
+                value: ArtifactRole::Launcher,
+                detector: "mohist-main-class",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 95,
+                correlation_group: "mohist-main-class",
+            });
+        }
+    }
+    let Some(product_section) = product_section else {
+        return;
+    };
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key("mohist"),
+            detector: "mohist-manifest-section",
+            source: EvidenceSource::ManifestSection,
+            location: manifest_section_location(
+                path,
+                product_section.name.as_deref(),
+                "Implementation-Title",
+            ),
+            weight: 85,
+            correlation_group: "mohist-product-section",
+        },
+        ecosystems: ecosystems_for_key("mohist", false),
+    });
+    if let Some(version) = attribute(&product_section.attributes, "Implementation-Version") {
+        let version_location = manifest_section_location(
+            path,
+            product_section.name.as_deref(),
+            "Implementation-Version",
+        );
+        add_product_version(
+            "mohist",
+            version,
+            "mohist-manifest-section",
+            EvidenceSource::ManifestSection,
+            version_location.clone(),
+            85,
+            findings,
+        );
+        add_component(
+            "mohist",
+            ServerComponentKind::Implementation,
+            "mohist",
+            "Mohist",
+            Some(version),
+            PathBuf::from("META-INF/MANIFEST.MF"),
+            "mohist-product-section",
+            EvidenceSource::ManifestSection,
+            version_location,
+            85,
+            findings,
+        );
+    }
+
+    add_section_component(
+        path,
+        sections,
+        "mohist",
+        "net.minecraftforge",
+        ServerComponentKind::ModLoader,
+        "forge",
+        "Forge",
+        findings,
+    );
+    add_section_component(
+        path,
+        sections,
+        "mohist",
+        "Spigot",
+        ServerComponentKind::Api,
+        "spigot",
+        "Spigot",
+        findings,
+    );
+    if let Some(mcp) = section_by_title(sections, "MCP") {
+        if let Some(minecraft_version) = attribute(&mcp.attributes, "Specification-Version") {
+            findings.minecraft_versions.push(Signal {
+                value: minecraft_version.to_string(),
+                detector: "mohist-mcp-section",
+                source: EvidenceSource::ManifestSection,
+                location: manifest_section_location(
+                    path,
+                    mcp.name.as_deref(),
+                    "Specification-Version",
+                ),
+                weight: 85,
+                correlation_group: "mohist-mcp-section",
+            });
+        }
+        if let Some(version) = attribute(&mcp.attributes, "Implementation-Version") {
+            add_component(
+                "mohist",
+                ServerComponentKind::Mapping,
+                "mcp",
+                "MCP",
+                Some(version),
+                PathBuf::from("META-INF/MANIFEST.MF"),
+                "mohist-mcp-section",
+                EvidenceSource::ManifestSection,
+                manifest_section_location(path, mcp.name.as_deref(), "Implementation-Version"),
+                85,
+                findings,
+            );
+        }
+    }
+}
+
+fn detect_youer(
+    path: &Path,
+    attributes: &BTreeMap<String, String>,
+    sections: &[super::super::model::ManifestSection],
+    findings: &mut Findings,
+) {
+    let unique_main =
+        attribute(attributes, "Main-Class") == Some("com.mohistmc.launcher.youer.Main");
+    let section = section_by_title(sections, "Youer");
+    if !unique_main && section.is_none() {
+        return;
+    }
+    if unique_main {
+        findings.products.push(ProductFinding {
+            signal: Signal {
+                value: product_from_key("youer"),
+                detector: "youer-main-class",
+                source: EvidenceSource::ManifestMain,
+                location: manifest_location(path, "Main-Class"),
+                weight: 90,
+                correlation_group: "youer-main-class",
+            },
+            ecosystems: ecosystems_for_key("youer", false),
+        });
+        findings.roles.push(Signal {
+            value: ArtifactRole::Launcher,
+            detector: "youer-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 95,
+            correlation_group: "youer-main-class",
+        });
+    }
+    let Some(section) = section else {
+        return;
+    };
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key("youer"),
+            detector: "youer-manifest-section",
+            source: EvidenceSource::ManifestSection,
+            location: manifest_section_location(
+                path,
+                section.name.as_deref(),
+                "Implementation-Title",
+            ),
+            weight: 85,
+            correlation_group: "youer-product-section",
+        },
+        ecosystems: ecosystems_for_key("youer", false),
+    });
+    if let Some(version) = attribute(&section.attributes, "Implementation-Version") {
+        let location =
+            manifest_section_location(path, section.name.as_deref(), "Implementation-Version");
+        add_product_version(
+            "youer",
+            version,
+            "youer-manifest-section",
+            EvidenceSource::ManifestSection,
+            location.clone(),
+            85,
+            findings,
+        );
+        if let Some((minecraft_version, _)) = version.split_once('-') {
+            findings.minecraft_versions.push(Signal {
+                value: minecraft_version.to_string(),
+                detector: "youer-manifest-section",
+                source: EvidenceSource::ManifestSection,
+                location: location.clone(),
+                weight: 85,
+                correlation_group: "youer-product-section",
+            });
+        }
+        add_component(
+            "youer",
+            ServerComponentKind::Implementation,
+            "youer",
+            "Youer",
+            Some(version),
+            PathBuf::from("META-INF/MANIFEST.MF"),
+            "youer-product-section",
+            EvidenceSource::ManifestSection,
+            location,
+            85,
+            findings,
+        );
+    }
+}
+
+fn detect_magma(path: &Path, metadata: Option<&[u8]>, findings: &mut Findings) {
+    let Some(metadata) = metadata else {
+        return;
+    };
+    let Ok(document) = serde_json::from_slice::<MagmaWrapperMetadata>(metadata) else {
+        return;
+    };
+    let Some(magma) = document.magma else {
+        return;
+    };
+    if !magma.group_id.eq_ignore_ascii_case("org.magmafoundation")
+        || !magma.artifact_id.eq_ignore_ascii_case("magma")
+    {
+        return;
+    }
+    let base_location = |field: &str| EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some(WRAPPER_METADATA_ENTRY.to_string()),
+        manifest_section: None,
+        field: Some(field.to_string()),
+    };
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key("magma"),
+            detector: "magma-wrapper-metadata",
+            source: EvidenceSource::JsonField,
+            location: base_location("magma.artifactId"),
+            weight: 85,
+            correlation_group: "magma-wrapper-metadata",
+        },
+        ecosystems: ecosystems_for_key("magma", false),
+    });
+    findings.roles.extend([
+        Signal {
+            value: ArtifactRole::Wrapper,
+            detector: "magma-wrapper-metadata",
+            source: EvidenceSource::JsonField,
+            location: base_location("magma.launcherUrl"),
+            weight: 85,
+            correlation_group: "magma-wrapper-metadata",
+        },
+        Signal {
+            value: ArtifactRole::Bootstrapper,
+            detector: "magma-wrapper-metadata",
+            source: EvidenceSource::JsonField,
+            location: base_location("magma.hasLauncher"),
+            weight: 85,
+            correlation_group: "magma-wrapper-metadata",
+        },
+    ]);
+    add_product_version(
+        "magma",
+        &magma.version,
+        "magma-wrapper-metadata",
+        EvidenceSource::JsonField,
+        base_location("magma.version"),
+        85,
+        findings,
+    );
+    if let Some(minecraft_version) = document.version.filter(|value| !value.trim().is_empty()) {
+        findings.minecraft_versions.push(Signal {
+            value: minecraft_version,
+            detector: "magma-wrapper-metadata",
+            source: EvidenceSource::JsonField,
+            location: base_location("version"),
+            weight: 85,
+            correlation_group: "magma-wrapper-metadata",
+        });
+    }
+    let coordinate = MavenCoordinate {
+        group: magma.group_id,
+        artifact: magma.artifact_id,
+        version: magma.version.clone(),
+        classifier: None,
+        extension: None,
+    };
+    let version = magma.version;
+    findings.components.push(ComponentFinding {
+        product_key: "magma".to_string(),
+        signal: Signal {
+            value: ServerComponent {
+                kind: ServerComponentKind::Implementation,
+                key: "magma".to_string(),
+                name: "Magma".to_string(),
+                version: Some(version.clone()),
+                release_channel: release_channel(&version),
+                coordinate: Some(coordinate),
+                source_path: Some(PathBuf::from(WRAPPER_METADATA_ENTRY)),
+            },
+            detector: "magma-wrapper-metadata",
+            source: EvidenceSource::JsonField,
+            location: base_location("magma.version"),
+            weight: 85,
+            correlation_group: "magma-wrapper-metadata",
+        },
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_section_component(
+    path: &Path,
+    sections: &[super::super::model::ManifestSection],
+    product_key: &str,
+    title: &str,
+    kind: ServerComponentKind,
+    key: &str,
+    name: &str,
+    findings: &mut Findings,
+) {
+    let Some(section) = section_by_title(sections, title) else {
+        return;
+    };
+    let Some(version) = attribute(&section.attributes, "Implementation-Version") else {
+        return;
+    };
+    add_component(
+        product_key,
+        kind,
+        key,
+        name,
+        Some(version),
+        PathBuf::from("META-INF/MANIFEST.MF"),
+        "hybrid-component-section",
+        EvidenceSource::ManifestSection,
+        manifest_section_location(path, section.name.as_deref(), "Implementation-Version"),
+        85,
+        findings,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_component(
+    product_key: &str,
+    kind: ServerComponentKind,
+    key: &str,
+    name: &str,
+    version: Option<&str>,
+    source_path: PathBuf,
+    correlation_group: &'static str,
+    source: EvidenceSource,
+    location: EvidenceLocation,
+    weight: u8,
+    findings: &mut Findings,
+) {
+    findings.components.push(ComponentFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: ServerComponent {
+                kind,
+                key: key.to_string(),
+                name: name.to_string(),
+                version: version.map(str::to_string),
+                release_channel: version.and_then(release_channel),
+                coordinate: None,
+                source_path: Some(source_path),
+            },
+            detector: "hybrid-server-metadata",
+            source,
+            location,
+            weight,
+            correlation_group,
+        },
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_product_version(
+    product_key: &str,
+    version: &str,
+    detector: &'static str,
+    source: EvidenceSource,
+    location: EvidenceLocation,
+    weight: u8,
+    findings: &mut Findings,
+) {
+    findings.product_versions.push(ProductValueFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: version.to_string(),
+            detector,
+            source,
+            location: location.clone(),
+            weight,
+            correlation_group: detector,
+        },
+    });
+    if let Some(channel) = release_channel(version) {
+        findings.release_channels.push(ProductValueFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: channel,
+                detector,
+                source,
+                location,
+                weight,
+                correlation_group: detector,
+            },
+        });
+    }
+}
+
+fn section_by_title<'a>(
+    sections: &'a [super::super::model::ManifestSection],
+    title: &str,
+) -> Option<&'a super::super::model::ManifestSection> {
+    sections.iter().find(|section| {
+        attribute(&section.attributes, "Implementation-Title")
+            .is_some_and(|value| value.eq_ignore_ascii_case(title))
+    })
+}
+
+fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn arclight_minecraft_version(version: &str) -> Option<&str> {
+    let prefix = "arclight-";
+    if version.len() < prefix.len() || !version[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        return None;
+    }
+    version[prefix.len()..]
+        .split_once('-')
+        .map(|(minecraft, _)| minecraft)
+        .filter(|minecraft| !minecraft.is_empty())
+}
+
+#[derive(Deserialize)]
+struct MagmaWrapperMetadata {
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    magma: Option<MagmaMetadata>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MagmaMetadata {
+    group_id: String,
+    artifact_id: String,
+    version: String,
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -3,6 +3,7 @@ mod forge;
 mod generic;
 mod hybrid;
 mod limbo;
+mod manifest_attributes;
 mod paperclip;
 mod proxy;
 mod sponge;
@@ -42,14 +43,23 @@ const PRODUCTS: &[ProductDefinition] = &[
         "pufferfish",
         "Pufferfish",
         PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
         "gg.pufferfish.pufferfish",
         "pufferfish-api",
     ),
-    ProductDefinition::new("legacy-fabric", "Legacy Fabric", LEGACY_FABRIC_ECOSYSTEMS, "", ""),
+    ProductDefinition::new(
+        "legacy-fabric",
+        "Legacy Fabric",
+        LEGACY_FABRIC_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
     ProductDefinition::new(
         "divinemc",
         "DivineMC",
         PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
         "org.bxteam.divinemc",
         "divinemc-api",
     ),
@@ -57,6 +67,7 @@ const PRODUCTS: &[ProductDefinition] = &[
         "aspaper",
         "AsPaper",
         PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
         "com.infernalsuite.asp",
         "aspaper-api",
     ),
@@ -64,6 +75,7 @@ const PRODUCTS: &[ProductDefinition] = &[
         "purpur",
         "Purpur",
         PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
         "org.purpurmc.purpur",
         "purpur-api",
     ),
@@ -71,6 +83,7 @@ const PRODUCTS: &[ProductDefinition] = &[
         "canvas",
         "Canvas",
         PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
         "io.canvasmc.canvas",
         "canvas-api",
     ),
@@ -78,30 +91,164 @@ const PRODUCTS: &[ProductDefinition] = &[
         "leaves",
         "Leaves",
         PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
         "org.leavesmc.leaves",
         "leaves-api",
     ),
-    ProductDefinition::new("vanilla", "Vanilla", VANILLA_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("neoforge", "NeoForge", NEOFORGE_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("fabric", "Fabric", FABRIC_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("spigot", "Spigot", BUKKIT_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("paper", "Paper", PAPER_ECOSYSTEMS, "io.papermc.paper", "paper-api"),
-    ProductDefinition::new("folia", "Folia", PAPER_ECOSYSTEMS, "dev.folia", "folia-api"),
-    ProductDefinition::new("pluto", "Pluto", PAPER_ECOSYSTEMS, "dev.yive.pluto", "pluto-api"),
-    ProductDefinition::new("forge", "Forge", FORGE_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("leaf", "Leaf", PAPER_ECOSYSTEMS, "cn.dreeam.leaf", "leaf-api"),
-    ProductDefinition::new("arclight", "Arclight", BUKKIT_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("mohist", "Mohist", MOHIST_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("youer", "Youer", NEOFORGE_HYBRID_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("magma", "Magma", NEOFORGE_HYBRID_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("velocity-ctd", "Velocity-CTD", VELOCITY_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("velocity", "Velocity", VELOCITY_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("bungeecord", "BungeeCord", BUNGEE_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("waterfall", "Waterfall", BUNGEE_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("spongevanilla", "SpongeVanilla", SPONGE_VANILLA_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("limbo", "Limbo", NO_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("nanolimbo", "NanoLimbo", NO_ECOSYSTEMS, "", ""),
-    ProductDefinition::new("craftbukkit", "CraftBukkit", BUKKIT_ECOSYSTEMS, "", ""),
+    ProductDefinition::new(
+        "vanilla",
+        "Vanilla",
+        VANILLA_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "neoforge",
+        "NeoForge",
+        NEOFORGE_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "fabric",
+        "Fabric",
+        FABRIC_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "spigot",
+        "Spigot",
+        BUKKIT_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "paper",
+        "Paper",
+        PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "io.papermc.paper",
+        "paper-api",
+    ),
+    ProductDefinition::new(
+        "folia",
+        "Folia",
+        PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "dev.folia",
+        "folia-api",
+    ),
+    ProductDefinition::new(
+        "pluto",
+        "Pluto",
+        PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "dev.yive.pluto",
+        "pluto-api",
+    ),
+    ProductDefinition::new(
+        "forge",
+        "Forge",
+        FORGE_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "leaf",
+        "Leaf",
+        PAPER_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "cn.dreeam.leaf",
+        "leaf-api",
+    ),
+    ProductDefinition::new(
+        "arclight",
+        "Arclight",
+        BUKKIT_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "mohist",
+        "Mohist",
+        MOHIST_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "youer",
+        "Youer",
+        NEOFORGE_HYBRID_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "magma",
+        "Magma",
+        NEOFORGE_HYBRID_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "velocity-ctd",
+        "Velocity-CTD",
+        VELOCITY_ECOSYSTEMS,
+        ServerCategory::Proxy,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "velocity",
+        "Velocity",
+        VELOCITY_ECOSYSTEMS,
+        ServerCategory::Proxy,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "bungeecord",
+        "BungeeCord",
+        BUNGEE_ECOSYSTEMS,
+        ServerCategory::Proxy,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "waterfall",
+        "Waterfall",
+        BUNGEE_ECOSYSTEMS,
+        ServerCategory::Proxy,
+        "",
+        "",
+    ),
+    ProductDefinition::new(
+        "spongevanilla",
+        "SpongeVanilla",
+        SPONGE_VANILLA_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
+    ProductDefinition::new("limbo", "Limbo", NO_ECOSYSTEMS, ServerCategory::Limbo, "", ""),
+    ProductDefinition::new("nanolimbo", "NanoLimbo", NO_ECOSYSTEMS, ServerCategory::Limbo, "", ""),
+    ProductDefinition::new(
+        "craftbukkit",
+        "CraftBukkit",
+        BUKKIT_ECOSYSTEMS,
+        ServerCategory::JavaGameServer,
+        "",
+        "",
+    ),
 ];
 
 #[derive(Debug, Clone, Copy)]
@@ -109,6 +256,7 @@ struct ProductDefinition {
     key: &'static str,
     display_name: &'static str,
     ecosystems: &'static [ServerEcosystem],
+    category: ServerCategory,
     api_group: Option<&'static str>,
     api_artifact: Option<&'static str>,
 }
@@ -118,6 +266,7 @@ impl ProductDefinition {
         key: &'static str,
         display_name: &'static str,
         ecosystems: &'static [ServerEcosystem],
+        category: ServerCategory,
         api_group: &'static str,
         api_artifact: &'static str,
     ) -> Self {
@@ -125,6 +274,7 @@ impl ProductDefinition {
             key,
             display_name,
             ecosystems,
+            category,
             api_group: if api_group.is_empty() {
                 None
             } else {
@@ -302,7 +452,8 @@ fn finalize(
         .collect::<Vec<_>>();
     category_claims.extend(findings.products.iter().map(|finding| {
         let signal = Signal {
-            value: category_for_key(&finding.signal.value.key),
+            value: product_definition(&finding.signal.value.key)
+                .map_or(ServerCategory::JavaGameServer, |definition| definition.category),
             detector: finding.signal.detector,
             source: finding.signal.source,
             location: finding.signal.location.clone(),
@@ -312,7 +463,7 @@ fn finalize(
         push_claim(
             &signal,
             DetectionTarget::ServerCategory,
-            "java_game_server".to_string(),
+            category_name(signal.value).to_string(),
             evidence,
         )
     }));
@@ -749,14 +900,6 @@ fn product_definition(key: &str) -> Option<&'static ProductDefinition> {
     PRODUCTS.iter().find(|definition| definition.key == key)
 }
 
-fn category_for_key(key: &str) -> ServerCategory {
-    match key {
-        "velocity" | "velocity-ctd" | "bungeecord" | "waterfall" => ServerCategory::Proxy,
-        "limbo" | "nanolimbo" => ServerCategory::Limbo,
-        _ => ServerCategory::JavaGameServer,
-    }
-}
-
 fn is_valid_product_key(key: &str) -> bool {
     !key.is_empty()
         && key.len() <= 64
@@ -851,8 +994,26 @@ pub(super) fn api_component(
 
 #[cfg(test)]
 mod tests {
-    use super::{contains_key_with_boundaries, release_channel, target_product_key};
-    use crate::provisioning::server_inspection::ReleaseChannel;
+    use super::{
+        contains_key_with_boundaries, product_definition, release_channel, target_product_key,
+    };
+    use crate::provisioning::server_inspection::{ReleaseChannel, ServerCategory};
+
+    #[test]
+    fn product_definitions_own_their_server_categories() {
+        assert_eq!(
+            product_definition("velocity").map(|definition| definition.category),
+            Some(ServerCategory::Proxy)
+        );
+        assert_eq!(
+            product_definition("nanolimbo").map(|definition| definition.category),
+            Some(ServerCategory::Limbo)
+        );
+        assert_eq!(
+            product_definition("paper").map(|definition| definition.category),
+            Some(ServerCategory::JavaGameServer)
+        );
+    }
 
     #[test]
     fn filename_boundaries_do_not_treat_aspaper_as_paper() {

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -1,6 +1,11 @@
 mod fabric;
 mod forge;
+mod generic;
+mod hybrid;
+mod limbo;
 mod paperclip;
+mod proxy;
+mod sponge;
 mod vanilla;
 
 use std::path::{Path, PathBuf};
@@ -23,6 +28,14 @@ const FABRIC_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Fabric];
 const LEGACY_FABRIC_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::LegacyFabric];
 const FORGE_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Forge];
 const NEOFORGE_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::NeoForge];
+const BUNGEE_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Bungee];
+const VELOCITY_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Velocity];
+const SPONGE_VANILLA_ECOSYSTEMS: &[ServerEcosystem] =
+    &[ServerEcosystem::Sponge, ServerEcosystem::Vanilla];
+const MOHIST_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Bukkit, ServerEcosystem::Forge];
+const NEOFORGE_HYBRID_ECOSYSTEMS: &[ServerEcosystem] =
+    &[ServerEcosystem::Bukkit, ServerEcosystem::NeoForge];
+const NO_ECOSYSTEMS: &[ServerEcosystem] = &[];
 
 const PRODUCTS: &[ProductDefinition] = &[
     ProductDefinition::new(
@@ -77,6 +90,18 @@ const PRODUCTS: &[ProductDefinition] = &[
     ProductDefinition::new("pluto", "Pluto", PAPER_ECOSYSTEMS, "dev.yive.pluto", "pluto-api"),
     ProductDefinition::new("forge", "Forge", FORGE_ECOSYSTEMS, "", ""),
     ProductDefinition::new("leaf", "Leaf", PAPER_ECOSYSTEMS, "cn.dreeam.leaf", "leaf-api"),
+    ProductDefinition::new("arclight", "Arclight", BUKKIT_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("mohist", "Mohist", MOHIST_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("youer", "Youer", NEOFORGE_HYBRID_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("magma", "Magma", NEOFORGE_HYBRID_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("velocity-ctd", "Velocity-CTD", VELOCITY_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("velocity", "Velocity", VELOCITY_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("bungeecord", "BungeeCord", BUNGEE_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("waterfall", "Waterfall", BUNGEE_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("spongevanilla", "SpongeVanilla", SPONGE_VANILLA_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("limbo", "Limbo", NO_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("nanolimbo", "NanoLimbo", NO_ECOSYSTEMS, "", ""),
+    ProductDefinition::new("craftbukkit", "CraftBukkit", BUKKIT_ECOSYSTEMS, "", ""),
 ];
 
 #[derive(Debug, Clone, Copy)]
@@ -146,6 +171,7 @@ pub(super) struct ComponentFinding {
 pub(super) struct Findings {
     pub(super) products: Vec<ProductFinding>,
     pub(super) categories: Vec<Signal<ServerCategory>>,
+    pub(super) ecosystems: Vec<Signal<ServerEcosystem>>,
     pub(super) minecraft_versions: Vec<Signal<String>>,
     pub(super) product_versions: Vec<ProductValueFinding<String>>,
     pub(super) release_channels: Vec<ProductValueFinding<ReleaseChannel>>,
@@ -185,6 +211,11 @@ pub(super) fn detect_jar(
     detect_filename(path, &mut findings);
     fabric::detect(path, archive, None, &mut findings);
     forge::detect_archive(path, None, archive, &mut findings);
+    hybrid::detect(path, archive, &mut findings);
+    proxy::detect(path, archive, &mut findings);
+    sponge::detect(path, archive, &mut findings);
+    limbo::detect(path, archive, &mut findings);
+    generic::detect(path, archive, None, &mut findings);
     paperclip::detect(path, artifact, archive, &mut findings);
     vanilla::detect(path, artifact, minecraft, &mut findings);
     finalize(path, findings, minecraft, java_major, evidence)
@@ -209,6 +240,16 @@ pub(super) fn detect_directory(
             &archive_path,
             Some((path, &root_archive.relative_path)),
             &root_archive.metadata,
+            &mut findings,
+        );
+        hybrid::detect(&archive_path, &root_archive.metadata, &mut findings);
+        proxy::detect(&archive_path, &root_archive.metadata, &mut findings);
+        sponge::detect(&archive_path, &root_archive.metadata, &mut findings);
+        limbo::detect(&archive_path, &root_archive.metadata, &mut findings);
+        generic::detect(
+            &archive_path,
+            &root_archive.metadata,
+            Some((path, &root_archive.relative_path)),
             &mut findings,
         );
     }
@@ -261,7 +302,7 @@ fn finalize(
         .collect::<Vec<_>>();
     category_claims.extend(findings.products.iter().map(|finding| {
         let signal = Signal {
-            value: ServerCategory::JavaGameServer,
+            value: category_for_key(&finding.signal.value.key),
             detector: finding.signal.detector,
             source: finding.signal.source,
             location: finding.signal.location.clone(),
@@ -292,33 +333,46 @@ fn finalize(
         evidence,
     );
 
-    let ecosystems = selected_key.map_or_else(Vec::new, |selected_key| {
-        let mut claims = Vec::new();
-        for finding in findings
-            .products
+    let ecosystems = {
+        let mut claims = findings
+            .ecosystems
             .iter()
-            .filter(|finding| finding.signal.value.key == selected_key)
-        {
-            for ecosystem in &finding.ecosystems {
-                let signal = Signal {
-                    value: ecosystem.clone(),
-                    detector: finding.signal.detector,
-                    source: finding.signal.source,
-                    location: finding.signal.location.clone(),
-                    weight: finding.signal.weight,
-                    correlation_group: finding.signal.correlation_group,
-                };
-                let candidate = ecosystem_name(&signal.value);
-                claims.push(push_claim(
-                    &signal,
+            .map(|signal| {
+                push_claim(
+                    signal,
                     DetectionTarget::ServerEcosystem,
-                    candidate,
+                    ecosystem_name(&signal.value),
                     evidence,
-                ));
+                )
+            })
+            .collect::<Vec<_>>();
+        if let Some(selected_key) = selected_key {
+            for finding in findings
+                .products
+                .iter()
+                .filter(|finding| finding.signal.value.key == selected_key)
+            {
+                for ecosystem in &finding.ecosystems {
+                    let signal = Signal {
+                        value: ecosystem.clone(),
+                        detector: finding.signal.detector,
+                        source: finding.signal.source,
+                        location: finding.signal.location.clone(),
+                        weight: finding.signal.weight,
+                        correlation_group: finding.signal.correlation_group,
+                    };
+                    let candidate = ecosystem_name(&signal.value);
+                    claims.push(push_claim(
+                        &signal,
+                        DetectionTarget::ServerEcosystem,
+                        candidate,
+                        evidence,
+                    ));
+                }
             }
         }
         resolve_attributed(claims)
-    });
+    };
 
     let components = resolve_attributed(
         findings
@@ -610,6 +664,16 @@ pub(super) fn release_channel(version: &str) -> Option<ReleaseChannel> {
     let version = version.to_ascii_lowercase();
     if has_version_label(&version, "snapshot") {
         Some(ReleaseChannel::Snapshot)
+    } else if version
+        .split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|token| {
+            token == "rc"
+                || token.strip_prefix("rc").is_some_and(|suffix| {
+                    !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit())
+                })
+        })
+    {
+        Some(ReleaseChannel::ReleaseCandidate)
     } else if has_version_label(&version, "alpha") {
         Some(ReleaseChannel::Alpha)
     } else if has_version_label(&version, "beta") {
@@ -659,6 +723,19 @@ pub(super) fn manifest_location(path: &Path, field: &str) -> EvidenceLocation {
     }
 }
 
+pub(super) fn manifest_section_location(
+    path: &Path,
+    section: Option<&str>,
+    field: &str,
+) -> EvidenceLocation {
+    EvidenceLocation {
+        path: path.to_path_buf(),
+        archive_entry: Some("META-INF/MANIFEST.MF".to_string()),
+        manifest_section: section.map(str::to_string),
+        field: Some(field.to_string()),
+    }
+}
+
 pub(super) fn version_json_location(path: &Path, field: &str) -> EvidenceLocation {
     EvidenceLocation {
         path: path.to_path_buf(),
@@ -670,6 +747,14 @@ pub(super) fn version_json_location(path: &Path, field: &str) -> EvidenceLocatio
 
 fn product_definition(key: &str) -> Option<&'static ProductDefinition> {
     PRODUCTS.iter().find(|definition| definition.key == key)
+}
+
+fn category_for_key(key: &str) -> ServerCategory {
+    match key {
+        "velocity" | "velocity-ctd" | "bungeecord" | "waterfall" => ServerCategory::Proxy,
+        "limbo" | "nanolimbo" => ServerCategory::Limbo,
+        _ => ServerCategory::JavaGameServer,
+    }
 }
 
 fn is_valid_product_key(key: &str) -> bool {
@@ -723,6 +808,7 @@ fn category_name(category: ServerCategory) -> &'static str {
 fn release_channel_name(channel: ReleaseChannel) -> &'static str {
     match channel {
         ReleaseChannel::Stable => "stable",
+        ReleaseChannel::ReleaseCandidate => "release_candidate",
         ReleaseChannel::Beta => "beta",
         ReleaseChannel::Alpha => "alpha",
         ReleaseChannel::Snapshot => "snapshot",
@@ -785,6 +871,8 @@ mod tests {
     #[test]
     fn release_channel_requires_a_version_label_boundary() {
         assert_eq!(release_channel("26.2.build.1-beta2"), Some(ReleaseChannel::Beta));
+        assert_eq!(release_channel("20.0.0-RC2673"), Some(ReleaseChannel::ReleaseCandidate));
+        assert_eq!(release_channel("20.0.0-RC"), Some(ReleaseChannel::ReleaseCandidate));
         assert_eq!(release_channel("26.2-unstable"), None);
     }
 }

--- a/crates/core/src/provisioning/server_inspection/detectors/limbo.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/limbo.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use super::super::archive::ArchiveMetadata;
 use super::super::formats::manifest;
 use super::super::model::{EvidenceSource, ServerCategory, ServerComponent, ServerComponentKind};
+use super::manifest_attributes::attribute;
 use super::{
     ecosystems_for_key, manifest_location, product_from_key, release_channel, ComponentFinding,
     Findings, ProductFinding, ProductValueFinding, Signal,
@@ -91,12 +91,4 @@ pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Find
             correlation_group: "limbo-manifest-version",
         },
     });
-}
-
-fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
-    attributes
-        .iter()
-        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.as_str())
-        .filter(|value| !value.trim().is_empty())
 }

--- a/crates/core/src/provisioning/server_inspection/detectors/limbo.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/limbo.rs
@@ -1,0 +1,102 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::super::archive::ArchiveMetadata;
+use super::super::formats::manifest;
+use super::super::model::{EvidenceSource, ServerCategory, ServerComponent, ServerComponentKind};
+use super::{
+    ecosystems_for_key, manifest_location, product_from_key, release_channel, ComponentFinding,
+    Findings, ProductFinding, ProductValueFinding, Signal,
+};
+
+pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Findings) {
+    let Some(manifest_bytes) = archive.manifest.as_deref() else {
+        return;
+    };
+    let parsed = manifest::parse(manifest_bytes);
+    let attributes = &parsed.summary.main_attributes;
+    let (product_key, version_field) = match attribute(attributes, "Main-Class") {
+        Some("com.loohp.limbo.Limbo") => ("limbo", Some("Limbo-Version")),
+        Some("ua.nanit.limbo.NanoLimbo") => ("nanolimbo", None),
+        _ => return,
+    };
+
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key(product_key),
+            detector: "limbo-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 90,
+            correlation_group: "limbo-main-class",
+        },
+        ecosystems: ecosystems_for_key(product_key, false),
+    });
+    findings.categories.push(Signal {
+        value: ServerCategory::Limbo,
+        detector: "limbo-main-class",
+        source: EvidenceSource::ManifestMain,
+        location: manifest_location(path, "Main-Class"),
+        weight: 90,
+        correlation_group: "limbo-main-class",
+    });
+
+    let Some(version_field) = version_field else {
+        return;
+    };
+    let Some(version) = attribute(attributes, version_field) else {
+        return;
+    };
+    let location = manifest_location(path, version_field);
+    findings.product_versions.push(ProductValueFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: version.to_string(),
+            detector: "limbo-manifest-version",
+            source: EvidenceSource::ManifestMain,
+            location: location.clone(),
+            weight: 90,
+            correlation_group: "limbo-manifest-version",
+        },
+    });
+    if let Some(channel) = release_channel(version) {
+        findings.release_channels.push(ProductValueFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: channel,
+                detector: "limbo-manifest-version",
+                source: EvidenceSource::ManifestMain,
+                location: location.clone(),
+                weight: 90,
+                correlation_group: "limbo-manifest-version",
+            },
+        });
+    }
+    findings.components.push(ComponentFinding {
+        product_key: product_key.to_string(),
+        signal: Signal {
+            value: ServerComponent {
+                kind: ServerComponentKind::Implementation,
+                key: product_key.to_string(),
+                name: product_from_key(product_key).display_name,
+                version: Some(version.to_string()),
+                release_channel: release_channel(version),
+                coordinate: None,
+                source_path: Some(PathBuf::from("META-INF/MANIFEST.MF")),
+            },
+            detector: "limbo-manifest-version",
+            source: EvidenceSource::ManifestMain,
+            location,
+            weight: 90,
+            correlation_group: "limbo-manifest-version",
+        },
+    });
+}
+
+fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/manifest_attributes.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/manifest_attributes.rs
@@ -1,0 +1,59 @@
+use std::collections::BTreeMap;
+
+use super::super::model::ManifestSection;
+
+pub(super) fn attribute<'a>(
+    attributes: &'a BTreeMap<String, String>,
+    key: &str,
+) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}
+
+pub(super) fn section_by_title<'a>(
+    sections: &'a [ManifestSection],
+    title: &str,
+) -> Option<&'a ManifestSection> {
+    sections.iter().find(|section| {
+        attribute(&section.attributes, "Implementation-Title")
+            .is_some_and(|value| value.eq_ignore_ascii_case(title))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::{attribute, section_by_title};
+    use crate::provisioning::server_inspection::ManifestSection;
+
+    #[test]
+    fn looks_up_non_empty_attributes_case_insensitively() {
+        let attributes = BTreeMap::from([
+            ("Implementation-Title".to_string(), "Example".to_string()),
+            ("Empty".to_string(), "  ".to_string()),
+        ]);
+
+        assert_eq!(attribute(&attributes, "implementation-title"), Some("Example"));
+        assert_eq!(attribute(&attributes, "empty"), None);
+    }
+
+    #[test]
+    fn finds_sections_by_implementation_title() {
+        let section = ManifestSection {
+            name: Some("example/".to_string()),
+            attributes: BTreeMap::from([(
+                "Implementation-Title".to_string(),
+                "Example".to_string(),
+            )]),
+        };
+
+        assert_eq!(
+            section_by_title(&[section], "example").and_then(|value| value.name.as_deref()),
+            Some("example/")
+        );
+    }
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/proxy.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/proxy.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use super::super::archive::ArchiveMetadata;
@@ -6,6 +5,7 @@ use super::super::formats::manifest;
 use super::super::model::{
     EvidenceSource, ServerCategory, ServerComponent, ServerComponentKind, ServerEcosystem,
 };
+use super::manifest_attributes::attribute;
 use super::{
     ecosystems_for_key, manifest_location, product_from_key, release_channel, ComponentFinding,
     Findings, ProductFinding, ProductValueFinding, Signal,
@@ -141,12 +141,4 @@ pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Find
             correlation_group: "proxy-java-version",
         });
     }
-}
-
-fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
-    attributes
-        .iter()
-        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.as_str())
-        .filter(|value| !value.trim().is_empty())
 }

--- a/crates/core/src/provisioning/server_inspection/detectors/proxy.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/proxy.rs
@@ -1,0 +1,152 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::super::archive::ArchiveMetadata;
+use super::super::formats::manifest;
+use super::super::model::{
+    EvidenceSource, ServerCategory, ServerComponent, ServerComponentKind, ServerEcosystem,
+};
+use super::{
+    ecosystems_for_key, manifest_location, product_from_key, release_channel, ComponentFinding,
+    Findings, ProductFinding, ProductValueFinding, Signal,
+};
+
+const VELOCITY_MAIN: &str = "com.velocitypowered.proxy.Velocity";
+const BUNGEE_MAIN: &str = "net.md_5.bungee.Bootstrap";
+
+pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Findings) {
+    let Some(manifest_bytes) = archive.manifest.as_deref() else {
+        return;
+    };
+    let parsed = manifest::parse(manifest_bytes);
+    let attributes = &parsed.summary.main_attributes;
+    let main_class = attribute(attributes, "Main-Class");
+
+    let shared_ecosystem = match main_class {
+        Some(VELOCITY_MAIN) => Some(ServerEcosystem::Velocity),
+        Some(BUNGEE_MAIN) => Some(ServerEcosystem::Bungee),
+        _ => None,
+    };
+    if let Some(ecosystem) = shared_ecosystem {
+        findings.categories.push(Signal {
+            value: ServerCategory::Proxy,
+            detector: "proxy-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 90,
+            correlation_group: "proxy-main-class",
+        });
+        findings.ecosystems.push(Signal {
+            value: ecosystem,
+            detector: "proxy-main-class",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 85,
+            correlation_group: "proxy-main-class",
+        });
+    }
+
+    let title = attribute(attributes, "Implementation-Title");
+    let implementation_version = attribute(attributes, "Implementation-Version");
+    let product_key = match title {
+        Some(title) if title.eq_ignore_ascii_case("Velocity-CTD") => Some("velocity-ctd"),
+        Some(title) if title.eq_ignore_ascii_case("Velocity") => Some("velocity"),
+        _ => implementation_version.and_then(|version| {
+            let version = version.to_ascii_lowercase();
+            if version.contains("waterfall-bootstrap") {
+                Some("waterfall")
+            } else if version.contains("bungeecord-bootstrap") {
+                Some("bungeecord")
+            } else {
+                None
+            }
+        }),
+    };
+    let Some(product_key) = product_key else {
+        return;
+    };
+    let identity_field = if title.is_some() {
+        "Implementation-Title"
+    } else {
+        "Implementation-Version"
+    };
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key(product_key),
+            detector: "proxy-manifest-product",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, identity_field),
+            weight: 90,
+            correlation_group: "proxy-product-manifest",
+        },
+        ecosystems: ecosystems_for_key(product_key, false),
+    });
+
+    if let Some(version) = implementation_version {
+        let location = manifest_location(path, "Implementation-Version");
+        findings.product_versions.push(ProductValueFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: version.to_string(),
+                detector: "proxy-manifest-version",
+                source: EvidenceSource::ManifestMain,
+                location: location.clone(),
+                weight: 90,
+                correlation_group: "proxy-product-manifest",
+            },
+        });
+        if let Some(channel) = release_channel(version) {
+            findings.release_channels.push(ProductValueFinding {
+                product_key: product_key.to_string(),
+                signal: Signal {
+                    value: channel,
+                    detector: "proxy-manifest-version",
+                    source: EvidenceSource::ManifestMain,
+                    location: location.clone(),
+                    weight: 90,
+                    correlation_group: "proxy-product-manifest",
+                },
+            });
+        }
+        findings.components.push(ComponentFinding {
+            product_key: product_key.to_string(),
+            signal: Signal {
+                value: ServerComponent {
+                    kind: ServerComponentKind::Implementation,
+                    key: product_key.to_string(),
+                    name: product_from_key(product_key).display_name,
+                    version: Some(version.to_string()),
+                    release_channel: release_channel(version),
+                    coordinate: None,
+                    source_path: Some(PathBuf::from("META-INF/MANIFEST.MF")),
+                },
+                detector: "proxy-manifest-version",
+                source: EvidenceSource::ManifestMain,
+                location,
+                weight: 90,
+                correlation_group: "proxy-product-manifest",
+            },
+        });
+    }
+    if let Some(java_major) = attribute(attributes, "Java-Version")
+        .and_then(|value| value.parse::<u16>().ok())
+        .filter(|value| *value > 0)
+    {
+        findings.java_majors.push(Signal {
+            value: java_major,
+            detector: "proxy-java-version",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Java-Version"),
+            weight: 90,
+            correlation_group: "proxy-java-version",
+        });
+    }
+}
+
+fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/sponge.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/sponge.rs
@@ -1,0 +1,134 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::super::archive::ArchiveMetadata;
+use super::super::formats::manifest;
+use super::super::model::{ArtifactRole, EvidenceSource, ServerComponent, ServerComponentKind};
+use super::{
+    ecosystems_for_key, manifest_location, product_from_key, release_channel, ComponentFinding,
+    Findings, ProductFinding, ProductValueFinding, Signal,
+};
+
+const SPONGE_VANILLA_INSTALLER_MAIN: &str = "org.spongepowered.vanilla.installer.InstallerMain";
+
+pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Findings) {
+    let Some(manifest_bytes) = archive.manifest.as_deref() else {
+        return;
+    };
+    let parsed = manifest::parse(manifest_bytes);
+    let attributes = &parsed.summary.main_attributes;
+    let title = attribute(attributes, "Implementation-Title")
+        .or_else(|| attribute(attributes, "Specification-Title"));
+    let title_matches = title.is_some_and(|title| title.eq_ignore_ascii_case("SpongeVanilla"));
+    let installer_main = attribute(attributes, "Main-Class") == Some(SPONGE_VANILLA_INSTALLER_MAIN);
+    if !title_matches && !installer_main {
+        return;
+    }
+
+    findings.products.push(ProductFinding {
+        signal: Signal {
+            value: product_from_key("spongevanilla"),
+            detector: "spongevanilla-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(
+                path,
+                if title_matches {
+                    "Implementation-Title"
+                } else {
+                    "Main-Class"
+                },
+            ),
+            weight: if title_matches { 90 } else { 85 },
+            correlation_group: "spongevanilla-manifest",
+        },
+        ecosystems: ecosystems_for_key("spongevanilla", false),
+    });
+    if installer_main {
+        findings.roles.push(Signal {
+            value: ArtifactRole::Installer,
+            detector: "spongevanilla-installer-main",
+            source: EvidenceSource::ManifestMain,
+            location: manifest_location(path, "Main-Class"),
+            weight: 98,
+            correlation_group: "spongevanilla-manifest",
+        });
+    }
+
+    let Some(version) = attribute(attributes, "Implementation-Version") else {
+        return;
+    };
+    let version_location = manifest_location(path, "Implementation-Version");
+    findings.product_versions.push(ProductValueFinding {
+        product_key: "spongevanilla".to_string(),
+        signal: Signal {
+            value: version.to_string(),
+            detector: "spongevanilla-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: version_location.clone(),
+            weight: 90,
+            correlation_group: "spongevanilla-manifest",
+        },
+    });
+    if let Some(channel) = release_channel(version) {
+        findings.release_channels.push(ProductValueFinding {
+            product_key: "spongevanilla".to_string(),
+            signal: Signal {
+                value: channel,
+                detector: "spongevanilla-manifest",
+                source: EvidenceSource::ManifestMain,
+                location: version_location.clone(),
+                weight: 90,
+                correlation_group: "spongevanilla-manifest",
+            },
+        });
+    }
+    if let Some((minecraft_version, _)) = version.split_once('-') {
+        findings.minecraft_versions.push(Signal {
+            value: minecraft_version.to_string(),
+            detector: "spongevanilla-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: version_location.clone(),
+            weight: 90,
+            correlation_group: "spongevanilla-manifest",
+        });
+    }
+    findings.components.push(ComponentFinding {
+        product_key: "spongevanilla".to_string(),
+        signal: Signal {
+            value: ServerComponent {
+                kind: if installer_main {
+                    ServerComponentKind::Installer
+                } else {
+                    ServerComponentKind::Implementation
+                },
+                key: if installer_main {
+                    "spongevanilla-installer".to_string()
+                } else {
+                    "spongevanilla".to_string()
+                },
+                name: if installer_main {
+                    "SpongeVanilla Installer".to_string()
+                } else {
+                    "SpongeVanilla".to_string()
+                },
+                version: Some(version.to_string()),
+                release_channel: release_channel(version),
+                coordinate: None,
+                source_path: Some(PathBuf::from("META-INF/MANIFEST.MF")),
+            },
+            detector: "spongevanilla-manifest",
+            source: EvidenceSource::ManifestMain,
+            location: version_location,
+            weight: 90,
+            correlation_group: "spongevanilla-manifest",
+        },
+    });
+}
+
+fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+}

--- a/crates/core/src/provisioning/server_inspection/detectors/sponge.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/sponge.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use super::super::archive::ArchiveMetadata;
 use super::super::formats::manifest;
 use super::super::model::{ArtifactRole, EvidenceSource, ServerComponent, ServerComponentKind};
+use super::manifest_attributes::attribute;
 use super::{
     ecosystems_for_key, manifest_location, product_from_key, release_channel, ComponentFinding,
     Findings, ProductFinding, ProductValueFinding, Signal,
@@ -123,12 +123,4 @@ pub(super) fn detect(path: &Path, archive: &ArchiveMetadata, findings: &mut Find
             correlation_group: "spongevanilla-manifest",
         },
     });
-}
-
-fn attribute<'a>(attributes: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
-    attributes
-        .iter()
-        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.as_str())
-        .filter(|value| !value.trim().is_empty())
 }

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -736,6 +736,349 @@ mod tests {
         archive.finish().expect("finish test JAR");
     }
 
+    fn product_key(report: &super::ServerInspectionReport) -> Option<&str> {
+        report
+            .identity
+            .implementation
+            .value
+            .as_ref()
+            .map(|product| product.key.as_str())
+    }
+
+    #[test]
+    fn distinguishes_proxy_forks_that_share_main_classes() {
+        let cases = [
+            (
+                "velocity.jar",
+                "Implementation-Title: Velocity\r\n",
+                "4.1.0-SNAPSHOT (git-e11584ba-b13)",
+                "com.velocitypowered.proxy.Velocity",
+                "velocity",
+                ServerEcosystem::Velocity,
+            ),
+            (
+                "velocity-ctd.jar",
+                "Implementation-Title: Velocity-CTD\r\n",
+                "4.1.0-SNAPSHOT-git-6fd8e660",
+                "com.velocitypowered.proxy.Velocity",
+                "velocity-ctd",
+                ServerEcosystem::Velocity,
+            ),
+            (
+                "bungeecord.jar",
+                "",
+                "git:BungeeCord-Bootstrap:26.1-R0.1-SNAPSHOT:2e72932:2085",
+                "net.md_5.bungee.Bootstrap",
+                "bungeecord",
+                ServerEcosystem::Bungee,
+            ),
+            (
+                "waterfall.jar",
+                "",
+                "git:Waterfall-Bootstrap:26.1-R0.1-SNAPSHOT:4bc2b02:615",
+                "net.md_5.bungee.Bootstrap",
+                "waterfall",
+                ServerEcosystem::Bungee,
+            ),
+        ];
+
+        for (filename, title, version, main_class, expected_key, ecosystem) in cases {
+            let path = temporary_path(filename);
+            let manifest = format!(
+                "Manifest-Version: 1.0\r\n{title}Implementation-Version: {version}\r\nJava-Version: 11\r\nMain-Class: {main_class}\r\n\r\n"
+            );
+            write_test_jar_entries(&path, &[("META-INF/MANIFEST.MF", &manifest)]);
+
+            let report = inspect_server_artifact(&path, &InspectionOptions::default())
+                .expect("inspect proxy fixture");
+            fs::remove_file(&path).expect("remove proxy fixture");
+
+            assert_eq!(product_key(&report), Some(expected_key));
+            assert_eq!(report.identity.category.value, Some(ServerCategory::Proxy));
+            assert_eq!(report.identity.version.value.as_deref(), Some(version));
+            assert_eq!(report.identity.release_channel.value, Some(ReleaseChannel::Snapshot));
+            assert!(report
+                .identity
+                .ecosystems
+                .iter()
+                .any(|candidate| candidate.value == ecosystem));
+            assert_eq!(report.java.required_major.value, Some(11));
+        }
+    }
+
+    #[test]
+    fn shared_proxy_main_class_does_not_choose_a_specific_product() {
+        let path = temporary_path("server.jar");
+        write_test_jar_entries(
+            &path,
+            &[("META-INF/MANIFEST.MF", "Main-Class: com.velocitypowered.proxy.Velocity\r\n\r\n")],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect product-neutral proxy fixture");
+        fs::remove_file(&path).expect("remove proxy fixture");
+
+        assert!(report.identity.implementation.value.is_none());
+        assert_eq!(report.identity.category.value, Some(ServerCategory::Proxy));
+        assert_eq!(report.identity.ecosystems.len(), 1);
+        assert_eq!(report.identity.ecosystems[0].value, ServerEcosystem::Velocity);
+    }
+
+    #[test]
+    fn detects_arclight_and_preserves_its_loader_ecosystem() {
+        let path = temporary_path("arclight.jar");
+        write_test_jar_entries(
+            &path,
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: io.izzel.arclight.server.Launcher\r\nImplementation-Title: Arclight\r\nImplementation-Version: arclight-1.21.1-1.0.2-SNAPSHOT-8086b06\r\n\r\n",
+                ),
+                (
+                    "arclight-server-launch.properties",
+                    "launch.mainClass=io.izzel.arclight.boot.forge.application.Main_Forge\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect Arclight fixture");
+        fs::remove_file(&path).expect("remove Arclight fixture");
+
+        assert_eq!(product_key(&report), Some("arclight"));
+        assert_eq!(
+            report.identity.version.value.as_deref(),
+            Some("arclight-1.21.1-1.0.2-SNAPSHOT-8086b06")
+        );
+        assert_eq!(
+            report
+                .minecraft
+                .as_ref()
+                .and_then(|minecraft| minecraft.version.value.as_deref()),
+            Some("1.21.1")
+        );
+        assert!(report
+            .identity
+            .ecosystems
+            .iter()
+            .any(|candidate| candidate.value == ServerEcosystem::Forge));
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "forge"));
+        assert!(report
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::Launcher));
+    }
+
+    #[test]
+    fn extracts_mohist_named_section_components_without_merging_sections() {
+        let path = temporary_path("mohist.jar");
+        write_test_jar_entries(
+            &path,
+            &[(
+                "META-INF/MANIFEST.MF",
+                "Main-Class: com.mohistmc.MohistMCStart\r\n\r\nName: com/mohistmc/\r\nImplementation-Title: Mohist\r\nImplementation-Version: 1.20.2-00000000\r\n\r\nName: net/minecraftforge/versions/forge/\r\nImplementation-Title: net.minecraftforge\r\nImplementation-Version: 48.1.0\r\n\r\nName: org/bukkit/craftbukkit/v1_20_R2/\r\nImplementation-Title: Spigot\r\nImplementation-Version: build-48.1.0\r\n\r\nName: net/minecraftforge/versions/mcp/\r\nSpecification-Version: 1.20.2\r\nImplementation-Title: MCP\r\nImplementation-Version: 20230921.100330\r\n\r\n",
+            )],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect Mohist fixture");
+        fs::remove_file(&path).expect("remove Mohist fixture");
+
+        assert_eq!(product_key(&report), Some("mohist"));
+        assert_eq!(report.identity.version.value.as_deref(), Some("1.20.2-00000000"));
+        assert_eq!(
+            report
+                .minecraft
+                .as_ref()
+                .and_then(|minecraft| minecraft.version.value.as_deref()),
+            Some("1.20.2")
+        );
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "forge"
+                && component.value.version.as_deref() == Some("48.1.0")));
+        assert!(report
+            .components
+            .iter()
+            .any(|component| component.value.key == "mcp"
+                && component.value.version.as_deref() == Some("20230921.100330")));
+    }
+
+    #[test]
+    fn detects_youer_sections_and_magma_wrapper_metadata() {
+        let youer_path = temporary_path("youer.jar");
+        write_test_jar_entries(
+            &youer_path,
+            &[(
+                "META-INF/MANIFEST.MF",
+                "Main-Class: com.mohistmc.launcher.youer.Main\r\n\r\nName: com/mohistmc/launcher/youer/\r\nImplementation-Title: Youer\r\nImplementation-Version: 1.21.1-d380773e\r\n\r\n",
+            )],
+        );
+        let youer = inspect_server_artifact(&youer_path, &InspectionOptions::default())
+            .expect("inspect Youer fixture");
+        fs::remove_file(&youer_path).expect("remove Youer fixture");
+        assert_eq!(product_key(&youer), Some("youer"));
+        assert!(youer
+            .identity
+            .ecosystems
+            .iter()
+            .any(|candidate| candidate.value == ServerEcosystem::NeoForge));
+
+        let magma_path = temporary_path("server.jar");
+        write_test_jar_entries(
+            &magma_path,
+            &[(
+                "metadata.json",
+                r#"{"version":"1.21.1","magma":{"groupId":"org.magmafoundation","artifactId":"magma","version":"21.1.70-beta"}}"#,
+            )],
+        );
+        let magma = inspect_server_artifact(&magma_path, &InspectionOptions::default())
+            .expect("inspect Magma fixture");
+        fs::remove_file(&magma_path).expect("remove Magma fixture");
+        assert_eq!(product_key(&magma), Some("magma"));
+        assert_eq!(magma.identity.version.value.as_deref(), Some("21.1.70-beta"));
+        assert_eq!(magma.identity.release_channel.value, Some(ReleaseChannel::Beta));
+        assert!(magma
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::Wrapper));
+    }
+
+    #[test]
+    fn detects_a_magma_wrapper_directory_and_its_root_jar_launch() {
+        let path = temporary_path("magma-directory");
+        fs::create_dir(&path).expect("create Magma directory");
+        write_test_jar_entries(
+            &path.join("server.jar"),
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: app.mcjars.serverstarter.ServerStarter\r\n\r\n",
+                ),
+                (
+                    "metadata.json",
+                    r#"{"version":"1.21.1","magma":{"groupId":"org.magmafoundation","artifactId":"magma","version":"21.1.70-beta"}}"#,
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect Magma directory fixture");
+        fs::remove_dir_all(&path).expect("remove Magma directory fixture");
+
+        assert_eq!(product_key(&report), Some("magma"));
+        assert!(report
+            .launches
+            .iter()
+            .any(|launch| matches!(launch.value.target, LaunchTarget::Jar { ref path } if path.ends_with("server.jar"))));
+        assert!(report
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::InstallationDirectory));
+        assert!(report
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::Wrapper));
+    }
+
+    #[test]
+    fn separates_spongevanilla_identity_from_its_installer_role() {
+        let path = temporary_path("spongevanilla.jar");
+        write_test_jar_entries(
+            &path,
+            &[(
+                "META-INF/MANIFEST.MF",
+                "Main-Class: org.spongepowered.vanilla.installer.InstallerMain\r\nImplementation-Title: SpongeVanilla\r\nImplementation-Version: 26.2-20.0.0-RC2673\r\n\r\n",
+            )],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect SpongeVanilla fixture");
+        fs::remove_file(&path).expect("remove SpongeVanilla fixture");
+
+        assert_eq!(product_key(&report), Some("spongevanilla"));
+        assert_eq!(report.identity.category.value, Some(ServerCategory::JavaGameServer));
+        assert_eq!(report.identity.release_channel.value, Some(ReleaseChannel::ReleaseCandidate));
+        assert!(report
+            .artifact
+            .roles
+            .iter()
+            .any(|role| role.value == ArtifactRole::Installer));
+        assert!(report
+            .identity
+            .ecosystems
+            .iter()
+            .any(|candidate| candidate.value == ServerEcosystem::Sponge));
+    }
+
+    #[test]
+    fn detects_limbo_products_without_inventing_a_minecraft_version() {
+        let cases = [
+            (
+                "limbo.jar",
+                "com.loohp.limbo.Limbo",
+                "Limbo-Version: 2026.0.2-ALPHA\r\n",
+                "limbo",
+            ),
+            ("nanolimbo.jar", "ua.nanit.limbo.NanoLimbo", "", "nanolimbo"),
+        ];
+
+        for (filename, main_class, version_line, expected_key) in cases {
+            let path = temporary_path(filename);
+            let manifest = format!("Main-Class: {main_class}\r\n{version_line}\r\n");
+            write_test_jar_entries(&path, &[("META-INF/MANIFEST.MF", &manifest)]);
+            let report = inspect_server_artifact(&path, &InspectionOptions::default())
+                .expect("inspect Limbo fixture");
+            fs::remove_file(&path).expect("remove Limbo fixture");
+
+            assert_eq!(product_key(&report), Some(expected_key));
+            assert_eq!(report.identity.category.value, Some(ServerCategory::Limbo));
+            assert!(report.minecraft.is_none());
+        }
+    }
+
+    #[test]
+    fn detects_craftbukkit_two_field_version_lists() {
+        let path = temporary_path("craftbukkit.jar");
+        write_test_jar_entries(
+            &path,
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: org.bukkit.craftbukkit.bootstrap.Main\r\n\r\n",
+                ),
+                ("META-INF/versions.list", "hash *craftbukkit-26.2-R0.1-SNAPSHOT.jar\n"),
+            ],
+        );
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect CraftBukkit fixture");
+        fs::remove_file(&path).expect("remove CraftBukkit fixture");
+
+        assert_eq!(product_key(&report), Some("craftbukkit"));
+        assert_eq!(report.identity.version.value.as_deref(), Some("26.2-R0.1-SNAPSHOT"));
+        assert_eq!(
+            report
+                .minecraft
+                .as_ref()
+                .and_then(|minecraft| minecraft.version.value.as_deref()),
+            Some("26.2")
+        );
+        assert!(report
+            .identity
+            .ecosystems
+            .iter()
+            .any(|candidate| candidate.value == ServerEcosystem::Bukkit));
+    }
+
     #[test]
     fn distinguishes_fabric_loader_from_installer_version() {
         let cases = [

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -696,7 +696,7 @@ mod tests {
     use zip::write::FileOptions;
 
     use super::{
-        inspect_server_artifact, ArtifactFormat, ArtifactRole, InspectionOptions,
+        inspect_server_artifact, ArtifactFormat, ArtifactRole, DetectionTarget, InspectionOptions,
         InspectionSubjectKind, LaunchPlatform, LaunchTarget, ReleaseChannel, ServerCategory,
         ServerComponentKind, ServerEcosystem,
     };
@@ -803,6 +803,11 @@ mod tests {
                 .iter()
                 .any(|candidate| candidate.value == ecosystem));
             assert_eq!(report.java.required_major.value, Some(11));
+            assert!(report.evidence.iter().any(|evidence| {
+                evidence.detector == "proxy-manifest-product"
+                    && evidence.target == DetectionTarget::ServerCategory
+                    && evidence.candidate == "proxy"
+            }));
         }
     }
 
@@ -862,10 +867,18 @@ mod tests {
             .ecosystems
             .iter()
             .any(|candidate| candidate.value == ServerEcosystem::Forge));
-        assert!(report
+        let forge_component = report
             .components
             .iter()
-            .any(|component| component.value.key == "forge"));
+            .find(|component| component.value.key == "forge")
+            .expect("Forge loader component");
+        assert!(forge_component.evidence.iter().all(|evidence_id| {
+            report
+                .evidence
+                .iter()
+                .find(|evidence| evidence.id == *evidence_id)
+                .is_some_and(|evidence| evidence.detector == "arclight-launch-properties")
+        }));
         assert!(report
             .artifact
             .roles

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -1090,6 +1090,22 @@ mod tests {
             .ecosystems
             .iter()
             .any(|candidate| candidate.value == ServerEcosystem::Bukkit));
+        let implementation_detectors = report
+            .identity
+            .implementation
+            .evidence
+            .iter()
+            .filter_map(|evidence_id| {
+                report
+                    .evidence
+                    .iter()
+                    .find(|evidence| evidence.id == *evidence_id)
+                    .map(|evidence| evidence.detector.as_str())
+            })
+            .collect::<Vec<_>>();
+        assert!(implementation_detectors.contains(&"craftbukkit-main-class"));
+        assert!(implementation_detectors.contains(&"craftbukkit-versions-list"));
+        assert!(!implementation_detectors.contains(&"craftbukkit-bundler"));
     }
 
     #[test]

--- a/crates/core/src/provisioning/server_inspection/model.rs
+++ b/crates/core/src/provisioning/server_inspection/model.rs
@@ -180,6 +180,7 @@ pub enum ServerEcosystem {
 #[serde(rename_all = "snake_case")]
 pub enum ReleaseChannel {
     Stable,
+    ReleaseCandidate,
     Beta,
     Alpha,
     Snapshot,


### PR DESCRIPTION
补齐剩余服务端家族检测和样本回归。服务端检查结果接入导入/持久化流程尚未完成。

## Summary by Sourcery

为更多类型的 Minecraft 服务器家族和代理实现添加检测与分类支持，在检查报告中丰富生态系统、类别、版本以及启动元数据。

New Features:
- 检测混合服务器 Arclight、Mohist、Youer 和 Magma，包括封装器元数据、加载器生态系统以及 Minecraft 版本提取。
- 通过清单分析检测代理服务器 Velocity、Velocity-CTD、BungeeCord 和 Waterfall，并区分共享主类的分支。
- 检测 SpongeVanilla、Limbo 和 NanoLimbo 服务器，区分安装器角色，避免生成伪造的 Minecraft 版本。
- 通过清单和 `versions.list` 解析检测 CraftBukkit 发行版，包括捆绑实现和 Minecraft 版本信息。
- 支持从版本字符串推断 ReleaseCandidate 作为发布渠道，并在检查结果中公开该信息。

Enhancements:
- 在最终检查中独立传播服务器生态系统信号，不依赖于具体产品选择，并从产品定义中推导服务器类别。
- 捕获 Arclight 启动属性以及目录根 JAR 启动配置，以更好地建模启动器、封装器和安装角色。
- 将清单属性处理重构为共享辅助方法，并扩展归档元数据以读取 Arclight 特定属性。

Tests:
- 添加基于固件的测试用例，覆盖代理分支、中性代理 JAR、Arclight、Mohist、Youer、Magma（JAR 和目录）、SpongeVanilla、Limbo/NanoLimbo，以及 CraftBukkit 的 `versions.list` 解析。
- 添加针对产品类别归属、ReleaseCandidate 解析、清单属性辅助方法以及 CraftBukkit `versions.list` 提取的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add detection and classification support for additional Minecraft server families and proxy implementations, enriching inspection reports with ecosystem, category, version, and launch metadata.

New Features:
- Detect hybrid servers Arclight, Mohist, Youer, and Magma, including wrapper metadata, loader ecosystem, and Minecraft version extraction.
- Detect proxy servers Velocity, Velocity-CTD, BungeeCord, and Waterfall via manifest analysis, distinguishing forks that share main classes.
- Detect SpongeVanilla, Limbo and NanoLimbo servers, separating installer roles and avoiding synthetic Minecraft versions.
- Detect CraftBukkit distributions via manifest and versions.list parsing, including bundled implementation and Minecraft version information.
- Support ReleaseCandidate as a release channel inferred from version strings and expose it in inspection results.

Enhancements:
- Propagate server ecosystem signals independently of product selection and derive server categories from product definitions in final inspection.
- Capture Arclight launch properties and directory-root JAR launch profiles to better model launcher, wrapper, and installation roles.
- Refactor manifest attribute handling into shared helpers and extend archive metadata to read Arclight-specific properties.

Tests:
- Add fixture-based tests covering proxy forks, neutral proxy jars, Arclight, Mohist, Youer, Magma (jar and directory), SpongeVanilla, Limbo/NanoLimbo, and CraftBukkit versions.list parsing.
- Add unit tests for product category ownership, ReleaseCandidate parsing, manifest attribute helpers, and CraftBukkit versions.list extraction.

</details>

新功能：
- 为混合服务器（Arclight、Mohist、Youer、Magma）、代理服务器（Velocity/CTD、BungeeCord、Waterfall）、SpongeVanilla、Limbo/NanoLimbo，以及通用 CraftBukkit 打包和目录根路径启动添加检测器。
- 在服务器检查中引入 Arclight、Mohist、Youer、Magma、Velocity/CTD、BungeeCord、Waterfall、SpongeVanilla、Limbo、NanoLimbo 和 CraftBukkit 的新产品定义和生态系统映射。
- 支持将 ReleaseCandidate 作为新的发布渠道，并从版本字符串中检测该信息，包括 SpongeVanilla 和 Magma 元数据。
- 在检测结果中直接跟踪服务器生态系统，并在检查结果中与类别和组件一同解析。

增强：
- 从检测到的产品键中推导服务器类别（例如代理 vs limbo vs 通用 Java 游戏服务器），以更好地对检查报告进行分类。
- 捕获额外的归档元数据，例如 Arclight 启动属性，以识别加载器生态系统和启动器角色。
- 改进 manifest 和 versions.list 解析，以从混合和捆绑服务器发行版中提取 Minecraft 版本、产品版本和组件信息。

测试：
- 添加大量基于固件（fixture）的测试，涵盖对代理分支（proxy forks）、中立代理、Arclight、Mohist、Youer、Magma（jar 与目录）、SpongeVanilla、Limbo/NanoLimbo，以及 CraftBukkit versions.list 解析的检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为更多类型的 Minecraft 服务器家族和代理实现添加检测与分类支持，在检查报告中丰富生态系统、类别、版本以及启动元数据。

New Features:
- 检测混合服务器 Arclight、Mohist、Youer 和 Magma，包括封装器元数据、加载器生态系统以及 Minecraft 版本提取。
- 通过清单分析检测代理服务器 Velocity、Velocity-CTD、BungeeCord 和 Waterfall，并区分共享主类的分支。
- 检测 SpongeVanilla、Limbo 和 NanoLimbo 服务器，区分安装器角色，避免生成伪造的 Minecraft 版本。
- 通过清单和 `versions.list` 解析检测 CraftBukkit 发行版，包括捆绑实现和 Minecraft 版本信息。
- 支持从版本字符串推断 ReleaseCandidate 作为发布渠道，并在检查结果中公开该信息。

Enhancements:
- 在最终检查中独立传播服务器生态系统信号，不依赖于具体产品选择，并从产品定义中推导服务器类别。
- 捕获 Arclight 启动属性以及目录根 JAR 启动配置，以更好地建模启动器、封装器和安装角色。
- 将清单属性处理重构为共享辅助方法，并扩展归档元数据以读取 Arclight 特定属性。

Tests:
- 添加基于固件的测试用例，覆盖代理分支、中性代理 JAR、Arclight、Mohist、Youer、Magma（JAR 和目录）、SpongeVanilla、Limbo/NanoLimbo，以及 CraftBukkit 的 `versions.list` 解析。
- 添加针对产品类别归属、ReleaseCandidate 解析、清单属性辅助方法以及 CraftBukkit `versions.list` 提取的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add detection and classification support for additional Minecraft server families and proxy implementations, enriching inspection reports with ecosystem, category, version, and launch metadata.

New Features:
- Detect hybrid servers Arclight, Mohist, Youer, and Magma, including wrapper metadata, loader ecosystem, and Minecraft version extraction.
- Detect proxy servers Velocity, Velocity-CTD, BungeeCord, and Waterfall via manifest analysis, distinguishing forks that share main classes.
- Detect SpongeVanilla, Limbo and NanoLimbo servers, separating installer roles and avoiding synthetic Minecraft versions.
- Detect CraftBukkit distributions via manifest and versions.list parsing, including bundled implementation and Minecraft version information.
- Support ReleaseCandidate as a release channel inferred from version strings and expose it in inspection results.

Enhancements:
- Propagate server ecosystem signals independently of product selection and derive server categories from product definitions in final inspection.
- Capture Arclight launch properties and directory-root JAR launch profiles to better model launcher, wrapper, and installation roles.
- Refactor manifest attribute handling into shared helpers and extend archive metadata to read Arclight-specific properties.

Tests:
- Add fixture-based tests covering proxy forks, neutral proxy jars, Arclight, Mohist, Youer, Magma (jar and directory), SpongeVanilla, Limbo/NanoLimbo, and CraftBukkit versions.list parsing.
- Add unit tests for product category ownership, ReleaseCandidate parsing, manifest attribute helpers, and CraftBukkit versions.list extraction.

</details>

</details>