### PR TITLE
fix(core): LocalLaunch 参数字段改为 Vec<String>

### DIFF
--- a/crates/core/src/instance/model.rs
+++ b/crates/core/src/instance/model.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -79,9 +78,9 @@ pub struct LocalLaunch {
     pub startup_target: Option<PathBuf>,
     pub custom_command: Option<String>,
     pub custom_executable: Option<PathBuf>,
-    pub custom_arguments: Vec<OsString>,
+    pub custom_arguments: Vec<String>,
     pub java_executable: Option<PathBuf>,
-    pub jvm_arguments: Vec<OsString>,
+    pub jvm_arguments: Vec<String>,
 }
 
 impl LocalLaunch {
@@ -293,7 +292,6 @@ fn normalize_aliases(instance_name: &str, aliases: Vec<String>) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
     use std::path::{Path, PathBuf};
 
     use super::{Instance, InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
@@ -319,7 +317,7 @@ mod tests {
                 custom_executable: None,
                 custom_arguments: Vec::new(),
                 java_executable: Some(Path::new("java").to_path_buf()),
-                jvm_arguments: vec![OsString::from("-Xmx4G")],
+                jvm_arguments: vec!["-Xmx4G".to_string()],
             },
         }
     }
@@ -375,12 +373,12 @@ mod tests {
         spec.launch.startup_mode = StartupMode::Custom;
         spec.launch.startup_target = None;
         spec.launch.custom_executable = Some(PathBuf::from("launch-server.exe"));
-        spec.launch.custom_arguments = vec![OsString::from("--nogui")];
+        spec.launch.custom_arguments = vec!["--nogui".to_string()];
 
         let instance = Instance::new(spec).expect("custom launch should be valid");
 
         assert_eq!(instance.launch.custom_executable, Some(PathBuf::from("launch-server.exe")));
-        assert_eq!(instance.launch.custom_arguments, vec![OsString::from("--nogui")]);
+        assert_eq!(instance.launch.custom_arguments, vec!["--nogui".to_string()]);
     }
 
     #[test]

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -570,7 +570,6 @@ fn missing_diagnostic(field: &str) -> InspectionDiagnostic {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
@@ -779,7 +778,7 @@ mod tests {
     #[test]
     fn adopts_a_unique_jar_launch_and_persists_a_fingerprinted_snapshot() {
         let mut instance = instance_spec();
-        instance.launch.jvm_arguments = vec![OsString::from("-Xmx4G")];
+        instance.launch.jvm_arguments = vec![String::from("-Xmx4G")];
         let path = write_test_jar(
             "paper.jar",
             &[
@@ -809,7 +808,7 @@ mod tests {
 
         assert_eq!(projection.adopted_launch_profile.as_deref(), Some("manifest-main"));
         assert_eq!(instance.launch.startup_target, Some(path));
-        assert_eq!(instance.launch.jvm_arguments, vec![OsString::from("-Xmx4G")]);
+        assert_eq!(instance.launch.jvm_arguments, vec![String::from("-Xmx4G")]);
         assert_eq!(
             instance
                 .server_metadata

--- a/crates/core/src/provisioning/launch_adapter.rs
+++ b/crates/core/src/provisioning/launch_adapter.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::path::Path;
 
 use crate::instance::{LocalLaunch, StartupMode};
@@ -44,11 +43,7 @@ pub(super) fn adapt_launch_profile(
             if !profile.program_arguments.is_empty() {
                 return Err(LaunchAdapterError::ProgramArguments);
             }
-            (
-                StartupMode::Jar,
-                path.clone(),
-                profile.jvm_arguments.iter().map(OsString::from).collect(),
-            )
+            (StartupMode::Jar, path.clone(), profile.jvm_arguments.to_vec())
         }
         LaunchTarget::Script { path } => {
             let Some(mode) = script_startup_mode(path) else {


### PR DESCRIPTION
- custom_arguments / jvm_arguments 从 Vec<OsString> 改为 Vec<String>
- 消除 serde 平台耦合形态（OsString 序列化为 {Windows: [...]} 等），改用可移植字符串，前端/HTTP/插件 API 可直接传字符串数组
- 真正构造进程 Command 时再转 OsString（command_build 边界，本次不受影响）
- 同步测试构造点与 import

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## Summary by Sourcery

更新 LocalLaunch 启动配置，将操作系统相关的字符串参数改为可移植的通用字符串参数。

增强内容：
- 将 LocalLaunch 的 `custom_arguments` 和 `jvm_arguments` 字段从依赖操作系统的类型修改为 `Vec<String>`，以提升可移植性并保持 API 一致性。

测试：
- 调整实例模型测试，用 `Vec<String>` 值来构造并断言启动参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update LocalLaunch launch configuration to use portable string arguments instead of OS-specific strings.

Enhancements:
- Change LocalLaunch custom_arguments and jvm_arguments fields from OS-specific types to Vec<String> for better portability and API consistency.

Tests:
- Adjust instance model tests to construct and assert launch arguments using Vec<String> values.

</details>