### PR TITLE
refactor(core): 复用服务端检查兼容解析

### DIFF
--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -195,17 +195,13 @@ fn is_ambiguous<T>(detected: &Detected<T>) -> bool {
 }
 
 fn selected_or_fallback<T: Clone>(detected: &Detected<T>, fallback: Option<T>) -> Option<T> {
-    if let Some(value) = selected_value(detected) {
-        Some(value)
+    if let Some(value) = detected.value.as_ref() {
+        Some(value.clone())
     } else if detected.alternatives.is_empty() {
         fallback
     } else {
         None
     }
-}
-
-fn selected_value<T: Clone>(detected: &Detected<T>) -> Option<T> {
-    detected.value.as_ref().cloned()
 }
 
 fn legacy_kind_from_report(report: &ServerInspectionReport, filename_kind: CoreKind) -> CoreKind {
@@ -259,23 +255,27 @@ fn legacy_kind_from_report(report: &ServerInspectionReport, filename_kind: CoreK
 }
 
 fn arclight_legacy_kind(ecosystems: &[Attributed<ServerEcosystem>]) -> CoreKind {
-    if ecosystems
-        .iter()
-        .any(|ecosystem| ecosystem.value == ServerEcosystem::NeoForge)
-    {
-        CoreKind::ArclightNeoForge
-    } else if ecosystems
-        .iter()
-        .any(|ecosystem| ecosystem.value == ServerEcosystem::Fabric)
-    {
-        CoreKind::ArclightFabric
-    } else if ecosystems
-        .iter()
-        .any(|ecosystem| ecosystem.value == ServerEcosystem::Forge)
-    {
-        CoreKind::ArclightForge
-    } else {
-        CoreKind::Unknown
+    let mut result = CoreKind::Unknown;
+    for ecosystem in ecosystems {
+        let candidate = match ecosystem.value {
+            ServerEcosystem::NeoForge => CoreKind::ArclightNeoForge,
+            ServerEcosystem::Fabric => CoreKind::ArclightFabric,
+            ServerEcosystem::Forge => CoreKind::ArclightForge,
+            _ => continue,
+        };
+        if arclight_kind_priority(candidate) > arclight_kind_priority(result) {
+            result = candidate;
+        }
+    }
+    result
+}
+
+fn arclight_kind_priority(kind: CoreKind) -> u8 {
+    match kind {
+        CoreKind::ArclightNeoForge => 3,
+        CoreKind::ArclightFabric => 2,
+        CoreKind::ArclightForge => 1,
+        _ => 0,
     }
 }
 
@@ -396,9 +396,10 @@ mod tests {
     use zip::write::FileOptions;
 
     use super::{
-        extract_minecraft_version, inspect_core_file, inspect_core_filename, CoreKind,
-        CoreParseError,
+        arclight_legacy_kind, extract_minecraft_version, inspect_core_file, inspect_core_filename,
+        CoreKind, CoreParseError,
     };
+    use crate::provisioning::server_inspection::{Attributed, ServerEcosystem};
 
     fn write_test_jar(filename: &str, entries: &[(&str, &str)]) -> PathBuf {
         let timestamp = SystemTime::now()
@@ -536,6 +537,29 @@ mod tests {
 
         assert_eq!(parsed.kind, CoreKind::ArclightNeoForge);
         assert_eq!(parsed.minecraft_version.as_deref(), Some("1.21.1"));
+    }
+
+    #[test]
+    fn arclight_ecosystem_priority_is_independent_of_input_order() {
+        let ecosystems = [
+            Attributed {
+                value: ServerEcosystem::Forge,
+                confidence: 95,
+                evidence: Vec::new(),
+            },
+            Attributed {
+                value: ServerEcosystem::Fabric,
+                confidence: 95,
+                evidence: Vec::new(),
+            },
+            Attributed {
+                value: ServerEcosystem::NeoForge,
+                confidence: 95,
+                evidence: Vec::new(),
+            },
+        ];
+
+        assert_eq!(arclight_legacy_kind(&ecosystems), CoreKind::ArclightNeoForge);
     }
 
     #[test]

--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -1,9 +1,13 @@
 use std::fmt;
-use std::fs::File;
-use std::io::{self, Read};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use zip::result::ZipError;
+
+use super::server_inspection::{
+    inspect_server_artifact, Attributed, Detected, InspectionOptions, ReleaseChannel,
+    ServerEcosystem, ServerInspectionError, ServerInspectionReport,
+};
 
 /// 一个可识别的服务端核心系列。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,7 +129,7 @@ const CORE_KEYWORDS: &[(CoreKind, &[&str])] = &[
     (CoreKind::Vanilla, &["vanilla"]),
 ];
 
-/// 从文件名或 JAR 清单解析的服务端核心元数据。
+/// 从文件名或新版服务端检查报告投影的兼容核心元数据。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoreFileInfo {
     pub kind: CoreKind,
@@ -150,6 +154,143 @@ impl CoreFileInfo {
             main_class: None,
         }
     }
+
+    fn from_report(filename: &str, report: &ServerInspectionReport) -> Self {
+        let fallback = Self::from_filename(filename);
+        let fallback_kind = fallback.kind;
+        let fallback_core_version = fallback.core_version;
+        let fallback_minecraft_version = fallback.minecraft_version;
+        let implementation_is_ambiguous = is_ambiguous(&report.identity.implementation);
+        let kind = if has_detection_evidence(&report.identity.implementation) {
+            legacy_kind_from_report(report, fallback_kind)
+        } else {
+            fallback_kind
+        };
+        let core_version = selected_or_fallback(
+            &report.identity.version,
+            (!implementation_is_ambiguous)
+                .then(|| {
+                    manifest_main_attribute(report, "Implementation-Version")
+                        .or(fallback_core_version)
+                })
+                .flatten(),
+        );
+        let minecraft_version = match report.minecraft.as_ref() {
+            Some(minecraft) => selected_or_fallback(&minecraft.version, fallback_minecraft_version),
+            None => fallback_minecraft_version,
+        };
+
+        Self {
+            kind,
+            core_version,
+            minecraft_version,
+            main_class: report.artifact.main_class.value.clone(),
+        }
+    }
+}
+
+fn has_detection_evidence<T>(detected: &Detected<T>) -> bool {
+    detected.value.is_some() || !detected.alternatives.is_empty()
+}
+
+fn is_ambiguous<T>(detected: &Detected<T>) -> bool {
+    detected.value.is_none() && !detected.alternatives.is_empty()
+}
+
+fn selected_or_fallback<T: Clone>(detected: &Detected<T>, fallback: Option<T>) -> Option<T> {
+    if let Some(value) = selected_value(detected) {
+        Some(value)
+    } else if detected.alternatives.is_empty() {
+        fallback
+    } else {
+        None
+    }
+}
+
+fn selected_value<T: Clone>(detected: &Detected<T>) -> Option<T> {
+    detected.value.as_ref().cloned()
+}
+
+fn legacy_kind_from_report(report: &ServerInspectionReport, filename_kind: CoreKind) -> CoreKind {
+    let Some(product) = report.identity.implementation.value.as_ref() else {
+        return CoreKind::Unknown;
+    };
+    match product.key.as_str() {
+        "arclight" => {
+            let kind = arclight_legacy_kind(&report.identity.ecosystems);
+            if kind == CoreKind::Unknown {
+                match filename_kind {
+                    CoreKind::ArclightForge
+                    | CoreKind::ArclightNeoForge
+                    | CoreKind::ArclightFabric => filename_kind,
+                    _ => CoreKind::Unknown,
+                }
+            } else {
+                kind
+            }
+        }
+        "youer" => CoreKind::Youer,
+        "mohist" => CoreKind::Mohist,
+        "neoforge" => CoreKind::NeoForge,
+        "forge" => CoreKind::Forge,
+        "fabric" | "legacy-fabric" => CoreKind::Fabric,
+        "pufferfish" if filename_kind == CoreKind::PufferfishPurpur => CoreKind::PufferfishPurpur,
+        "pufferfish" => CoreKind::Pufferfish,
+        "spongevanilla" => CoreKind::SpongeVanilla,
+        "purpur" => CoreKind::Purpur,
+        "paper" => CoreKind::Paper,
+        "folia" => CoreKind::Folia,
+        "leaves" => CoreKind::Leaves,
+        "leaf" => CoreKind::Leaf,
+        "spigot" => CoreKind::Spigot,
+        "craftbukkit" => CoreKind::Bukkit,
+        "vanilla" if report.identity.release_channel.value == Some(ReleaseChannel::Snapshot) => {
+            CoreKind::VanillaSnapshot
+        }
+        "vanilla"
+            if !has_detection_evidence(&report.identity.release_channel)
+                && filename_kind == CoreKind::VanillaSnapshot =>
+        {
+            CoreKind::VanillaSnapshot
+        }
+        "vanilla" => CoreKind::Vanilla,
+        "velocity" => CoreKind::Velocity,
+        "bungeecord" => CoreKind::BungeeCord,
+        _ => CoreKind::Unknown,
+    }
+}
+
+fn arclight_legacy_kind(ecosystems: &[Attributed<ServerEcosystem>]) -> CoreKind {
+    if ecosystems
+        .iter()
+        .any(|ecosystem| ecosystem.value == ServerEcosystem::NeoForge)
+    {
+        CoreKind::ArclightNeoForge
+    } else if ecosystems
+        .iter()
+        .any(|ecosystem| ecosystem.value == ServerEcosystem::Fabric)
+    {
+        CoreKind::ArclightFabric
+    } else if ecosystems
+        .iter()
+        .any(|ecosystem| ecosystem.value == ServerEcosystem::Forge)
+    {
+        CoreKind::ArclightForge
+    } else {
+        CoreKind::Unknown
+    }
+}
+
+fn manifest_main_attribute(report: &ServerInspectionReport, key: &str) -> Option<String> {
+    report
+        .artifact
+        .manifest
+        .as_ref()?
+        .main_attributes
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 /// 检查服务端核心文件名，无需从磁盘读取。
@@ -161,38 +302,23 @@ pub fn inspect_core_filename(filename: &str) -> CoreFileInfo {
     CoreFileInfo::from_filename(filename)
 }
 
-/// 读取 JAR 清单并将其与基于文件名的服务端核心检测进行协调。
+/// 将服务端检查报告投影为旧的核心信息模型。
 pub fn inspect_core_file(path: &Path) -> Result<CoreFileInfo, CoreParseError> {
     let filename = path
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| CoreParseError::InvalidPath { path: path.to_path_buf() })?;
-    let mut info = CoreFileInfo::from_filename(filename);
-
     if !path
         .extension()
         .and_then(|extension| extension.to_str())
         .is_some_and(|extension| extension.eq_ignore_ascii_case("jar"))
     {
-        return Ok(info);
+        return Ok(CoreFileInfo::from_filename(filename));
     }
 
-    let manifest = read_manifest(path)?;
-    let Some(manifest) = manifest else {
-        return Ok(info);
-    };
-
-    info.main_class = manifest.main_class;
-    if let Some(manifest_version) = manifest.implementation_version {
-        info.core_version = Some(manifest_version);
-    }
-    if let Some(main_class) = info.main_class.as_deref() {
-        if let Some(main_class_kind) = core_kind_from_main_class(main_class) {
-            info.kind = reconcile_core_kind(info.kind, main_class_kind);
-        }
-    }
-
-    Ok(info)
+    let report = inspect_server_artifact(path, &InspectionOptions::default())
+        .map_err(|source| CoreParseError::Inspection { path: path.to_path_buf(), source })?;
+    Ok(CoreFileInfo::from_report(filename, &report))
 }
 
 /// 从文本中提取第一个 Minecraft 风格的版本提示（例如 `1.20.1`）。
@@ -200,115 +326,6 @@ pub fn extract_minecraft_version(input: &str) -> Option<String> {
     extract_version_tokens(input)
         .into_iter()
         .find(|version| version.starts_with("1."))
-}
-
-fn reconcile_core_kind(filename_kind: CoreKind, main_class_kind: CoreKind) -> CoreKind {
-    match (filename_kind, main_class_kind) {
-        // NeoForge 安装程序保留了旧的 Forge 安装程序主类。
-        (CoreKind::NeoForge | CoreKind::ArclightNeoForge, CoreKind::Forge) => filename_kind,
-        (_, main_class_kind) => main_class_kind,
-    }
-}
-
-fn core_kind_from_main_class(main_class: &str) -> Option<CoreKind> {
-    match main_class {
-        value if value.starts_with("net.neoforged.serverstarterjar") => Some(CoreKind::NeoForge),
-        "net.minecraft.server.MinecraftServer" | "net.minecraft.bundler.Main" => {
-            Some(CoreKind::Vanilla)
-        }
-        "net.minecraft.client.Main" => Some(CoreKind::Unknown),
-        "net.minecraftforge.installer.SimpleInstaller" => Some(CoreKind::Forge),
-        "net.fabricmc.installer.Main" | "net.fabricmc.installer.ServerLauncher" => {
-            Some(CoreKind::Fabric)
-        }
-        "io.izzel.arclight.server.Launcher" => Some(CoreKind::ArclightForge),
-        "catserver.server.CatServerLaunch" | "foxlaunch.FoxServerLauncher" => {
-            Some(CoreKind::CatServer)
-        }
-        "org.bukkit.craftbukkit.Main" | "org.bukkit.craftbukkit.bootstrap.Main" => {
-            Some(CoreKind::Bukkit)
-        }
-        "io.papermc.paperclip.Main" | "com.destroystokyo.paperclip.Paperclip" => {
-            Some(CoreKind::Paper)
-        }
-        "org.leavesmc.leavesclip.Main" => Some(CoreKind::Leaves),
-        "net.md_5.bungee.Bootstrap" => Some(CoreKind::Lightfall),
-        "com.mohistmc.MohistMCStart" | "com.mohistmc.MohistMC" => Some(CoreKind::Mohist),
-        "com.velocitypowered.proxy.Velocity" => Some(CoreKind::Velocity),
-        _ => None,
-    }
-}
-
-struct JarManifest {
-    main_class: Option<String>,
-    implementation_version: Option<String>,
-}
-
-fn read_manifest(path: &Path) -> Result<Option<JarManifest>, CoreParseError> {
-    let file = File::open(path)
-        .map_err(|source| CoreParseError::Open { path: path.to_path_buf(), source })?;
-    let mut archive = zip::ZipArchive::new(file)
-        .map_err(|source| CoreParseError::Archive { path: path.to_path_buf(), source })?;
-    let mut manifest = match archive.by_name("META-INF/MANIFEST.MF") {
-        Ok(manifest) => manifest,
-        Err(ZipError::FileNotFound) => return Ok(None),
-        Err(source) => {
-            return Err(CoreParseError::Manifest { path: path.to_path_buf(), source });
-        }
-    };
-
-    let mut bytes = Vec::new();
-    manifest
-        .read_to_end(&mut bytes)
-        .map_err(|source| CoreParseError::ManifestRead { path: path.to_path_buf(), source })?;
-    Ok(Some(parse_manifest(&String::from_utf8_lossy(&bytes))))
-}
-
-fn parse_manifest(content: &str) -> JarManifest {
-    let mut entries = Vec::new();
-    let mut current_key = String::new();
-    let mut current_value = String::new();
-
-    for line in content.lines() {
-        if line.is_empty() {
-            flush_manifest_entry(&mut entries, &mut current_key, &mut current_value);
-            continue;
-        }
-        if line.starts_with(' ') {
-            current_value.push_str(line.trim_start());
-            continue;
-        }
-
-        flush_manifest_entry(&mut entries, &mut current_key, &mut current_value);
-        if let Some((key, value)) = line.split_once(':') {
-            current_key.push_str(key.trim());
-            current_value.push_str(value.trim());
-        }
-    }
-    flush_manifest_entry(&mut entries, &mut current_key, &mut current_value);
-
-    JarManifest {
-        main_class: manifest_value(&entries, "Main-Class"),
-        implementation_version: manifest_value(&entries, "Implementation-Version"),
-    }
-}
-
-fn flush_manifest_entry(
-    entries: &mut Vec<(String, String)>,
-    current_key: &mut String,
-    current_value: &mut String,
-) {
-    if !current_key.is_empty() {
-        entries.push((std::mem::take(current_key), std::mem::take(current_value)));
-    }
-}
-
-fn manifest_value(entries: &[(String, String)], key: &str) -> Option<String> {
-    entries
-        .iter()
-        .find(|(entry_key, _)| entry_key.eq_ignore_ascii_case(key))
-        .map(|(_, value)| value.trim().to_string())
-        .filter(|value| !value.is_empty())
 }
 
 fn extract_version_tokens(input: &str) -> Vec<String> {
@@ -339,11 +356,29 @@ fn extract_version_tokens(input: &str) -> Vec<String> {
 /// 描述打开或解析服务端核心文件时的失败。
 #[derive(Debug)]
 pub enum CoreParseError {
-    InvalidPath { path: PathBuf },
-    Open { path: PathBuf, source: io::Error },
-    Archive { path: PathBuf, source: ZipError },
-    Manifest { path: PathBuf, source: ZipError },
-    ManifestRead { path: PathBuf, source: io::Error },
+    InvalidPath {
+        path: PathBuf,
+    },
+    Open {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Archive {
+        path: PathBuf,
+        source: ZipError,
+    },
+    Manifest {
+        path: PathBuf,
+        source: ZipError,
+    },
+    ManifestRead {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Inspection {
+        path: PathBuf,
+        source: ServerInspectionError,
+    },
 }
 
 impl fmt::Display for CoreParseError {
@@ -366,6 +401,9 @@ impl fmt::Display for CoreParseError {
                 "could not read JAR manifest content from {}: {source}",
                 path.display()
             ),
+            Self::Inspection { path, source } => {
+                write!(formatter, "could not inspect core file {}: {source}", path.display())
+            }
         }
     }
 }
@@ -376,6 +414,7 @@ impl std::error::Error for CoreParseError {
             Self::InvalidPath { .. } => None,
             Self::Open { source, .. } | Self::ManifestRead { source, .. } => Some(source),
             Self::Archive { source, .. } | Self::Manifest { source, .. } => Some(source),
+            Self::Inspection { source, .. } => Some(source),
         }
     }
 }
@@ -389,12 +428,9 @@ mod tests {
 
     use zip::write::FileOptions;
 
-    use super::{
-        extract_minecraft_version, inspect_core_file, inspect_core_filename, parse_manifest,
-        CoreKind,
-    };
+    use super::{extract_minecraft_version, inspect_core_file, inspect_core_filename, CoreKind};
 
-    fn write_test_jar(filename: &str, manifest: &str) -> PathBuf {
+    fn write_test_jar(filename: &str, entries: &[(&str, &str)]) -> PathBuf {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after the Unix epoch")
@@ -407,12 +443,14 @@ mod tests {
         ));
         let file = File::create(&path).expect("create test JAR");
         let mut archive = zip::ZipWriter::new(file);
-        archive
-            .start_file("META-INF/MANIFEST.MF", FileOptions::<()>::default())
-            .expect("create manifest entry");
-        archive
-            .write_all(manifest.as_bytes())
-            .expect("write manifest content");
+        for (name, content) in entries {
+            archive
+                .start_file(*name, FileOptions::<()>::default())
+                .expect("create metadata entry");
+            archive
+                .write_all(content.as_bytes())
+                .expect("write metadata entry");
+        }
         archive.finish().expect("finish test JAR");
         path
     }
@@ -427,13 +465,31 @@ mod tests {
     }
 
     #[test]
-    fn manifest_parser_handles_continuation_lines() {
-        let manifest = parse_manifest(
-            "Manifest-Version: 1.0\r\nMain-Class: net.neoforged.server\r\n starterjar.Main\r\nImplementation-Version: 20.6.119\r\n\r\n",
+    fn compatibility_projection_keeps_manifest_continuation_lines() {
+        let path = write_test_jar(
+            "unknown.jar",
+            &[(
+                "META-INF/MANIFEST.MF",
+                "Manifest-Version: 1.0\r\nMain-Class: example.\r\n Main\r\nImplementation-Version: 20.6.119\r\n\r\n",
+            )],
         );
+        let parsed = inspect_core_file(&path).expect("inspect test JAR");
+        std::fs::remove_file(&path).expect("remove test JAR");
 
-        assert_eq!(manifest.main_class.as_deref(), Some("net.neoforged.serverstarterjar.Main"));
-        assert_eq!(manifest.implementation_version.as_deref(), Some("20.6.119"));
+        assert_eq!(parsed.main_class.as_deref(), Some("example.Main"));
+        assert_eq!(parsed.core_version.as_deref(), Some("20.6.119"));
+    }
+
+    #[test]
+    fn compatibility_projection_keeps_filename_fallback_without_metadata() {
+        let path = write_test_jar("paper-1.21.4-123.jar", &[("empty", "")]);
+        let parsed = inspect_core_file(&path).expect("inspect metadata-free JAR");
+        std::fs::remove_file(&path).expect("remove test JAR");
+
+        assert_eq!(parsed.kind, CoreKind::Paper);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("1.21.4"));
+        assert_eq!(parsed.core_version.as_deref(), Some("123"));
+        assert_eq!(parsed.main_class, None);
     }
 
     #[test]
@@ -446,7 +502,16 @@ mod tests {
     fn jar_manifest_keeps_neoforge_filename_over_legacy_forge_installer_class() {
         let path = write_test_jar(
             "neoforge-1.20.6-20.6.119-installer.jar",
-            "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.installer.SimpleInstaller\r\nImplementation-Version: 20.6.119\r\n\r\n",
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Manifest-Version: 1.0\r\nMain-Class: net.minecraftforge.installer.SimpleInstaller\r\nImplementation-Version: 20.6.119\r\n\r\n",
+                ),
+                (
+                    "metadata.json",
+                    r#"{"neoforge":"20.6.119"}"#,
+                ),
+            ],
         );
 
         let parsed = inspect_core_file(&path).expect("inspect test JAR");
@@ -458,5 +523,106 @@ mod tests {
             Some("net.minecraftforge.installer.SimpleInstaller")
         );
         assert_eq!(parsed.core_version.as_deref(), Some("20.6.119"));
+    }
+
+    #[test]
+    fn compatibility_projection_prefers_paperclip_content_over_filename() {
+        let path = write_test_jar(
+            "paper-26.2.jar",
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/purpur-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\torg.purpurmc.purpur:purpur-api:26.2.build.1-stable\tpurpur-api.jar\n",
+                ),
+            ],
+        );
+        let parsed = inspect_core_file(&path).expect("inspect Paperclip fixture");
+        std::fs::remove_file(&path).expect("remove Paperclip fixture");
+
+        assert_eq!(parsed.kind, CoreKind::Purpur);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("26.2"));
+        assert_eq!(parsed.core_version.as_deref(), Some("26.2.build.1-stable"));
+    }
+
+    #[test]
+    fn compatibility_projection_maps_arclight_by_detected_ecosystem() {
+        let path = write_test_jar(
+            "arclight.jar",
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: io.izzel.arclight.server.Launcher\r\nImplementation-Title: Arclight\r\nImplementation-Version: arclight-1.21.1-1.0.2\r\n\r\n",
+                ),
+                (
+                    "arclight-server-launch.properties",
+                    "launch.mainClass=io.izzel.arclight.boot.neoforge.application.Main_NeoForge\n",
+                ),
+            ],
+        );
+        let parsed = inspect_core_file(&path).expect("inspect Arclight fixture");
+        std::fs::remove_file(&path).expect("remove Arclight fixture");
+
+        assert_eq!(parsed.kind, CoreKind::ArclightNeoForge);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("1.21.1"));
+    }
+
+    #[test]
+    fn compatibility_projection_does_not_masquerade_new_products() {
+        let path = write_test_jar(
+            "paper-26.2.jar",
+            &[(
+                "META-INF/MANIFEST.MF",
+                "Main-Class: com.velocitypowered.proxy.Velocity\r\nImplementation-Title: Velocity-CTD\r\nImplementation-Version: 4.1.0-SNAPSHOT\r\n\r\n",
+            )],
+        );
+        let parsed = inspect_core_file(&path).expect("inspect Velocity-CTD fixture");
+        std::fs::remove_file(&path).expect("remove Velocity-CTD fixture");
+
+        assert_eq!(parsed.kind, CoreKind::Unknown);
+        assert_eq!(parsed.main_class.as_deref(), Some("com.velocitypowered.proxy.Velocity"));
+        assert_eq!(parsed.core_version.as_deref(), Some("4.1.0-SNAPSHOT"));
+    }
+
+    #[test]
+    fn compatibility_projection_prefers_detected_release_channel_over_filename() {
+        let path = write_test_jar(
+            "vanilla-snapshot.jar",
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: net.minecraft.bundler.Main\r\n\r\n"),
+                (
+                    "version.json",
+                    r#"{"id":"26.2","name":"26.2","world_version":4903,"stable":true}"#,
+                ),
+            ],
+        );
+        let parsed = inspect_core_file(&path).expect("inspect Vanilla fixture");
+        std::fs::remove_file(&path).expect("remove Vanilla fixture");
+
+        assert_eq!(parsed.kind, CoreKind::Vanilla);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("26.2"));
+        assert_eq!(parsed.core_version.as_deref(), Some("26.2"));
+    }
+
+    #[test]
+    fn compatibility_projection_keeps_conflicting_products_unknown() {
+        let path = write_test_jar(
+            "paper-26.2.jar",
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/purpur-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\tio.papermc.paper:paper-api:26.2.build.1-stable\tpaper-api.jar\n",
+                ),
+            ],
+        );
+        let parsed = inspect_core_file(&path).expect("inspect conflicting fixture");
+        std::fs::remove_file(&path).expect("remove conflicting fixture");
+
+        assert_eq!(parsed.kind, CoreKind::Unknown);
+        assert_eq!(parsed.core_version, None);
+        assert_eq!(parsed.minecraft_version.as_deref(), Some("26.2"));
     }
 }

--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -1,8 +1,5 @@
 use std::fmt;
-use std::io;
 use std::path::{Path, PathBuf};
-
-use zip::result::ZipError;
 
 use super::server_inspection::{
     inspect_server_artifact, Attributed, Detected, InspectionOptions, ReleaseChannel,
@@ -213,6 +210,7 @@ fn selected_value<T: Clone>(detected: &Detected<T>) -> Option<T> {
 
 fn legacy_kind_from_report(report: &ServerInspectionReport, filename_kind: CoreKind) -> CoreKind {
     let Some(product) = report.identity.implementation.value.as_ref() else {
+        // 多个高置信度实现候选时，不能用文件名擅自打破冲突。
         return CoreKind::Unknown;
     };
     match product.key.as_str() {
@@ -353,27 +351,11 @@ fn extract_version_tokens(input: &str) -> Vec<String> {
     tokens
 }
 
-/// 描述打开或解析服务端核心文件时的失败。
+/// 描述检查服务端核心文件时的失败。
 #[derive(Debug)]
 pub enum CoreParseError {
     InvalidPath {
         path: PathBuf,
-    },
-    Open {
-        path: PathBuf,
-        source: io::Error,
-    },
-    Archive {
-        path: PathBuf,
-        source: ZipError,
-    },
-    Manifest {
-        path: PathBuf,
-        source: ZipError,
-    },
-    ManifestRead {
-        path: PathBuf,
-        source: io::Error,
     },
     Inspection {
         path: PathBuf,
@@ -387,20 +369,6 @@ impl fmt::Display for CoreParseError {
             Self::InvalidPath { path } => {
                 write!(formatter, "core file path has no filename: {}", path.display())
             }
-            Self::Open { path, source } => {
-                write!(formatter, "could not open core file {}: {source}", path.display())
-            }
-            Self::Archive { path, source } => {
-                write!(formatter, "could not parse JAR archive {}: {source}", path.display())
-            }
-            Self::Manifest { path, source } => {
-                write!(formatter, "could not read JAR manifest from {}: {source}", path.display())
-            }
-            Self::ManifestRead { path, source } => write!(
-                formatter,
-                "could not read JAR manifest content from {}: {source}",
-                path.display()
-            ),
             Self::Inspection { path, source } => {
                 write!(formatter, "could not inspect core file {}: {source}", path.display())
             }
@@ -412,8 +380,6 @@ impl std::error::Error for CoreParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::InvalidPath { .. } => None,
-            Self::Open { source, .. } | Self::ManifestRead { source, .. } => Some(source),
-            Self::Archive { source, .. } | Self::Manifest { source, .. } => Some(source),
             Self::Inspection { source, .. } => Some(source),
         }
     }
@@ -421,6 +387,7 @@ impl std::error::Error for CoreParseError {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
@@ -428,7 +395,10 @@ mod tests {
 
     use zip::write::FileOptions;
 
-    use super::{extract_minecraft_version, inspect_core_file, inspect_core_filename, CoreKind};
+    use super::{
+        extract_minecraft_version, inspect_core_file, inspect_core_filename, CoreKind,
+        CoreParseError,
+    };
 
     fn write_test_jar(filename: &str, entries: &[(&str, &str)]) -> PathBuf {
         let timestamp = SystemTime::now()
@@ -624,5 +594,24 @@ mod tests {
         assert_eq!(parsed.kind, CoreKind::Unknown);
         assert_eq!(parsed.core_version, None);
         assert_eq!(parsed.minecraft_version.as_deref(), Some("26.2"));
+    }
+
+    #[test]
+    fn compatibility_projection_wraps_new_inspection_errors() {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "sealantern-core-provisioning-{}-{timestamp}-invalid.jar",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"not a ZIP archive").expect("write invalid JAR");
+
+        let error = inspect_core_file(&path).expect_err("reject invalid JAR");
+        std::fs::remove_file(&path).expect("remove invalid JAR");
+
+        assert!(matches!(error, CoreParseError::Inspection { .. }));
+        assert!(error.source().is_some());
     }
 }


### PR DESCRIPTION
让旧核心解析复用新版服务端检查报告。实例导入和持久化快照接入尚未完成。