### PR TITLE
feat(core): 完成服务端检查接入

### DIFF
--- a/crates/core/src/instance/identity.rs
+++ b/crates/core/src/instance/identity.rs
@@ -51,6 +51,7 @@ mod tests {
             min_memory_mib: 0,
             created_at_unix_secs: 0,
             last_started_at_unix_secs: None,
+            server_metadata: None,
             launch: LocalLaunch {
                 startup_mode: StartupMode::Jar,
                 startup_target: Some(PathBuf::from("servers/paper-main/server.jar")),

--- a/crates/core/src/instance/import.rs
+++ b/crates/core/src/instance/import.rs
@@ -139,6 +139,7 @@ mod tests {
             min_memory_mib: 1024,
             created_at_unix_secs: 100,
             last_started_at_unix_secs: None,
+            server_metadata: None,
             launch: LocalLaunch {
                 startup_mode,
                 startup_target,

--- a/crates/core/src/instance/import.rs
+++ b/crates/core/src/instance/import.rs
@@ -27,6 +27,13 @@ pub fn plan_import(
 ) -> Result<InstanceImportPlan, InstanceImportError> {
     let InstanceImportRequest { source_directory, mut instance } = request;
 
+    tracing::debug!(
+        target: "sealantern.core.provisioning.import",
+        source_directory = %source_directory.display(),
+        destination_directory = %instance.directory.display(),
+        "planning instance import"
+    );
+
     if source_directory.as_os_str().is_empty() {
         return Err(InstanceImportError::EmptySourceDirectory);
     }
@@ -61,12 +68,20 @@ pub fn plan_import(
 
     let instance = Instance::new(instance).map_err(InstanceImportError::Instance)?;
 
-    Ok(InstanceImportPlan {
+    let plan = InstanceImportPlan {
         source_directory,
         destination_directory: instance.directory.clone(),
         startup_target_relative,
         instance,
-    })
+    };
+    tracing::debug!(
+        target: "sealantern.core.provisioning.import",
+        source_directory = %plan.source_directory.display(),
+        destination_directory = %plan.destination_directory.display(),
+        has_startup_target = plan.startup_target_relative.is_some(),
+        "instance import plan ready"
+    );
+    Ok(plan)
 }
 
 /// 描述无法创建实例导入计划的原因。

--- a/crates/core/src/instance/lib.rs
+++ b/crates/core/src/instance/lib.rs
@@ -5,6 +5,7 @@ pub mod lifecycle;
 pub mod model;
 pub mod player;
 pub mod repository;
+pub mod server_metadata;
 
 pub use extension::{InstanceExtension, InstanceExtensionError, InstanceExtensionKind};
 pub use identity::InstanceIdentity;
@@ -16,3 +17,9 @@ pub use lifecycle::{
 pub use model::{Instance, InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
 pub use player::{PlayerName, PlayerNameError, PlayerSnapshot};
 pub use repository::InstanceRepository;
+pub use server_metadata::{
+    ServerMetadataComponent, ServerMetadataDiagnostic, ServerMetadataFingerprint,
+    ServerMetadataIdentity, ServerMetadataJava, ServerMetadataLaunch, ServerMetadataMinecraft,
+    ServerMetadataSnapshot, ServerMetadataSnapshotValidity, ServerMetadataSubject,
+    ServerMetadataSubjectKind, SERVER_METADATA_SNAPSHOT_SCHEMA_VERSION,
+};

--- a/crates/core/src/instance/lifecycle.rs
+++ b/crates/core/src/instance/lifecycle.rs
@@ -339,6 +339,7 @@ mod tests {
             min_memory_mib: 0,
             created_at_unix_secs: 0,
             last_started_at_unix_secs: None,
+            server_metadata: None,
             launch: LocalLaunch {
                 startup_mode: StartupMode::Jar,
                 startup_target: Some(PathBuf::from("servers/restartable/server.jar")),

--- a/crates/core/src/instance/model.rs
+++ b/crates/core/src/instance/model.rs
@@ -145,6 +145,8 @@ pub struct InstanceSpec {
     pub min_memory_mib: u32,
     pub created_at_unix_secs: u64,
     pub last_started_at_unix_secs: Option<u64>,
+    #[serde(default)]
+    pub server_metadata: Option<super::server_metadata::ServerMetadataSnapshot>,
     pub launch: LocalLaunch,
 }
 
@@ -163,6 +165,8 @@ pub struct Instance {
     pub min_memory_mib: u32,
     pub created_at_unix_secs: u64,
     pub last_started_at_unix_secs: Option<u64>,
+    #[serde(default)]
+    pub server_metadata: Option<super::server_metadata::ServerMetadataSnapshot>,
     pub launch: LocalLaunch,
 }
 
@@ -204,6 +208,7 @@ impl Instance {
             min_memory_mib: spec.min_memory_mib,
             created_at_unix_secs: spec.created_at_unix_secs,
             last_started_at_unix_secs: spec.last_started_at_unix_secs,
+            server_metadata: spec.server_metadata,
             launch: spec.launch,
         })
     }
@@ -312,6 +317,7 @@ mod tests {
             min_memory_mib: 1024,
             created_at_unix_secs: 100,
             last_started_at_unix_secs: None,
+            server_metadata: None,
             launch: LocalLaunch {
                 startup_mode: StartupMode::Jar,
                 startup_target: Some(Path::new("servers/instance-a/server.jar").to_path_buf()),
@@ -418,5 +424,20 @@ mod tests {
         let error = StartupMode::parse("docker").expect_err("unknown mode should fail");
 
         assert_eq!(error, InstanceError::UnsupportedStartupMode { value: "docker".to_string() });
+    }
+
+    #[test]
+    fn legacy_instance_json_without_server_metadata_still_deserializes() {
+        let instance = Instance::new(base_spec()).expect("base instance should be valid");
+        let mut value = serde_json::to_value(instance).expect("serialize instance");
+        value
+            .as_object_mut()
+            .expect("instance JSON object")
+            .remove("server_metadata");
+
+        let restored: Instance =
+            serde_json::from_value(value).expect("deserialize legacy instance");
+
+        assert!(restored.server_metadata.is_none());
     }
 }

--- a/crates/core/src/instance/server_metadata.rs
+++ b/crates/core/src/instance/server_metadata.rs
@@ -1,0 +1,181 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+pub const SERVER_METADATA_SNAPSHOT_SCHEMA_VERSION: u16 = 1;
+
+/// 已完成服务端检查后保存的轻量摘要，不包含证据明细。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataSnapshot {
+    pub schema_version: u16,
+    pub inspected_at_unix_secs: u64,
+    pub subject: ServerMetadataSubject,
+    pub identity: Option<ServerMetadataIdentity>,
+    pub minecraft: Option<ServerMetadataMinecraft>,
+    pub java: ServerMetadataJava,
+    pub components: Vec<ServerMetadataComponent>,
+    pub launches: Vec<ServerMetadataLaunch>,
+    pub diagnostics: Vec<ServerMetadataDiagnostic>,
+}
+
+impl ServerMetadataSnapshot {
+    pub fn validity_for(
+        &self,
+        fingerprint: Option<&ServerMetadataFingerprint>,
+    ) -> ServerMetadataSnapshotValidity {
+        if self.schema_version != SERVER_METADATA_SNAPSHOT_SCHEMA_VERSION {
+            return ServerMetadataSnapshotValidity::SchemaMismatch;
+        }
+        let Some(saved) = self.subject.fingerprint.as_ref() else {
+            return ServerMetadataSnapshotValidity::MissingFingerprint;
+        };
+        let Some(current) = fingerprint else {
+            return ServerMetadataSnapshotValidity::MissingFingerprint;
+        };
+        if saved == current {
+            ServerMetadataSnapshotValidity::Current
+        } else {
+            ServerMetadataSnapshotValidity::FingerprintChanged
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataSubject {
+    pub kind: ServerMetadataSubjectKind,
+    pub size_bytes: Option<u64>,
+    pub modified_at_unix_secs: Option<u64>,
+    pub fingerprint: Option<ServerMetadataFingerprint>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerMetadataSubjectKind {
+    File,
+    Directory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataFingerprint {
+    pub algorithm: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataIdentity {
+    pub category: String,
+    pub implementation_key: String,
+    pub implementation_name: String,
+    pub implementation_confidence: u8,
+    pub version: Option<String>,
+    pub version_confidence: u8,
+    pub release_channel: Option<String>,
+    pub ecosystems: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataMinecraft {
+    pub version: Option<String>,
+    pub version_confidence: u8,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub java_version: Option<u16>,
+    pub stable: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ServerMetadataJava {
+    pub required_major: Option<u16>,
+    pub required_major_confidence: u8,
+    pub runtime_component: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataComponent {
+    pub kind: String,
+    pub key: String,
+    pub name: String,
+    pub version: Option<String>,
+    pub confidence: u8,
+    pub source_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataLaunch {
+    pub id: String,
+    pub platform: String,
+    pub target_kind: String,
+    pub target_path: Option<PathBuf>,
+    pub confidence: u8,
+    pub required_java_major: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerMetadataDiagnostic {
+    pub severity: String,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerMetadataSnapshotValidity {
+    Current,
+    FingerprintChanged,
+    MissingFingerprint,
+    SchemaMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ServerMetadataFingerprint, ServerMetadataSnapshot, ServerMetadataSnapshotValidity,
+        ServerMetadataSubject, ServerMetadataSubjectKind, SERVER_METADATA_SNAPSHOT_SCHEMA_VERSION,
+    };
+
+    fn snapshot(value: &str) -> ServerMetadataSnapshot {
+        ServerMetadataSnapshot {
+            schema_version: SERVER_METADATA_SNAPSHOT_SCHEMA_VERSION,
+            inspected_at_unix_secs: 1,
+            subject: ServerMetadataSubject {
+                kind: ServerMetadataSubjectKind::File,
+                size_bytes: Some(1),
+                modified_at_unix_secs: Some(1),
+                fingerprint: Some(ServerMetadataFingerprint {
+                    algorithm: "sha256".to_string(),
+                    value: value.to_string(),
+                }),
+            },
+            identity: None,
+            minecraft: None,
+            java: Default::default(),
+            components: Vec::new(),
+            launches: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_validity_distinguishes_current_and_changed_artifacts() {
+        let current = ServerMetadataFingerprint {
+            algorithm: "sha256".to_string(),
+            value: "abc".to_string(),
+        };
+        let snapshot = snapshot("abc");
+
+        assert_eq!(snapshot.validity_for(Some(&current)), ServerMetadataSnapshotValidity::Current);
+        assert_eq!(
+            snapshot.validity_for(Some(&ServerMetadataFingerprint {
+                algorithm: "sha256".to_string(),
+                value: "def".to_string(),
+            })),
+            ServerMetadataSnapshotValidity::FingerprintChanged
+        );
+        assert_eq!(snapshot.validity_for(None), ServerMetadataSnapshotValidity::MissingFingerprint);
+    }
+
+    #[test]
+    fn serialized_snapshot_does_not_contain_evidence_details() {
+        let json = serde_json::to_string(&snapshot("abc")).expect("serialize snapshot");
+        assert!(!json.contains("evidence"));
+    }
+}

--- a/crates/core/src/provisioning/copy.rs
+++ b/crates/core/src/provisioning/copy.rs
@@ -95,6 +95,7 @@ mod tests {
                 min_memory_mib: 0,
                 created_at_unix_secs: 0,
                 last_started_at_unix_secs: None,
+                server_metadata: None,
                 launch: LocalLaunch {
                     startup_mode: StartupMode::Jar,
                     startup_target: Some(source_directory.join("server.jar")),

--- a/crates/core/src/provisioning/copy.rs
+++ b/crates/core/src/provisioning/copy.rs
@@ -20,6 +20,12 @@ pub struct CopyInstancePlan {
 }
 
 pub fn plan_copy(request: CopyInstanceRequest) -> Result<CopyInstancePlan, CopyInstanceError> {
+    tracing::debug!(
+        target: "sealantern.core.provisioning.copy",
+        source_directory = %request.source_directory.display(),
+        import_source_directory = %request.import.source_directory.display(),
+        "planning instance copy"
+    );
     if request.source_directory.as_os_str().is_empty() {
         return Err(CopyInstanceError::EmptySourceDirectory);
     }
@@ -31,11 +37,18 @@ pub fn plan_copy(request: CopyInstanceRequest) -> Result<CopyInstancePlan, CopyI
     }
 
     let import = plan_import(request.import).map_err(CopyInstanceError::Import)?;
-    Ok(CopyInstancePlan {
+    let plan = CopyInstancePlan {
         source_directory: request.source_directory,
         destination_directory: import.destination_directory.clone(),
         import,
-    })
+    };
+    tracing::debug!(
+        target: "sealantern.core.provisioning.copy",
+        source_directory = %plan.source_directory.display(),
+        destination_directory = %plan.destination_directory.display(),
+        "instance copy plan ready"
+    );
+    Ok(plan)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,15 +81,24 @@ impl std::fmt::Display for CopyInstanceError {
     }
 }
 
-impl std::error::Error for CopyInstanceError {}
+impl std::error::Error for CopyInstanceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Import(error) => Some(error),
+            Self::EmptySourceDirectory | Self::SourceDirectoryMismatch { .. } => None,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
     use std::path::PathBuf;
 
     use super::{plan_copy, CopyInstanceError, CopyInstanceRequest};
     use crate::instance::{
-        InstanceId, InstanceImportRequest, InstanceSpec, LocalLaunch, StartupMode,
+        InstanceId, InstanceImportError, InstanceImportRequest, InstanceSpec, LocalLaunch,
+        StartupMode,
     };
 
     fn import_request(source_directory: PathBuf) -> InstanceImportRequest {
@@ -126,5 +148,12 @@ mod tests {
                 import_source_directory,
             }
         );
+    }
+
+    #[test]
+    fn copy_error_exposes_the_import_error_source() {
+        let error = CopyInstanceError::Import(InstanceImportError::EmptySourceDirectory);
+
+        assert!(error.source().is_some());
     }
 }

--- a/crates/core/src/provisioning/create.rs
+++ b/crates/core/src/provisioning/create.rs
@@ -8,7 +8,18 @@ pub struct CreateInstancePlan {
 
 /// 校验创建输入并生成待持久化实例。
 pub fn plan_create(instance: InstanceSpec) -> Result<CreateInstancePlan, CreateInstanceError> {
+    tracing::debug!(
+        target: "sealantern.core.provisioning.create",
+        instance_id = %instance.id.as_str(),
+        directory = %instance.directory.display(),
+        "planning instance creation"
+    );
     let instance = Instance::new(instance).map_err(CreateInstanceError::Instance)?;
+    tracing::debug!(
+        target: "sealantern.core.provisioning.create",
+        instance_id = %instance.id.as_str(),
+        "instance creation plan ready"
+    );
     Ok(CreateInstancePlan { instance })
 }
 
@@ -27,4 +38,10 @@ impl std::fmt::Display for CreateInstanceError {
     }
 }
 
-impl std::error::Error for CreateInstanceError {}
+impl std::error::Error for CreateInstanceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Instance(error) => Some(error),
+        }
+    }
+}

--- a/crates/core/src/provisioning/existing.rs
+++ b/crates/core/src/provisioning/existing.rs
@@ -24,4 +24,10 @@ impl std::fmt::Display for ExistingInstanceError {
     }
 }
 
-impl std::error::Error for ExistingInstanceError {}
+impl std::error::Error for ExistingInstanceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Import(error) => Some(error),
+        }
+    }
+}

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -6,9 +5,10 @@ use crate::instance::{
     InstanceSpec, LocalLaunch, ServerMetadataComponent, ServerMetadataDiagnostic,
     ServerMetadataFingerprint, ServerMetadataIdentity, ServerMetadataJava, ServerMetadataLaunch,
     ServerMetadataMinecraft, ServerMetadataSnapshot, ServerMetadataSubject,
-    ServerMetadataSubjectKind, StartupMode,
+    ServerMetadataSubjectKind,
 };
 
+use super::launch_adapter::adapt_launch_profile;
 use super::server_inspection::{
     inspect_server_artifact, Detected, DiagnosticSeverity, InspectionDiagnostic, InspectionOptions,
     LaunchPlatform, LaunchProfile, LaunchTarget, ReleaseChannel, ServerInspectionError,
@@ -238,47 +238,11 @@ fn compatible_launch_candidate(
         return None;
     }
 
-    let (startup_mode, startup_target, jvm_arguments) = match &profile.target {
-        LaunchTarget::Jar { path } => {
-            if !profile.program_arguments.is_empty() {
-                diagnostics.push(launch_diagnostic(
-                    "launch_profile_program_arguments_unsupported",
-                    &profile.id,
-                    "launch profile has program arguments that LocalLaunch cannot represent; choose it manually",
-                ));
-                return None;
-            }
-            (
-                StartupMode::Jar,
-                path.clone(),
-                profile.jvm_arguments.iter().map(OsString::from).collect(),
-            )
-        }
-        LaunchTarget::Script { path } => {
-            let Some(mode) = script_startup_mode(path) else {
-                diagnostics.push(launch_diagnostic(
-                    "launch_profile_script_type_unsupported",
-                    &profile.id,
-                    "launch profile script extension is not supported by LocalLaunch; choose it manually",
-                ));
-                return None;
-            };
-            (mode, path.clone(), Vec::new())
-        }
-        LaunchTarget::MainClass { .. } => {
-            diagnostics.push(launch_diagnostic(
-                "launch_profile_main_class_unrepresentable",
-                &profile.id,
-                "LocalLaunch cannot represent a main-class target; choose a concrete launcher manually",
-            ));
-            return None;
-        }
-        LaunchTarget::ArgumentFiles { .. } => {
-            diagnostics.push(launch_diagnostic(
-                "launch_profile_argument_files_unrepresentable",
-                &profile.id,
-                "LocalLaunch cannot represent argument-file targets; choose a concrete launcher manually",
-            ));
+    let launch = match adapt_launch_profile(profile) {
+        Ok(launch) => launch,
+        Err(error) => {
+            let (code, detail) = error.diagnostic();
+            diagnostics.push(launch_diagnostic(code, &profile.id, detail));
             return None;
         }
     };
@@ -286,15 +250,7 @@ fn compatible_launch_candidate(
     Some(ImportLaunchCandidate {
         profile_id: profile.id.clone(),
         confidence: attributed.confidence,
-        launch: LocalLaunch {
-            startup_mode,
-            startup_target: Some(startup_target),
-            custom_command: None,
-            custom_executable: None,
-            custom_arguments: Vec::new(),
-            java_executable: None,
-            jvm_arguments,
-        },
+        launch,
         required_java_major: profile.required_java_major,
     })
 }
@@ -355,15 +311,6 @@ fn platform_matches_host(platform: LaunchPlatform) -> bool {
         LaunchPlatform::Any => true,
         LaunchPlatform::Windows => cfg!(target_os = "windows"),
         LaunchPlatform::Unix => cfg!(unix),
-    }
-}
-
-fn script_startup_mode(path: &Path) -> Option<StartupMode> {
-    match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
-        "bat" | "cmd" => Some(StartupMode::Batch),
-        "sh" => Some(StartupMode::Shell),
-        "ps1" => Some(StartupMode::PowerShell),
-        _ => None,
     }
 }
 

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -1,0 +1,332 @@
+use crate::instance::InstanceSpec;
+
+use super::server_inspection::{
+    Detected, DiagnosticSeverity, InspectionDiagnostic, ServerInspectionError,
+    ServerInspectionReport,
+};
+
+/// 将主机已经完成的服务端检查结果投影到实例导入元数据。
+///
+/// 该函数只处理报告，不读取路径、不执行脚本。检查失败、字段缺失或候选冲突时，
+/// 保留调用方已有的值，并返回可供导入界面展示的诊断。
+pub fn apply_server_inspection(
+    instance: &mut InstanceSpec,
+    inspection: Result<&ServerInspectionReport, &ServerInspectionError>,
+) -> Vec<InspectionDiagnostic> {
+    let report = match inspection {
+        Ok(report) => report,
+        Err(error) => {
+            return vec![InspectionDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                code: "server_inspection_failed".to_string(),
+                message: format!(
+                    "server inspection failed ({error}); existing import metadata was preserved; retry inspection or choose values manually"
+                ),
+                evidence: Vec::new(),
+            }]
+        }
+    };
+
+    let mut diagnostics = report.diagnostics.clone();
+    if let Some(product) = report
+        .identity
+        .implementation
+        .value
+        .as_ref()
+        .filter(|product| !product.key.trim().is_empty())
+    {
+        instance.core_type = product.key.trim().to_string();
+    } else {
+        diagnostics.push(unresolved_diagnostic(
+            "server implementation",
+            &report.identity.implementation,
+            |product| product.key.clone(),
+        ));
+    }
+
+    if let Some(version) = report
+        .identity
+        .version
+        .value
+        .as_ref()
+        .filter(|version| !version.trim().is_empty())
+    {
+        instance.core_version = version.trim().to_string();
+    } else {
+        diagnostics.push(unresolved_diagnostic(
+            "server implementation version",
+            &report.identity.version,
+            |version| version.clone(),
+        ));
+    }
+
+    match report.minecraft.as_ref() {
+        Some(minecraft) => {
+            if let Some(version) = minecraft
+                .version
+                .value
+                .as_ref()
+                .filter(|version| !version.trim().is_empty())
+            {
+                instance.game_version = version.trim().to_string();
+            } else {
+                diagnostics.push(unresolved_diagnostic(
+                    "Minecraft version",
+                    &minecraft.version,
+                    |version| version.clone(),
+                ));
+            }
+        }
+        None => diagnostics.push(missing_diagnostic("Minecraft version")),
+    }
+
+    diagnostics
+}
+
+fn unresolved_diagnostic<T, F>(
+    field: &str,
+    detected: &Detected<T>,
+    format_candidate: F,
+) -> InspectionDiagnostic
+where
+    F: Fn(&T) -> String,
+{
+    if detected.alternatives.is_empty() {
+        return missing_diagnostic(field);
+    }
+
+    let candidates = detected
+        .alternatives
+        .iter()
+        .map(|candidate| {
+            format!("{} (confidence {})", format_candidate(&candidate.value), candidate.confidence)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: format!(
+            "server_inspection_{}_ambiguous",
+            field.replace(' ', "_").to_ascii_lowercase()
+        ),
+        message: format!(
+            "{field} is ambiguous ({candidates}); existing import metadata was preserved; choose a value manually or provide stronger metadata"
+        ),
+        evidence: detected.evidence.clone(),
+    }
+}
+
+fn missing_diagnostic(field: &str) -> InspectionDiagnostic {
+    InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: format!(
+            "server_inspection_{}_unresolved",
+            field.replace(' ', "_").to_ascii_lowercase()
+        ),
+        message: format!(
+            "{field} was not identified; existing import metadata was preserved; choose a value manually or provide stronger metadata"
+        ),
+        evidence: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::apply_server_inspection;
+    use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+    use crate::provisioning::{inspect_server_artifact, InspectionOptions};
+    use zip::write::FileOptions;
+
+    fn instance_spec() -> InstanceSpec {
+        InstanceSpec {
+            id: InstanceId::new("imported").expect("instance ID should be valid"),
+            name: "Imported".to_string(),
+            aliases: Vec::new(),
+            core_type: "paper".to_string(),
+            core_version: "old-core".to_string(),
+            game_version: "old-game".to_string(),
+            directory: PathBuf::from("managed/imported"),
+            port: 25565,
+            max_memory_mib: 4096,
+            min_memory_mib: 1024,
+            created_at_unix_secs: 100,
+            last_started_at_unix_secs: None,
+            launch: LocalLaunch {
+                startup_mode: StartupMode::Jar,
+                startup_target: Some(PathBuf::from("imports/server.jar")),
+                custom_command: None,
+                custom_executable: None,
+                custom_arguments: Vec::new(),
+                java_executable: None,
+                jvm_arguments: Vec::new(),
+            },
+        }
+    }
+
+    fn write_test_jar(filename: &str, entries: &[(&str, &str)]) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "sealantern-import-metadata-{}-{timestamp}-{filename}",
+            std::process::id()
+        ));
+        let file = File::create(&path).expect("create test JAR");
+        let mut archive = zip::ZipWriter::new(file);
+        for (name, content) in entries {
+            archive
+                .start_file(*name, FileOptions::<()>::default())
+                .expect("create metadata entry");
+            archive
+                .write_all(content.as_bytes())
+                .expect("write metadata entry");
+        }
+        archive.finish().expect("finish test JAR");
+        path
+    }
+
+    #[test]
+    fn projects_unknown_paperclip_product_and_preserves_open_product_key() {
+        let mut instance = instance_spec();
+        let path = write_test_jar(
+            "custom-fork.jar",
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: io.papermc.paperclip.Main\r\n\r\n",
+                ),
+                (
+                    "META-INF/versions.list",
+                    "hash\t26.2\t26.2/custom-fork-26.2.jar\n",
+                ),
+                (
+                    "META-INF/libraries.list",
+                    "hash\texample.server:custom-fork-api:26.2.build.1-stable\tcustom-fork-api.jar\n",
+                ),
+            ],
+        );
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect unknown Paperclip fixture");
+        std::fs::remove_file(&path).expect("remove unknown Paperclip fixture");
+
+        let diagnostics = apply_server_inspection(&mut instance, Ok(&report));
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(instance.core_type, "custom-fork");
+        assert_eq!(instance.core_version, "26.2.build.1-stable");
+        assert_eq!(instance.game_version, "26.2");
+    }
+
+    #[test]
+    fn projects_paperclip_derived_product_and_build_version() {
+        let mut instance = instance_spec();
+        let path = write_test_jar(
+            "purpur.jar",
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/purpur-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\torg.purpurmc.purpur:purpur-api:26.2.build.2618-stable\tpurpur-api.jar\n",
+                ),
+            ],
+        );
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect Paperclip fixture");
+        std::fs::remove_file(&path).expect("remove Paperclip fixture");
+
+        let diagnostics = apply_server_inspection(&mut instance, Ok(&report));
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(instance.core_type, "purpur");
+        assert_eq!(instance.core_version, "26.2.build.2618-stable");
+        assert_eq!(instance.game_version, "26.2");
+    }
+
+    #[test]
+    fn projects_fabric_loader_version_instead_of_installer_version() {
+        let mut instance = instance_spec();
+        let path = write_test_jar(
+            "fabric.jar",
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Implementation-Title: FabricInstaller\r\nImplementation-Version: 1.1.1\r\nMain-Class: net.fabricmc.installer.ServerLauncher\r\n\r\n",
+                ),
+                (
+                    "install.properties",
+                    "fabric-loader-version=0.19.3\ngame-version=26.2\n",
+                ),
+            ],
+        );
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect Fabric fixture");
+        std::fs::remove_file(&path).expect("remove Fabric fixture");
+
+        let diagnostics = apply_server_inspection(&mut instance, Ok(&report));
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(instance.core_type, "fabric");
+        assert_eq!(instance.core_version, "0.19.3");
+        assert_ne!(instance.core_version, "1.1.1");
+    }
+
+    #[test]
+    fn preserves_conflicting_fields_and_applies_selected_minecraft_version() {
+        let mut instance = instance_spec();
+        let path = write_test_jar(
+            "conflicting.jar",
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/purpur-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\tio.papermc.paper:paper-api:26.2.build.87-stable\tpaper-api.jar\n",
+                ),
+            ],
+        );
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect conflicting Paperclip fixture");
+        std::fs::remove_file(&path).expect("remove conflicting Paperclip fixture");
+
+        let diagnostics = apply_server_inspection(&mut instance, Ok(&report));
+
+        assert_eq!(instance.core_type, "paper");
+        assert_eq!(instance.core_version, "old-core");
+        assert_eq!(instance.game_version, "26.2");
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "server_inspection_server_implementation_ambiguous"
+        }));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "server_inspection_server_implementation_version_unresolved"
+        }));
+    }
+
+    #[test]
+    fn preserves_existing_values_when_inspection_fails() {
+        let mut instance = instance_spec();
+        let path = std::env::temp_dir()
+            .join(format!("sealantern-import-metadata-{}-invalid.jar", std::process::id()));
+        std::fs::write(&path, b"not a ZIP archive").expect("write invalid JAR");
+        let inspection = inspect_server_artifact(&path, &InspectionOptions::default());
+        std::fs::remove_file(&path).expect("remove invalid JAR");
+
+        let diagnostics = apply_server_inspection(&mut instance, inspection.as_ref());
+
+        assert!(inspection.is_err());
+        assert_eq!(instance.core_type, "paper");
+        assert_eq!(instance.core_version, "old-core");
+        assert_eq!(instance.game_version, "old-game");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "server_inspection_failed");
+        assert!(diagnostics[0]
+            .message
+            .contains("existing import metadata was preserved"));
+    }
+}

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -1,9 +1,56 @@
-use crate::instance::InstanceSpec;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::instance::{
+    InstanceSpec, LocalLaunch, ServerMetadataComponent, ServerMetadataDiagnostic,
+    ServerMetadataFingerprint, ServerMetadataIdentity, ServerMetadataJava, ServerMetadataLaunch,
+    ServerMetadataMinecraft, ServerMetadataSnapshot, ServerMetadataSubject,
+    ServerMetadataSubjectKind, StartupMode,
+};
 
 use super::server_inspection::{
-    Detected, DiagnosticSeverity, InspectionDiagnostic, ServerInspectionError,
+    inspect_server_artifact, Detected, DiagnosticSeverity, InspectionDiagnostic, InspectionOptions,
+    LaunchPlatform, LaunchProfile, LaunchTarget, ReleaseChannel, ServerInspectionError,
     ServerInspectionReport,
 };
+
+/// 控制检查结果是否可以替换已有的启动配置。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchProfilePolicy {
+    PreserveExisting,
+    AdoptBestCompatible,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerInspectionProjectionOptions {
+    pub launch_profile_policy: LaunchProfilePolicy,
+    pub inspected_at_unix_secs: Option<u64>,
+}
+
+impl Default for ServerInspectionProjectionOptions {
+    fn default() -> Self {
+        Self {
+            launch_profile_policy: LaunchProfilePolicy::PreserveExisting,
+            inspected_at_unix_secs: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportLaunchCandidate {
+    pub profile_id: String,
+    pub confidence: u8,
+    pub launch: LocalLaunch,
+    pub required_java_major: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerInspectionProjection {
+    pub diagnostics: Vec<InspectionDiagnostic>,
+    pub launch_candidates: Vec<ImportLaunchCandidate>,
+    pub adopted_launch_profile: Option<String>,
+}
 
 /// 将主机已经完成的服务端检查结果投影到实例导入元数据。
 ///
@@ -13,17 +60,30 @@ pub fn apply_server_inspection(
     instance: &mut InstanceSpec,
     inspection: Result<&ServerInspectionReport, &ServerInspectionError>,
 ) -> Vec<InspectionDiagnostic> {
+    apply_server_inspection_with_options(instance, inspection, &Default::default()).diagnostics
+}
+
+/// 将检查结果投影到导入元数据，并按显式策略生成或采纳启动候选。
+pub fn apply_server_inspection_with_options(
+    instance: &mut InstanceSpec,
+    inspection: Result<&ServerInspectionReport, &ServerInspectionError>,
+    options: &ServerInspectionProjectionOptions,
+) -> ServerInspectionProjection {
     let report = match inspection {
         Ok(report) => report,
         Err(error) => {
-            return vec![InspectionDiagnostic {
-                severity: DiagnosticSeverity::Error,
-                code: "server_inspection_failed".to_string(),
-                message: format!(
-                    "server inspection failed ({error}); existing import metadata was preserved; retry inspection or choose values manually"
-                ),
-                evidence: Vec::new(),
-            }]
+            return ServerInspectionProjection {
+                diagnostics: vec![InspectionDiagnostic {
+                    severity: DiagnosticSeverity::Error,
+                    code: "server_inspection_failed".to_string(),
+                    message: format!(
+                        "server inspection failed ({error}); existing import metadata was preserved; retry inspection or choose values manually"
+                    ),
+                    evidence: Vec::new(),
+                }],
+                launch_candidates: Vec::new(),
+                adopted_launch_profile: None,
+            };
         }
     };
 
@@ -80,7 +140,393 @@ pub fn apply_server_inspection(
         None => diagnostics.push(missing_diagnostic("Minecraft version")),
     }
 
-    diagnostics
+    let launch_candidates = compatible_launch_candidates(report, &mut diagnostics);
+    let adopted_launch_profile =
+        if options.launch_profile_policy == LaunchProfilePolicy::AdoptBestCompatible {
+            adopt_best_launch(instance, &launch_candidates, &mut diagnostics)
+        } else {
+            None
+        };
+
+    instance.server_metadata = Some(snapshot_from_report(
+        report,
+        options
+            .inspected_at_unix_secs
+            .unwrap_or_else(current_unix_secs),
+    ));
+
+    ServerInspectionProjection {
+        diagnostics,
+        launch_candidates,
+        adopted_launch_profile,
+    }
+}
+
+/// 检查文件或目录并立即生成导入投影。此函数是主机适配层的显式 I/O 边界。
+pub fn inspect_and_apply_import_metadata(
+    instance: &mut InstanceSpec,
+    subject_path: &Path,
+    inspection_options: &InspectionOptions,
+    projection_options: &ServerInspectionProjectionOptions,
+) -> Result<ServerInspectionProjection, ServerInspectionError> {
+    let mut options = inspection_options.clone();
+    options.compute_sha256 = true;
+    let report = inspect_server_artifact(subject_path, &options)?;
+    Ok(apply_server_inspection_with_options(instance, Ok(&report), projection_options))
+}
+
+fn compatible_launch_candidates(
+    report: &ServerInspectionReport,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Vec<ImportLaunchCandidate> {
+    report
+        .launches
+        .iter()
+        .filter_map(|launch| compatible_launch_candidate(launch, diagnostics))
+        .collect()
+}
+
+fn compatible_launch_candidate(
+    attributed: &super::server_inspection::Attributed<LaunchProfile>,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Option<ImportLaunchCandidate> {
+    let profile = &attributed.value;
+    if !platform_matches_host(profile.platform) {
+        diagnostics.push(launch_diagnostic(
+            "launch_profile_platform_mismatch",
+            &profile.id,
+            "launch profile targets a different host platform; it was kept as a manual candidate",
+        ));
+        return None;
+    }
+
+    let (startup_mode, startup_target, jvm_arguments) = match &profile.target {
+        LaunchTarget::Jar { path } => {
+            if !profile.program_arguments.is_empty() {
+                diagnostics.push(launch_diagnostic(
+                    "launch_profile_program_arguments_unsupported",
+                    &profile.id,
+                    "launch profile has program arguments that LocalLaunch cannot represent; choose it manually",
+                ));
+                return None;
+            }
+            (
+                StartupMode::Jar,
+                path.clone(),
+                profile.jvm_arguments.iter().map(OsString::from).collect(),
+            )
+        }
+        LaunchTarget::Script { path } => {
+            let Some(mode) = script_startup_mode(path) else {
+                diagnostics.push(launch_diagnostic(
+                    "launch_profile_script_type_unsupported",
+                    &profile.id,
+                    "launch profile script extension is not supported by LocalLaunch; choose it manually",
+                ));
+                return None;
+            };
+            (mode, path.clone(), Vec::new())
+        }
+        LaunchTarget::MainClass { .. } => {
+            diagnostics.push(launch_diagnostic(
+                "launch_profile_main_class_unrepresentable",
+                &profile.id,
+                "LocalLaunch cannot represent a main-class target; choose a concrete launcher manually",
+            ));
+            return None;
+        }
+        LaunchTarget::ArgumentFiles { .. } => {
+            diagnostics.push(launch_diagnostic(
+                "launch_profile_argument_files_unrepresentable",
+                &profile.id,
+                "LocalLaunch cannot represent argument-file targets; choose a concrete launcher manually",
+            ));
+            return None;
+        }
+    };
+
+    Some(ImportLaunchCandidate {
+        profile_id: profile.id.clone(),
+        confidence: attributed.confidence,
+        launch: LocalLaunch {
+            startup_mode,
+            startup_target: Some(startup_target),
+            custom_command: None,
+            custom_executable: None,
+            custom_arguments: Vec::new(),
+            java_executable: None,
+            jvm_arguments,
+        },
+        required_java_major: profile.required_java_major,
+    })
+}
+
+fn adopt_best_launch(
+    instance: &mut InstanceSpec,
+    candidates: &[ImportLaunchCandidate],
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) -> Option<String> {
+    if instance.launch.custom_command.is_some()
+        || instance.launch.custom_executable.is_some()
+        || !instance.launch.custom_arguments.is_empty()
+    {
+        diagnostics.push(InspectionDiagnostic {
+            severity: DiagnosticSeverity::Info,
+            code: "launch_profile_preserved_custom_configuration".to_string(),
+            message: "existing custom launch configuration was preserved".to_string(),
+            evidence: Vec::new(),
+        });
+        return None;
+    }
+    let best_confidence = candidates
+        .iter()
+        .map(|candidate| candidate.confidence)
+        .max()?;
+    let best = candidates
+        .iter()
+        .filter(|candidate| candidate.confidence == best_confidence)
+        .collect::<Vec<_>>();
+    if best.len() != 1 {
+        diagnostics.push(InspectionDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: "launch_profile_ambiguous".to_string(),
+            message: format!(
+                "{} compatible launch profiles share confidence {best_confidence}; existing launch configuration was preserved",
+                best.len()
+            ),
+            evidence: Vec::new(),
+        });
+        return None;
+    }
+    let candidate = best[0];
+    let java_executable = instance.launch.java_executable.clone();
+    instance.launch = candidate.launch.clone();
+    instance.launch.java_executable = java_executable;
+    Some(candidate.profile_id.clone())
+}
+
+fn platform_matches_host(platform: LaunchPlatform) -> bool {
+    match platform {
+        LaunchPlatform::Any => true,
+        LaunchPlatform::Windows => cfg!(target_os = "windows"),
+        LaunchPlatform::Unix => cfg!(unix),
+    }
+}
+
+fn script_startup_mode(path: &Path) -> Option<StartupMode> {
+    match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
+        "bat" | "cmd" => Some(StartupMode::Batch),
+        "sh" => Some(StartupMode::Shell),
+        "ps1" => Some(StartupMode::PowerShell),
+        _ => None,
+    }
+}
+
+fn launch_diagnostic(code: &str, profile_id: &str, detail: &str) -> InspectionDiagnostic {
+    InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: code.to_string(),
+        message: format!("launch profile {profile_id}: {detail}"),
+        evidence: Vec::new(),
+    }
+}
+
+fn snapshot_from_report(
+    report: &ServerInspectionReport,
+    inspected_at_unix_secs: u64,
+) -> ServerMetadataSnapshot {
+    ServerMetadataSnapshot {
+        schema_version: crate::instance::SERVER_METADATA_SNAPSHOT_SCHEMA_VERSION,
+        inspected_at_unix_secs,
+        subject: ServerMetadataSubject {
+            kind: match report.subject.kind {
+                super::server_inspection::InspectionSubjectKind::File => {
+                    ServerMetadataSubjectKind::File
+                }
+                super::server_inspection::InspectionSubjectKind::Directory => {
+                    ServerMetadataSubjectKind::Directory
+                }
+            },
+            size_bytes: report.subject.size_bytes,
+            modified_at_unix_secs: report.subject.modified_at_unix_secs,
+            fingerprint: report.subject.fingerprint.as_ref().map(|fingerprint| {
+                ServerMetadataFingerprint {
+                    algorithm: fingerprint_algorithm_name(fingerprint.algorithm).to_string(),
+                    value: fingerprint.value.clone(),
+                }
+            }),
+        },
+        identity: report
+            .identity
+            .implementation
+            .value
+            .as_ref()
+            .map(|implementation| ServerMetadataIdentity {
+                category: category_name(report.identity.category.value),
+                implementation_key: implementation.key.clone(),
+                implementation_name: implementation.display_name.clone(),
+                implementation_confidence: report.identity.implementation.confidence,
+                version: report.identity.version.value.clone(),
+                version_confidence: report.identity.version.confidence,
+                release_channel: report
+                    .identity
+                    .release_channel
+                    .value
+                    .map(release_channel_name),
+                ecosystems: report
+                    .identity
+                    .ecosystems
+                    .iter()
+                    .map(|ecosystem| ecosystem_name(&ecosystem.value))
+                    .collect(),
+            }),
+        minecraft: report
+            .minecraft
+            .as_ref()
+            .map(|minecraft| ServerMetadataMinecraft {
+                version: minecraft.version.value.clone(),
+                version_confidence: minecraft.version.confidence,
+                id: minecraft.id.clone(),
+                name: minecraft.name.clone(),
+                java_version: minecraft.java_version,
+                stable: minecraft.stable,
+            }),
+        java: ServerMetadataJava {
+            required_major: report.java.required_major.value,
+            required_major_confidence: report.java.required_major.confidence,
+            runtime_component: report.java.runtime_component.value.clone(),
+        },
+        components: report
+            .components
+            .iter()
+            .map(|component| ServerMetadataComponent {
+                kind: component_kind_name(component.value.kind).to_string(),
+                key: component.value.key.clone(),
+                name: component.value.name.clone(),
+                version: component.value.version.clone(),
+                confidence: component.confidence,
+                source_path: component.value.source_path.clone(),
+            })
+            .collect(),
+        launches: report
+            .launches
+            .iter()
+            .map(|launch| {
+                let (target_kind, target_path) = launch_target_summary(&launch.value.target);
+                ServerMetadataLaunch {
+                    id: launch.value.id.clone(),
+                    platform: launch_platform_name(launch.value.platform).to_string(),
+                    target_kind: target_kind.to_string(),
+                    target_path,
+                    confidence: launch.confidence,
+                    required_java_major: launch.value.required_java_major,
+                }
+            })
+            .collect(),
+        diagnostics: report
+            .diagnostics
+            .iter()
+            .map(|diagnostic| ServerMetadataDiagnostic {
+                severity: diagnostic_severity_name(diagnostic.severity).to_string(),
+                code: diagnostic.code.clone(),
+                message: diagnostic.message.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn current_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn fingerprint_algorithm_name(
+    algorithm: super::server_inspection::FingerprintAlgorithm,
+) -> &'static str {
+    match algorithm {
+        super::server_inspection::FingerprintAlgorithm::Sha256 => "sha256",
+    }
+}
+
+fn category_name(category: Option<super::server_inspection::ServerCategory>) -> String {
+    match category {
+        Some(super::server_inspection::ServerCategory::JavaGameServer) => "java_game_server",
+        Some(super::server_inspection::ServerCategory::BedrockGameServer) => "bedrock_game_server",
+        Some(super::server_inspection::ServerCategory::Proxy) => "proxy",
+        Some(super::server_inspection::ServerCategory::Limbo) => "limbo",
+        Some(super::server_inspection::ServerCategory::Unknown) | None => "unknown",
+    }
+    .to_string()
+}
+
+fn release_channel_name(channel: ReleaseChannel) -> String {
+    match channel {
+        ReleaseChannel::Stable => "stable",
+        ReleaseChannel::ReleaseCandidate => "release_candidate",
+        ReleaseChannel::Beta => "beta",
+        ReleaseChannel::Alpha => "alpha",
+        ReleaseChannel::Snapshot => "snapshot",
+        ReleaseChannel::Development => "development",
+        ReleaseChannel::Unknown => "unknown",
+    }
+    .to_string()
+}
+
+fn ecosystem_name(ecosystem: &super::server_inspection::ServerEcosystem) -> String {
+    match ecosystem {
+        super::server_inspection::ServerEcosystem::Vanilla => "vanilla".to_string(),
+        super::server_inspection::ServerEcosystem::Bukkit => "bukkit".to_string(),
+        super::server_inspection::ServerEcosystem::Paper => "paper".to_string(),
+        super::server_inspection::ServerEcosystem::Fabric => "fabric".to_string(),
+        super::server_inspection::ServerEcosystem::LegacyFabric => "legacy_fabric".to_string(),
+        super::server_inspection::ServerEcosystem::Quilt => "quilt".to_string(),
+        super::server_inspection::ServerEcosystem::Forge => "forge".to_string(),
+        super::server_inspection::ServerEcosystem::NeoForge => "neoforge".to_string(),
+        super::server_inspection::ServerEcosystem::Sponge => "sponge".to_string(),
+        super::server_inspection::ServerEcosystem::Bungee => "bungee".to_string(),
+        super::server_inspection::ServerEcosystem::Velocity => "velocity".to_string(),
+        super::server_inspection::ServerEcosystem::Other(value) => value.clone(),
+    }
+}
+
+fn component_kind_name(kind: super::server_inspection::ServerComponentKind) -> &'static str {
+    match kind {
+        super::server_inspection::ServerComponentKind::Implementation => "implementation",
+        super::server_inspection::ServerComponentKind::Api => "api",
+        super::server_inspection::ServerComponentKind::ModLoader => "mod_loader",
+        super::server_inspection::ServerComponentKind::Installer => "installer",
+        super::server_inspection::ServerComponentKind::Launcher => "launcher",
+        super::server_inspection::ServerComponentKind::Bootstrap => "bootstrap",
+        super::server_inspection::ServerComponentKind::Mapping => "mapping",
+        super::server_inspection::ServerComponentKind::Wrapper => "wrapper",
+    }
+}
+
+fn launch_platform_name(platform: LaunchPlatform) -> &'static str {
+    match platform {
+        LaunchPlatform::Any => "any",
+        LaunchPlatform::Windows => "windows",
+        LaunchPlatform::Unix => "unix",
+    }
+}
+
+fn launch_target_summary(target: &LaunchTarget) -> (&'static str, Option<PathBuf>) {
+    match target {
+        LaunchTarget::Jar { path } => ("jar", Some(path.clone())),
+        LaunchTarget::MainClass { .. } => ("main_class", None),
+        LaunchTarget::ArgumentFiles { paths } => ("argument_files", paths.first().cloned()),
+        LaunchTarget::Script { path } => ("script", Some(path.clone())),
+    }
+}
+
+fn diagnostic_severity_name(severity: DiagnosticSeverity) -> &'static str {
+    match severity {
+        DiagnosticSeverity::Info => "info",
+        DiagnosticSeverity::Warning => "warning",
+        DiagnosticSeverity::Error => "error",
+    }
 }
 
 fn unresolved_diagnostic<T, F>(
@@ -137,7 +583,10 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::apply_server_inspection;
+    use super::{
+        apply_server_inspection, apply_server_inspection_with_options, LaunchProfilePolicy,
+        ServerInspectionProjectionOptions,
+    };
     use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
     use crate::provisioning::{inspect_server_artifact, InspectionOptions};
     use zip::write::FileOptions;
@@ -156,6 +605,7 @@ mod tests {
             min_memory_mib: 1024,
             created_at_unix_secs: 100,
             last_started_at_unix_secs: None,
+            server_metadata: None,
             launch: LocalLaunch {
                 startup_mode: StartupMode::Jar,
                 startup_target: Some(PathBuf::from("imports/server.jar")),
@@ -328,5 +778,79 @@ mod tests {
         assert!(diagnostics[0]
             .message
             .contains("existing import metadata was preserved"));
+    }
+
+    #[test]
+    fn adopts_a_unique_jar_launch_and_persists_a_fingerprinted_snapshot() {
+        let mut instance = instance_spec();
+        let path = write_test_jar(
+            "paper.jar",
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/paper-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\tio.papermc.paper:paper-api:26.2.build.87-stable\tpaper-api.jar\n",
+                ),
+            ],
+        );
+        let inspection_options = InspectionOptions {
+            compute_sha256: true,
+            ..InspectionOptions::default()
+        };
+        let report = inspect_server_artifact(&path, &inspection_options)
+            .expect("inspect launch candidate fixture");
+        let projection = apply_server_inspection_with_options(
+            &mut instance,
+            Ok(&report),
+            &ServerInspectionProjectionOptions {
+                launch_profile_policy: LaunchProfilePolicy::AdoptBestCompatible,
+                inspected_at_unix_secs: Some(42),
+            },
+        );
+        std::fs::remove_file(&path).expect("remove launch candidate fixture");
+
+        assert_eq!(projection.adopted_launch_profile.as_deref(), Some("manifest-main"));
+        assert_eq!(instance.launch.startup_target, Some(path));
+        assert_eq!(
+            instance
+                .server_metadata
+                .as_ref()
+                .map(|snapshot| snapshot.inspected_at_unix_secs),
+            Some(42)
+        );
+        assert!(instance
+            .server_metadata
+            .as_ref()
+            .and_then(|snapshot| snapshot.subject.fingerprint.as_ref())
+            .is_some());
+    }
+
+    #[test]
+    fn preserves_existing_launch_by_default_but_exposes_candidates() {
+        let mut instance = instance_spec();
+        let path = write_test_jar(
+            "candidate.jar",
+            &[("META-INF/MANIFEST.MF", "Main-Class: example.Server\r\n\r\n")],
+        );
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect candidate fixture");
+        std::fs::remove_file(&path).expect("remove candidate fixture");
+
+        let projection = apply_server_inspection_with_options(
+            &mut instance,
+            Ok(&report),
+            &ServerInspectionProjectionOptions::default(),
+        );
+
+        assert_eq!(projection.launch_candidates.len(), 1);
+        assert_eq!(instance.launch.startup_target, Some(PathBuf::from("imports/server.jar")));
+        assert_eq!(
+            instance
+                .server_metadata
+                .as_ref()
+                .map(|snapshot| snapshot.schema_version),
+            Some(1)
+        );
     }
 }

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -72,9 +72,21 @@ pub fn apply_server_inspection_with_options(
     inspection: Result<&ServerInspectionReport, &ServerInspectionError>,
     options: &ServerInspectionProjectionOptions,
 ) -> ServerInspectionProjection {
+    tracing::debug!(
+        target: "sealantern.core.provisioning.import",
+        instance_id = %instance.id.as_str(),
+        launch_policy = ?options.launch_profile_policy,
+        "projecting server inspection into import metadata"
+    );
     let report = match inspection {
         Ok(report) => report,
         Err(error) => {
+            tracing::warn!(
+                target: "sealantern.core.provisioning.import",
+                instance_id = %instance.id.as_str(),
+                error = %error,
+                "server inspection projection skipped after inspection failure"
+            );
             return ServerInspectionProjection {
                 diagnostics: vec![InspectionDiagnostic {
                     severity: DiagnosticSeverity::Error,
@@ -158,6 +170,23 @@ pub fn apply_server_inspection_with_options(
             .unwrap_or_else(current_unix_secs),
     ));
 
+    if !diagnostics.is_empty() {
+        tracing::warn!(
+            target: "sealantern.core.provisioning.import",
+            instance_id = %instance.id.as_str(),
+            diagnostics = diagnostics.len(),
+            launch_candidates = launch_candidates.len(),
+            "server inspection projection completed with diagnostics"
+        );
+    } else {
+        tracing::debug!(
+            target: "sealantern.core.provisioning.import",
+            instance_id = %instance.id.as_str(),
+            launch_candidates = launch_candidates.len(),
+            "server inspection projection completed"
+        );
+    }
+
     ServerInspectionProjection {
         diagnostics,
         launch_candidates,
@@ -172,7 +201,13 @@ pub fn inspect_and_apply_import_metadata(
     inspection_options: &InspectionOptions,
     projection_options: &ServerInspectionProjectionOptions,
 ) -> Result<ServerInspectionProjection, ServerInspectionError> {
-    let mut options = inspection_options.clone();
+    tracing::debug!(
+        target: "sealantern.core.provisioning.import",
+        instance_id = %instance.id.as_str(),
+        subject_path = %subject_path.display(),
+        "inspecting artifact for import projection"
+    );
+    let mut options = *inspection_options;
     options.compute_sha256 = true;
     let report = inspect_server_artifact(subject_path, &options)?;
     Ok(apply_server_inspection_with_options(instance, Ok(&report), projection_options))

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -18,7 +18,10 @@ use super::server_inspection::{
 /// 控制检查结果是否可以替换已有的启动配置。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LaunchProfilePolicy {
+    /// 只返回可兼容候选，不改变已有 `LocalLaunch`。
     PreserveExisting,
+    /// 采纳唯一最高置信度候选；候选的模式和目标路径替换旧值，
+    /// profile 未提供 JVM 参数时保留已有 JVM 参数，Java 可执行文件始终保留。
     AdoptBestCompatible,
 }
 
@@ -195,7 +198,7 @@ fn compatible_launch_candidate(
         diagnostics.push(launch_diagnostic(
             "launch_profile_platform_mismatch",
             &profile.id,
-            "launch profile targets a different host platform; it was kept as a manual candidate",
+            "launch profile targets a different host platform; it was rejected and not returned as a candidate",
         ));
         return None;
     }
@@ -298,10 +301,17 @@ fn adopt_best_launch(
         });
         return None;
     }
+    // 采用时由检测 profile 决定启动模式和目标路径；profile 未提供 JVM 参数时，
+    // 保留调用方已有参数，避免导入确认无意中丢失内存或诊断配置。
     let candidate = best[0];
+    let existing_jvm_arguments = instance.launch.jvm_arguments.clone();
     let java_executable = instance.launch.java_executable.clone();
-    instance.launch = candidate.launch.clone();
-    instance.launch.java_executable = java_executable;
+    let mut adopted_launch = candidate.launch.clone();
+    if adopted_launch.jvm_arguments.is_empty() {
+        adopted_launch.jvm_arguments = existing_jvm_arguments;
+    }
+    adopted_launch.java_executable = java_executable;
+    instance.launch = adopted_launch;
     Some(candidate.profile_id.clone())
 }
 
@@ -578,16 +588,20 @@ fn missing_diagnostic(field: &str) -> InspectionDiagnostic {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        apply_server_inspection, apply_server_inspection_with_options, LaunchProfilePolicy,
-        ServerInspectionProjectionOptions,
+        apply_server_inspection, apply_server_inspection_with_options, compatible_launch_candidate,
+        LaunchProfilePolicy, ServerInspectionProjectionOptions,
     };
     use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+    use crate::provisioning::server_inspection::{
+        Attributed, LaunchPlatform, LaunchProfile, LaunchTarget,
+    };
     use crate::provisioning::{inspect_server_artifact, InspectionOptions};
     use zip::write::FileOptions;
 
@@ -783,6 +797,7 @@ mod tests {
     #[test]
     fn adopts_a_unique_jar_launch_and_persists_a_fingerprinted_snapshot() {
         let mut instance = instance_spec();
+        instance.launch.jvm_arguments = vec![OsString::from("-Xmx4G")];
         let path = write_test_jar(
             "paper.jar",
             &[
@@ -812,6 +827,7 @@ mod tests {
 
         assert_eq!(projection.adopted_launch_profile.as_deref(), Some("manifest-main"));
         assert_eq!(instance.launch.startup_target, Some(path));
+        assert_eq!(instance.launch.jvm_arguments, vec![OsString::from("-Xmx4G")]);
         assert_eq!(
             instance
                 .server_metadata
@@ -852,5 +868,34 @@ mod tests {
                 .map(|snapshot| snapshot.schema_version),
             Some(1)
         );
+    }
+
+    #[test]
+    fn rejects_platform_mismatch_instead_of_returning_a_manual_candidate() {
+        let attributed = Attributed {
+            value: LaunchProfile {
+                id: "wrong-platform".to_string(),
+                platform: if cfg!(target_os = "windows") {
+                    LaunchPlatform::Unix
+                } else {
+                    LaunchPlatform::Windows
+                },
+                working_directory: None,
+                target: LaunchTarget::MainClass { class_name: "example.Main".to_string() },
+                jvm_arguments: Vec::new(),
+                program_arguments: Vec::new(),
+                required_java_major: None,
+            },
+            confidence: 90,
+            evidence: Vec::new(),
+        };
+        let mut diagnostics = Vec::new();
+
+        let candidate = compatible_launch_candidate(&attributed, &mut diagnostics);
+
+        assert!(candidate.is_none());
+        assert!(diagnostics[0]
+            .message
+            .contains("rejected and not returned as a candidate"));
     }
 }

--- a/crates/core/src/provisioning/launch_adapter.rs
+++ b/crates/core/src/provisioning/launch_adapter.rs
@@ -1,0 +1,117 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+use crate::instance::{LocalLaunch, StartupMode};
+
+use super::server_inspection::{LaunchProfile, LaunchTarget};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LaunchAdapterError {
+    ProgramArguments,
+    ScriptType,
+    MainClass,
+    ArgumentFiles,
+}
+
+impl LaunchAdapterError {
+    pub(super) const fn diagnostic(self) -> (&'static str, &'static str) {
+        match self {
+            Self::ProgramArguments => (
+                "launch_profile_program_arguments_unsupported",
+                "launch profile has program arguments that LocalLaunch cannot represent; choose it manually",
+            ),
+            Self::ScriptType => (
+                "launch_profile_script_type_unsupported",
+                "launch profile script extension is not supported by LocalLaunch; choose it manually",
+            ),
+            Self::MainClass => (
+                "launch_profile_main_class_unrepresentable",
+                "LocalLaunch cannot represent a main-class target; choose a concrete launcher manually",
+            ),
+            Self::ArgumentFiles => (
+                "launch_profile_argument_files_unrepresentable",
+                "LocalLaunch cannot represent argument-file targets; choose a concrete launcher manually",
+            ),
+        }
+    }
+}
+
+pub(super) fn adapt_launch_profile(
+    profile: &LaunchProfile,
+) -> Result<LocalLaunch, LaunchAdapterError> {
+    let (startup_mode, startup_target, jvm_arguments) = match &profile.target {
+        LaunchTarget::Jar { path } => {
+            if !profile.program_arguments.is_empty() {
+                return Err(LaunchAdapterError::ProgramArguments);
+            }
+            (
+                StartupMode::Jar,
+                path.clone(),
+                profile.jvm_arguments.iter().map(OsString::from).collect(),
+            )
+        }
+        LaunchTarget::Script { path } => {
+            let Some(mode) = script_startup_mode(path) else {
+                return Err(LaunchAdapterError::ScriptType);
+            };
+            (mode, path.clone(), Vec::new())
+        }
+        LaunchTarget::MainClass { .. } => return Err(LaunchAdapterError::MainClass),
+        LaunchTarget::ArgumentFiles { .. } => return Err(LaunchAdapterError::ArgumentFiles),
+    };
+
+    Ok(LocalLaunch {
+        startup_mode,
+        startup_target: Some(startup_target),
+        custom_command: None,
+        custom_executable: None,
+        custom_arguments: Vec::new(),
+        java_executable: None,
+        jvm_arguments,
+    })
+}
+
+fn script_startup_mode(path: &Path) -> Option<StartupMode> {
+    match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
+        "bat" | "cmd" => Some(StartupMode::Batch),
+        "sh" => Some(StartupMode::Shell),
+        "ps1" => Some(StartupMode::PowerShell),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{adapt_launch_profile, LaunchAdapterError};
+    use crate::provisioning::server_inspection::{LaunchPlatform, LaunchProfile, LaunchTarget};
+
+    fn profile(target: LaunchTarget) -> LaunchProfile {
+        LaunchProfile {
+            id: "test".to_string(),
+            platform: LaunchPlatform::Any,
+            working_directory: None,
+            target,
+            jvm_arguments: Vec::new(),
+            program_arguments: Vec::new(),
+            required_java_major: None,
+        }
+    }
+
+    #[test]
+    fn rejects_targets_without_a_local_launch_representation() {
+        assert_eq!(
+            adapt_launch_profile(&profile(LaunchTarget::MainClass {
+                class_name: "example.Main".to_string(),
+            })),
+            Err(LaunchAdapterError::MainClass)
+        );
+        assert_eq!(
+            adapt_launch_profile(&profile(LaunchTarget::ArgumentFiles {
+                paths: vec![PathBuf::from("args.txt")],
+            })),
+            Err(LaunchAdapterError::ArgumentFiles)
+        );
+    }
+}

--- a/crates/core/src/provisioning/lib.rs
+++ b/crates/core/src/provisioning/lib.rs
@@ -2,6 +2,7 @@ pub mod copy;
 pub mod core_parsing;
 pub mod create;
 pub mod existing;
+pub mod import_metadata;
 pub mod modpack;
 pub mod run_dir;
 #[path = "server_inspection/lib.rs"]
@@ -14,6 +15,7 @@ pub use core_parsing::{
 };
 pub use create::{plan_create, CreateInstanceError, CreateInstancePlan};
 pub use existing::{plan_existing_instance, ExistingInstanceError};
+pub use import_metadata::apply_server_inspection;
 pub use modpack::{
     plan_modpack, ModpackProvisionError, ModpackProvisionPlan, ModpackProvisionRequest,
 };

--- a/crates/core/src/provisioning/lib.rs
+++ b/crates/core/src/provisioning/lib.rs
@@ -15,7 +15,11 @@ pub use core_parsing::{
 };
 pub use create::{plan_create, CreateInstanceError, CreateInstancePlan};
 pub use existing::{plan_existing_instance, ExistingInstanceError};
-pub use import_metadata::apply_server_inspection;
+pub use import_metadata::{
+    apply_server_inspection, apply_server_inspection_with_options,
+    inspect_and_apply_import_metadata, ImportLaunchCandidate, LaunchProfilePolicy,
+    ServerInspectionProjection, ServerInspectionProjectionOptions,
+};
 pub use modpack::{
     plan_modpack, ModpackProvisionError, ModpackProvisionPlan, ModpackProvisionRequest,
 };

--- a/crates/core/src/provisioning/lib.rs
+++ b/crates/core/src/provisioning/lib.rs
@@ -3,6 +3,7 @@ pub mod core_parsing;
 pub mod create;
 pub mod existing;
 pub mod import_metadata;
+mod launch_adapter;
 pub mod modpack;
 pub mod run_dir;
 #[path = "server_inspection/lib.rs"]

--- a/crates/core/src/provisioning/modpack.rs
+++ b/crates/core/src/provisioning/modpack.rs
@@ -100,6 +100,7 @@ mod tests {
             min_memory_mib: 0,
             created_at_unix_secs: 0,
             last_started_at_unix_secs: None,
+            server_metadata: None,
             launch: LocalLaunch {
                 startup_mode: StartupMode::Jar,
                 startup_target: Some(directory.join("server.jar")),

--- a/crates/core/src/provisioning/modpack.rs
+++ b/crates/core/src/provisioning/modpack.rs
@@ -25,6 +25,12 @@ pub struct ModpackProvisionPlan {
 pub fn plan_modpack(
     request: ModpackProvisionRequest,
 ) -> Result<ModpackProvisionPlan, ModpackProvisionError> {
+    tracing::debug!(
+        target: "sealantern.core.provisioning.modpack",
+        archive_path = %request.archive_path.display(),
+        requested_run_directory = %request.requested_run_directory.display(),
+        "planning modpack provision"
+    );
     if request.archive_path.as_os_str().is_empty() {
         return Err(ModpackProvisionError::EmptyArchivePath);
     }
@@ -40,11 +46,19 @@ pub fn plan_modpack(
     }
 
     let instance = Instance::new(request.instance).map_err(ModpackProvisionError::Instance)?;
-    Ok(ModpackProvisionPlan {
+    let plan = ModpackProvisionPlan {
         archive_path: request.archive_path,
         run_directory,
         instance,
-    })
+    };
+    tracing::debug!(
+        target: "sealantern.core.provisioning.modpack",
+        archive_path = %plan.archive_path.display(),
+        run_directory = %plan.run_directory.display(),
+        instance_id = %plan.instance.id.as_str(),
+        "modpack provision plan ready"
+    );
+    Ok(plan)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,15 +90,24 @@ impl std::fmt::Display for ModpackProvisionError {
     }
 }
 
-impl std::error::Error for ModpackProvisionError {}
+impl std::error::Error for ModpackProvisionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::RunDirectory(error) => Some(error),
+            Self::Instance(error) => Some(error),
+            Self::EmptyArchivePath | Self::InstanceDirectoryMismatch { .. } => None,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
     use std::path::PathBuf;
 
     use super::{plan_modpack, ModpackProvisionError, ModpackProvisionRequest};
     use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
-    use crate::provisioning::RunDirectoryState;
+    use crate::provisioning::{RunDirectoryError, RunDirectoryState};
 
     fn instance_spec(directory: PathBuf) -> InstanceSpec {
         InstanceSpec {
@@ -139,5 +162,14 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error, ModpackProvisionError::InstanceDirectoryMismatch { .. }));
+    }
+
+    #[test]
+    fn modpack_error_exposes_the_run_directory_source() {
+        let error = ModpackProvisionError::RunDirectory(RunDirectoryError::NonEmpty {
+            path: PathBuf::from("E:/servers/existing"),
+        });
+
+        assert!(error.source().is_some());
     }
 }

--- a/crates/core/src/provisioning/run_dir.rs
+++ b/crates/core/src/provisioning/run_dir.rs
@@ -17,6 +17,12 @@ pub fn resolve_run_directory(
     state: RunDirectoryState,
 ) -> Result<PathBuf, RunDirectoryError> {
     let requested = requested.into();
+    tracing::debug!(
+        target: "sealantern.core.provisioning.run_directory",
+        path = %requested.display(),
+        state = ?state,
+        "resolving modpack run directory"
+    );
     if requested.as_os_str().is_empty() {
         return Err(RunDirectoryError::Empty);
     }

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -384,6 +384,7 @@ pub(super) fn detect_directory(
     for root_archive in &directory.root_archives {
         let archive_path = path.join(&root_archive.relative_path);
         let artifact = root_artifact(&root_archive.metadata);
+        let root_minecraft = root_minecraft_metadata(&root_archive.metadata);
         fabric::detect(
             &archive_path,
             &root_archive.metadata,
@@ -418,7 +419,7 @@ pub(super) fn detect_directory(
                 )
             })
         {
-            vanilla::detect(&archive_path, &artifact, minecraft, &mut findings);
+            vanilla::detect(&archive_path, &artifact, root_minecraft.as_ref(), &mut findings);
         }
     }
     for installation in &directory.installations {
@@ -428,6 +429,33 @@ pub(super) fn detect_directory(
         forge::detect_script(path, script, &mut findings);
     }
     finalize(path, findings, minecraft, existing_java_major, evidence)
+}
+
+fn root_minecraft_metadata(archive: &ArchiveMetadata) -> Option<MinecraftVersionInfo> {
+    let bytes = archive.mojang_version.as_deref()?;
+    let document = super::formats::mojang_version::parse(bytes).ok()??;
+    let id = document.id?;
+    Some(MinecraftVersionInfo {
+        version: Detected {
+            value: Some(id.clone()),
+            confidence: 95,
+            evidence: Vec::new(),
+            alternatives: Vec::new(),
+        },
+        id: Some(id),
+        name: document.name,
+        world_version: document.world_version,
+        series_id: document.series_id,
+        protocol_version: document.protocol_version,
+        pack_version: document.pack_version,
+        build_time: document.build_time,
+        java_component: document.java_component,
+        java_version: document.java_version,
+        stable: document.stable,
+        use_editor: document.use_editor,
+        extra: document.extra,
+        evidence: Vec::new(),
+    })
 }
 
 fn root_artifact(archive: &ArchiveMetadata) -> ArtifactInfo {

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use super::archive::ArchiveMetadata;
 use super::directory::DirectoryMetadata;
 use super::evidence::{EvidenceCollector, NewEvidence};
+use super::formats::manifest;
 use super::model::{
     ArtifactInfo, ArtifactRole, Attributed, Detected, DetectionTarget, DiagnosticSeverity,
     EvidenceLocation, EvidenceSource, InspectionDiagnostic, LaunchProfile, MavenCoordinate,
@@ -374,12 +375,15 @@ pub(super) fn detect_jar(
 pub(super) fn detect_directory(
     path: &Path,
     directory: &DirectoryMetadata,
+    minecraft: Option<&MinecraftVersionInfo>,
+    existing_java_major: Option<&Detected<u16>>,
     evidence: &mut EvidenceCollector,
 ) -> DetectorOutput {
     let mut findings = Findings::default();
     detect_filename(path, &mut findings);
     for root_archive in &directory.root_archives {
         let archive_path = path.join(&root_archive.relative_path);
+        let artifact = root_artifact(&root_archive.metadata);
         fabric::detect(
             &archive_path,
             &root_archive.metadata,
@@ -402,6 +406,20 @@ pub(super) fn detect_directory(
             Some((path, &root_archive.relative_path)),
             &mut findings,
         );
+        paperclip::detect(&archive_path, &artifact, &root_archive.metadata, &mut findings);
+        if artifact
+            .main_class
+            .value
+            .as_deref()
+            .is_some_and(|main_class| {
+                matches!(
+                    main_class,
+                    "net.minecraft.bundler.Main" | "net.minecraft.server.MinecraftServer"
+                )
+            })
+        {
+            vanilla::detect(&archive_path, &artifact, minecraft, &mut findings);
+        }
     }
     for installation in &directory.installations {
         forge::detect_installation(path, installation, &mut findings);
@@ -409,7 +427,33 @@ pub(super) fn detect_directory(
     for script in &directory.scripts {
         forge::detect_script(path, script, &mut findings);
     }
-    finalize(path, findings, None, None, evidence)
+    finalize(path, findings, minecraft, existing_java_major, evidence)
+}
+
+fn root_artifact(archive: &ArchiveMetadata) -> ArtifactInfo {
+    let mut artifact = ArtifactInfo {
+        format: Detected::default(),
+        roles: Vec::new(),
+        main_class: Detected::default(),
+        premain_class: Detected::default(),
+        agent_class: Detected::default(),
+        automatic_module_name: Detected::default(),
+        manifest: None,
+    };
+    let Some(bytes) = archive.manifest.as_deref() else {
+        return artifact;
+    };
+    let parsed = manifest::parse(bytes);
+    if let Some(value) = parsed.main_value("Main-Class") {
+        artifact.main_class = Detected {
+            value: Some(value.to_string()),
+            confidence: 100,
+            evidence: Vec::new(),
+            alternatives: Vec::new(),
+        };
+    }
+    artifact.manifest = Some(parsed.summary);
+    artifact
 }
 
 fn finalize(

--- a/crates/core/src/provisioning/server_inspection/directory.rs
+++ b/crates/core/src/provisioning/server_inspection/directory.rs
@@ -136,9 +136,20 @@ pub(super) fn read_metadata(
     let mut scripts = Vec::new();
     for name in ROOT_SCRIPT_NAMES {
         let relative_path = PathBuf::from(name);
-        let Some(content) =
-            read_optional_file(path, &relative_path, options, &mut consumed, &mut diagnostics)?
-        else {
+        let content = match read_optional_file(
+            path,
+            &relative_path,
+            options,
+            &mut consumed,
+            &mut diagnostics,
+        ) {
+            Ok(content) => content,
+            Err(error) => {
+                diagnostics.push(optional_metadata_diagnostic(&path.join(&relative_path), &error));
+                None
+            }
+        };
+        let Some(content) = content else {
             continue;
         };
         let Some(kind) = StartupScriptKind::from_path(&relative_path) else {
@@ -197,15 +208,24 @@ fn scan_installations(
         {
             return Ok(());
         }
+        Err(error @ ServerInspectionError::Open { .. }) => {
+            diagnostics.push(optional_metadata_diagnostic(&base, &error));
+            return Ok(());
+        }
         Err(error) => return Err(error),
     };
 
     for entry in entries {
-        if !entry
-            .file_type()
-            .map_err(|source| ServerInspectionError::Metadata { path: entry.path(), source })?
-            .is_dir()
-        {
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(source) => {
+                let entry_path = entry.path();
+                let error = ServerInspectionError::Metadata { path: entry_path.clone(), source };
+                diagnostics.push(optional_metadata_diagnostic(&entry_path, &error));
+                continue;
+            }
+        };
+        if !file_type.is_dir() {
             continue;
         }
         let coordinate_version = entry.file_name().to_string_lossy().into_owned();
@@ -213,20 +233,26 @@ fn scan_installations(
             continue;
         }
         let relative_directory = relative_base.join(&coordinate_version);
-        let windows_args = read_metadata_file(
-            root,
-            &relative_directory.join("win_args.txt"),
-            options,
-            consumed,
-            diagnostics,
-        )?;
-        let unix_args = read_metadata_file(
-            root,
-            &relative_directory.join("unix_args.txt"),
-            options,
-            consumed,
-            diagnostics,
-        )?;
+        let windows_args_path = relative_directory.join("win_args.txt");
+        let windows_args =
+            match read_metadata_file(root, &windows_args_path, options, consumed, diagnostics) {
+                Ok(args) => args,
+                Err(error) => {
+                    diagnostics
+                        .push(optional_metadata_diagnostic(&root.join(&windows_args_path), &error));
+                    None
+                }
+            };
+        let unix_args_path = relative_directory.join("unix_args.txt");
+        let unix_args =
+            match read_metadata_file(root, &unix_args_path, options, consumed, diagnostics) {
+                Ok(args) => args,
+                Err(error) => {
+                    diagnostics
+                        .push(optional_metadata_diagnostic(&root.join(&unix_args_path), &error));
+                    None
+                }
+            };
 
         let nested_relative = match family {
             ModLoaderFamily::Forge => PathBuf::from(format!(
@@ -238,9 +264,18 @@ fn scan_installations(
             }
         };
         let nested_path = root.join(&nested_relative);
-        let nested_metadata = if options.max_archive_depth == 0
-            || !nested_archive_allowed(&nested_path, options, diagnostics)?
-        {
+        let nested_allowed = if options.max_archive_depth == 0 {
+            false
+        } else {
+            match nested_archive_allowed(&nested_path, options, diagnostics) {
+                Ok(allowed) => allowed,
+                Err(error) => {
+                    diagnostics.push(optional_metadata_diagnostic(&nested_path, &error));
+                    false
+                }
+            }
+        };
+        let nested_metadata = if !nested_allowed {
             None
         } else {
             match archive::read_metadata_with_budget(&nested_path, options, consumed) {
@@ -253,7 +288,10 @@ fn scan_installations(
                 {
                     None
                 }
-                Err(error) => return Err(error),
+                Err(error) => {
+                    diagnostics.push(optional_metadata_diagnostic(&nested_path, &error));
+                    None
+                }
             }
         };
 
@@ -485,6 +523,24 @@ fn limit_diagnostic(code: &str, message: String) -> InspectionDiagnostic {
         severity: DiagnosticSeverity::Warning,
         code: code.to_string(),
         message,
+        evidence: Vec::new(),
+    }
+}
+
+fn optional_metadata_diagnostic(
+    path: &Path,
+    error: &ServerInspectionError,
+) -> InspectionDiagnostic {
+    tracing::warn!(
+        target: "sealantern.core.provisioning.server_inspection",
+        path = %path.display(),
+        error = %error,
+        "optional server metadata was skipped"
+    );
+    InspectionDiagnostic {
+        severity: DiagnosticSeverity::Warning,
+        code: "optional_metadata_unreadable".to_string(),
+        message: format!("optional server metadata {} was skipped: {error}", path.display()),
         evidence: Vec::new(),
     }
 }

--- a/crates/core/src/provisioning/server_inspection/directory.rs
+++ b/crates/core/src/provisioning/server_inspection/directory.rs
@@ -57,24 +57,55 @@ pub(super) fn read_metadata(
     let mut consumed = 0_u64;
     let mut diagnostics = Vec::new();
     let root_entries = sorted_entries(path, options)?;
+    let mut root_candidates = Vec::new();
+    for entry in root_entries {
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(source) => {
+                diagnostics.push(limit_diagnostic(
+                    "root_entry_unreadable",
+                    format!(
+                        "root entry {} could not be inspected and was skipped: {source}",
+                        entry.path().display()
+                    ),
+                ));
+                continue;
+            }
+        };
+        if file_type.is_file() && is_root_jar(&entry.file_name().to_string_lossy()) {
+            root_candidates.push(entry);
+        }
+    }
+    root_candidates
+        .sort_by_key(|entry| root_archive_sort_key(&entry.file_name().to_string_lossy()));
     let mut root_archives = Vec::new();
-    for entry in &root_entries {
-        let file_type = entry
-            .file_type()
-            .map_err(|source| ServerInspectionError::Metadata { path: entry.path(), source })?;
-        if !file_type.is_file() || !is_relevant_root_jar(&entry.file_name().to_string_lossy()) {
-            continue;
-        }
+    if root_candidates.len() > options.max_root_archives {
+        diagnostics.push(limit_diagnostic(
+            "root_archive_limit_reached",
+            format!(
+                "directory {} contains {} root JARs; only the first {} were inspected",
+                path.display(),
+                root_candidates.len(),
+                options.max_root_archives
+            ),
+        ));
+        root_candidates.truncate(options.max_root_archives);
+    }
+    for entry in root_candidates {
         let relative_path = PathBuf::from(entry.file_name());
-        if options.max_archive_depth == 0
-            || !nested_archive_allowed(&entry.path(), options, &mut diagnostics)?
-        {
-            continue;
+        match archive::read_metadata_with_budget(&entry.path(), options, &mut consumed) {
+            Ok(mut metadata) => {
+                diagnostics.append(&mut metadata.diagnostics);
+                root_archives.push(RootArchive { relative_path, metadata });
+            }
+            Err(error) => diagnostics.push(limit_diagnostic(
+                "root_archive_unreadable",
+                format!(
+                    "root archive {} could not be inspected and was skipped: {error}",
+                    entry.path().display()
+                ),
+            )),
         }
-        let mut metadata =
-            archive::read_metadata_with_budget(&entry.path(), options, &mut consumed)?;
-        diagnostics.append(&mut metadata.diagnostics);
-        root_archives.push(RootArchive { relative_path, metadata });
     }
 
     let mut scripts = Vec::new();
@@ -340,9 +371,37 @@ fn nested_archive_allowed(
     Ok(false)
 }
 
-fn is_relevant_root_jar(name: &str) -> bool {
-    let name = name.to_ascii_lowercase();
-    name == "server.jar" || (name.ends_with(".jar") && name.contains("fabric"))
+fn is_root_jar(name: &str) -> bool {
+    name.to_ascii_lowercase().ends_with(".jar")
+}
+
+fn root_archive_sort_key(name: &str) -> (u8, String) {
+    let lower = name.to_ascii_lowercase();
+    if lower == "server.jar" {
+        return (0, lower);
+    }
+    const KNOWN_TOKENS: &[&str] = &[
+        "paper",
+        "purpur",
+        "spigot",
+        "craftbukkit",
+        "fabric",
+        "forge",
+        "neoforge",
+        "arclight",
+        "mohist",
+        "magma",
+        "velocity",
+        "bungeecord",
+        "waterfall",
+        "sponge",
+        "limbo",
+    ];
+    if KNOWN_TOKENS.iter().any(|token| lower.contains(token)) {
+        (1, lower)
+    } else {
+        (2, lower)
+    }
 }
 
 fn limit_diagnostic(code: &str, message: String) -> InspectionDiagnostic {

--- a/crates/core/src/provisioning/server_inspection/directory.rs
+++ b/crates/core/src/provisioning/server_inspection/directory.rs
@@ -10,6 +10,23 @@ use crate::provisioning::StartupScriptKind;
 
 const ROOT_SCRIPT_NAMES: &[&str] =
     &["run.bat", "run.sh", "run.ps1", "start.bat", "start.sh", "start.ps1"];
+const KNOWN_ROOT_TOKENS: &[&str] = &[
+    "paper",
+    "purpur",
+    "spigot",
+    "craftbukkit",
+    "fabric",
+    "forge",
+    "neoforge",
+    "arclight",
+    "mohist",
+    "magma",
+    "velocity",
+    "bungeecord",
+    "waterfall",
+    "sponge",
+    "limbo",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ModLoaderFamily {
@@ -72,31 +89,29 @@ pub(super) fn read_metadata(
                 continue;
             }
         };
-        if file_type.is_file() && is_root_jar(&entry.file_name().to_string_lossy()) {
+        // 扩展名只用于构造有界探测集，是否为服务端归档仍由下面的文件名和元数据签名决定。
+        if file_type.is_file() && has_jar_extension(&entry.file_name().to_string_lossy()) {
             root_candidates.push(entry);
         }
     }
     root_candidates
         .sort_by_key(|entry| root_archive_sort_key(&entry.file_name().to_string_lossy()));
+    let root_jar_count = root_candidates.len();
     let mut root_archives = Vec::new();
-    if root_candidates.len() > options.max_root_archives {
-        diagnostics.push(limit_diagnostic(
-            "root_archive_limit_reached",
-            format!(
-                "directory {} contains {} root JARs; only the first {} were inspected",
-                path.display(),
-                root_candidates.len(),
-                options.max_root_archives
-            ),
-        ));
-        root_candidates.truncate(options.max_root_archives);
-    }
+    let mut root_archive_limit_reached = false;
     for entry in root_candidates {
+        if root_archives.len() >= options.max_root_archives {
+            root_archive_limit_reached = true;
+            break;
+        }
         let relative_path = PathBuf::from(entry.file_name());
+        let named_candidate = is_likely_root_archive_name(&relative_path);
         match archive::read_metadata_with_budget(&entry.path(), options, &mut consumed) {
             Ok(mut metadata) => {
-                diagnostics.append(&mut metadata.diagnostics);
-                root_archives.push(RootArchive { relative_path, metadata });
+                if named_candidate || is_likely_server_archive(&metadata) {
+                    diagnostics.append(&mut metadata.diagnostics);
+                    root_archives.push(RootArchive { relative_path, metadata });
+                }
             }
             Err(error) => diagnostics.push(limit_diagnostic(
                 "root_archive_unreadable",
@@ -106,6 +121,16 @@ pub(super) fn read_metadata(
                 ),
             )),
         }
+    }
+    if root_archive_limit_reached {
+        diagnostics.push(limit_diagnostic(
+            "root_archive_limit_reached",
+            format!(
+                "directory {} contains {root_jar_count} root JAR candidates; only the first {} server archives were inspected",
+                path.display(),
+                options.max_root_archives
+            ),
+        ));
     }
 
     let mut scripts = Vec::new();
@@ -371,8 +396,76 @@ fn nested_archive_allowed(
     Ok(false)
 }
 
-fn is_root_jar(name: &str) -> bool {
+fn has_jar_extension(name: &str) -> bool {
     name.to_ascii_lowercase().ends_with(".jar")
+}
+
+fn is_likely_root_archive_name(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let lower = name.to_ascii_lowercase();
+    lower == "server.jar"
+        || lower.contains("server")
+        || lower.contains("minecraft")
+        || lower.contains("launcher")
+        || lower.contains("bootstrap")
+        || KNOWN_ROOT_TOKENS.iter().any(|token| lower.contains(token))
+}
+
+fn is_likely_server_archive(metadata: &ArchiveMetadata) -> bool {
+    if metadata.versions_list.is_some()
+        || metadata.patches_list.is_some()
+        || metadata.libraries_list.is_some()
+        || metadata.install_properties.is_some()
+        || metadata.bootstrap_properties.is_some()
+        || metadata.bootstrap_list.is_some()
+        || metadata.wrapper_metadata.is_some()
+        || metadata.arclight_launch_properties.is_some()
+        || metadata.forge_version.is_some()
+        || metadata.neoforge_version_properties.is_some()
+    {
+        return true;
+    }
+
+    let Some(manifest) = metadata.manifest.as_deref() else {
+        return false;
+    };
+    let parsed = super::formats::manifest::parse(manifest);
+    let main_class = parsed.main_value("Main-Class");
+    main_class.is_some_and(is_known_server_main_class)
+        || parsed
+            .main_value("Implementation-Title")
+            .is_some_and(is_known_server_product_name)
+}
+
+fn is_known_server_main_class(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    [
+        "net.minecraft.",
+        "io.papermc.paperclip",
+        "paperclip",
+        "net.fabricmc.installer.serverlauncher",
+        "net.minecraftforge.",
+        "net.neoforged.",
+        "com.velocitypowered.",
+        "net.md_5.bungee.",
+        "org.spongepowered.",
+        "io.izzel.arclight.",
+        "com.mohistmc.",
+        "org.magmafoundation.",
+        "app.mcjars.serverstarter",
+        "com.loohp.limbo.",
+        "ua.nanit.limbo.",
+        "org.bukkit.craftbukkit.bootstrap.",
+    ]
+    .iter()
+    .any(|prefix| value.starts_with(prefix))
+}
+
+fn is_known_server_product_name(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    KNOWN_ROOT_TOKENS.iter().any(|token| value.contains(token))
 }
 
 fn root_archive_sort_key(name: &str) -> (u8, String) {
@@ -380,24 +473,7 @@ fn root_archive_sort_key(name: &str) -> (u8, String) {
     if lower == "server.jar" {
         return (0, lower);
     }
-    const KNOWN_TOKENS: &[&str] = &[
-        "paper",
-        "purpur",
-        "spigot",
-        "craftbukkit",
-        "fabric",
-        "forge",
-        "neoforge",
-        "arclight",
-        "mohist",
-        "magma",
-        "velocity",
-        "bungeecord",
-        "waterfall",
-        "sponge",
-        "limbo",
-    ];
-    if KNOWN_TOKENS.iter().any(|token| lower.contains(token)) {
+    if KNOWN_ROOT_TOKENS.iter().any(|token| lower.contains(token)) {
         (1, lower)
     } else {
         (2, lower)

--- a/crates/core/src/provisioning/server_inspection/directory.rs
+++ b/crates/core/src/provisioning/server_inspection/directory.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use super::archive::{self, ArchiveMetadata};
 use super::error::ServerInspectionError;
 use super::model::{DiagnosticSeverity, InspectionDiagnostic};
-use super::InspectionOptions;
+use super::{InspectionOptions, SERVER_INSPECTION_TARGET};
 use crate::provisioning::StartupScriptKind;
 
 const ROOT_SCRIPT_NAMES: &[&str] =
@@ -532,7 +532,7 @@ fn optional_metadata_diagnostic(
     error: &ServerInspectionError,
 ) -> InspectionDiagnostic {
     tracing::warn!(
-        target: "sealantern.core.provisioning.server_inspection",
+        target: SERVER_INSPECTION_TARGET,
         path = %path.display(),
         error = %error,
         "optional server metadata was skipped"

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -26,9 +26,10 @@ use resolver::{resolve, DetectionClaim};
 
 const MANIFEST_ENTRY: &str = "META-INF/MANIFEST.MF";
 const MOJANG_VERSION_ENTRY: &str = "version.json";
+const SERVER_INSPECTION_TARGET: &str = "sealantern.core.provisioning.server_inspection";
 
 /// 控制静态检查的资源预算；检查过程不会执行 JAR、脚本或 shell 展开。
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InspectionOptions {
     pub max_archive_entries: usize,
     /// 根目录中最多接受的服务端 JAR 数量，避免无界纳入普通库文件。
@@ -58,6 +59,48 @@ impl Default for InspectionOptions {
 
 /// 检查单个服务端文件或安装目录，不执行其中的任何内容。
 pub fn inspect_server_artifact(
+    path: &Path,
+    options: &InspectionOptions,
+) -> Result<ServerInspectionReport, ServerInspectionError> {
+    tracing::debug!(
+        target: SERVER_INSPECTION_TARGET,
+        path = %path.display(),
+        compute_sha256 = options.compute_sha256,
+        max_archive_entries = options.max_archive_entries,
+        max_archive_depth = options.max_archive_depth,
+        "starting server artifact inspection"
+    );
+    let result = inspect_server_artifact_inner(path, options);
+    match &result {
+        Ok(report) => {
+            let implementation = report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str())
+                .unwrap_or("unknown");
+            tracing::debug!(
+                target: SERVER_INSPECTION_TARGET,
+                path = %path.display(),
+                subject_kind = ?report.subject.kind,
+                implementation,
+                diagnostics = report.diagnostics.len(),
+                launches = report.launches.len(),
+                "server artifact inspection completed"
+            );
+        }
+        Err(error) => tracing::warn!(
+            target: SERVER_INSPECTION_TARGET,
+            path = %path.display(),
+            error = %error,
+            "server artifact inspection failed"
+        ),
+    }
+    result
+}
+
+fn inspect_server_artifact_inner(
     path: &Path,
     options: &InspectionOptions,
 ) -> Result<ServerInspectionReport, ServerInspectionError> {
@@ -2127,5 +2170,42 @@ mod tests {
         fs::remove_dir_all(&root).expect("remove root directory");
 
         assert!(matches!(error, ServerInspectionError::InvalidOptions { .. }));
+    }
+
+    #[test]
+    fn skips_a_corrupt_optional_modloader_archive() {
+        let root = temporary_path("corrupt-nested-loader");
+        let version = "1.20.1-47.2.0";
+        let args_directory = root
+            .join("libraries/net/minecraftforge/forge")
+            .join(version);
+        fs::create_dir_all(&args_directory).expect("create Forge args directory");
+        fs::write(args_directory.join("win_args.txt"), "-jar forge-shim.jar\n")
+            .expect("write Forge args");
+        let nested_path = root
+            .join("libraries/net/minecraftforge/fmlloader")
+            .join(version)
+            .join(format!("fmlloader-{version}.jar"));
+        fs::create_dir_all(nested_path.parent().expect("nested archive parent"))
+            .expect("create nested archive directory");
+        fs::write(&nested_path, b"not a ZIP archive").expect("write corrupt nested archive");
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("corrupt optional nested archive should not abort inspection");
+        fs::remove_dir_all(&root).expect("remove corrupt nested fixture");
+
+        assert_eq!(
+            report
+                .identity
+                .implementation
+                .value
+                .as_ref()
+                .map(|product| product.key.as_str()),
+            Some("forge")
+        );
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "optional_metadata_unreadable"));
     }
 }

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -31,7 +31,7 @@ const MOJANG_VERSION_ENTRY: &str = "version.json";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InspectionOptions {
     pub max_archive_entries: usize,
-    /// 根目录中最多读取的候选 JAR 数量，避免无界扫描任意文件。
+    /// 根目录中最多接受的服务端 JAR 数量，避免无界纳入普通库文件。
     pub max_root_archives: usize,
     pub max_metadata_entry_bytes: u64,
     pub max_total_metadata_bytes: u64,
@@ -1955,6 +1955,58 @@ mod tests {
             .launches
             .iter()
             .any(|launch| matches!(&launch.value.target, LaunchTarget::Jar { path } if path.ends_with("paper-26.2.jar"))));
+    }
+
+    #[test]
+    fn skips_an_unrelated_root_library_jar() {
+        let root = temporary_path("root-library-filter");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar(
+            &root.join("server.jar"),
+            "Main-Class: net.minecraft.bundler.Main\r\n\r\n",
+            r#"{"id":"26.2","world_version":4903}"#,
+        );
+        write_test_jar_entries(
+            &root.join("a-library.jar"),
+            &[("META-INF/MANIFEST.MF", "Main-Class: com.example.Library\r\n\r\n")],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect root with unrelated library");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("vanilla"));
+        assert_eq!(
+            report
+                .launches
+                .iter()
+                .filter(|launch| matches!(&launch.value.target, LaunchTarget::Jar { .. }))
+                .count(),
+            1
+        );
+        assert!(!report
+            .launches
+            .iter()
+            .any(|launch| matches!(&launch.value.target, LaunchTarget::Jar { path } if path.ends_with("a-library.jar"))));
+    }
+
+    #[test]
+    fn accepts_an_unknown_root_name_when_server_metadata_is_present() {
+        let root = temporary_path("unknown-root-filter");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar_entries(
+            &root.join("custom-runtime.jar"),
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/custom-runtime-26.2.jar\n"),
+            ],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect unknown server root");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("custom-runtime"));
     }
 
     #[test]

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -31,6 +31,8 @@ const MOJANG_VERSION_ENTRY: &str = "version.json";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InspectionOptions {
     pub max_archive_entries: usize,
+    /// 根目录中最多读取的候选 JAR 数量，避免无界扫描任意文件。
+    pub max_root_archives: usize,
     pub max_metadata_entry_bytes: u64,
     pub max_total_metadata_bytes: u64,
     /// 后续嵌套归档检测的单归档上限；设为 0 可禁用嵌套归档读取。
@@ -44,6 +46,7 @@ impl Default for InspectionOptions {
     fn default() -> Self {
         Self {
             max_archive_entries: 50_000,
+            max_root_archives: 64,
             max_metadata_entry_bytes: 4 * 1024 * 1024,
             max_total_metadata_bytes: 32 * 1024 * 1024,
             max_nested_archive_bytes: 128 * 1024 * 1024,
@@ -135,7 +138,60 @@ pub fn inspect_server_artifact(
 
         let mut directory_metadata = directory::read_metadata(path, options)?;
         diagnostics.append(&mut directory_metadata.diagnostics);
-        let detector_output = detectors::detect_directory(path, &directory_metadata, &mut evidence);
+        let mut root_version_seen = false;
+        for root_archive in &directory_metadata.root_archives {
+            let archive_path = path.join(&root_archive.relative_path);
+            let Some(bytes) = root_archive.metadata.mojang_version.as_deref() else {
+                continue;
+            };
+            match formats::mojang_version::parse(bytes) {
+                Ok(Some(document)) => {
+                    let (root_minecraft, root_java, mut version_diagnostics) =
+                        apply_mojang_version(&archive_path, document, &mut evidence);
+                    diagnostics.append(&mut version_diagnostics);
+                    if !root_version_seen {
+                        minecraft = Some(root_minecraft);
+                        java = root_java;
+                        root_version_seen = true;
+                    } else {
+                        diagnostics.push(InspectionDiagnostic {
+                            severity: DiagnosticSeverity::Warning,
+                            code: "multiple_root_version_json".to_string(),
+                            message: format!(
+                                "multiple root archives in {} provide version.json; the first recognized document was selected",
+                                path.display()
+                            ),
+                            evidence: Vec::new(),
+                        });
+                    }
+                }
+                Ok(None) => diagnostics.push(InspectionDiagnostic {
+                    severity: DiagnosticSeverity::Info,
+                    code: "unrecognized_root_version_json".to_string(),
+                    message: format!(
+                        "version.json in {} does not match the Mojang version metadata shape",
+                        archive_path.display()
+                    ),
+                    evidence: Vec::new(),
+                }),
+                Err(source) => diagnostics.push(InspectionDiagnostic {
+                    severity: DiagnosticSeverity::Warning,
+                    code: "invalid_root_version_json".to_string(),
+                    message: format!(
+                        "could not parse version.json in {}: {source}",
+                        archive_path.display()
+                    ),
+                    evidence: Vec::new(),
+                }),
+            }
+        }
+        let detector_output = detectors::detect_directory(
+            path,
+            &directory_metadata,
+            minecraft.as_ref(),
+            Some(&java.required_major),
+            &mut evidence,
+        );
         apply_detector_output(
             detector_output,
             &mut identity,
@@ -316,6 +372,11 @@ fn validate_options(options: &InspectionOptions) -> Result<(), ServerInspectionE
     if options.max_archive_entries == 0 {
         return Err(ServerInspectionError::InvalidOptions {
             detail: "max_archive_entries must be greater than zero",
+        });
+    }
+    if options.max_root_archives == 0 {
+        return Err(ServerInspectionError::InvalidOptions {
+            detail: "max_root_archives must be greater than zero",
         });
     }
     if options.max_metadata_entry_bytes == 0 {
@@ -698,7 +759,7 @@ mod tests {
     use super::{
         inspect_server_artifact, ArtifactFormat, ArtifactRole, DetectionTarget, InspectionOptions,
         InspectionSubjectKind, LaunchPlatform, LaunchTarget, ReleaseChannel, ServerCategory,
-        ServerComponentKind, ServerEcosystem,
+        ServerComponentKind, ServerEcosystem, ServerInspectionError,
     };
 
     fn temporary_path(suffix: &str) -> PathBuf {
@@ -1867,5 +1928,152 @@ mod tests {
             report.subject.fingerprint.expect("fingerprint").value,
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
+    }
+
+    #[test]
+    fn discovers_a_paperclip_root_archive_without_a_server_filename() {
+        let root = temporary_path("paperclip-root");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar_entries(
+            &root.join("paper-26.2.jar"),
+            &[
+                ("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n"),
+                ("META-INF/versions.list", "hash\t26.2\t26.2/paper-26.2.jar\n"),
+                (
+                    "META-INF/libraries.list",
+                    "hash\tio.papermc.paper:paper-api:26.2.build.87-stable\tpaper-api.jar\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect Paperclip root archive");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("paper"));
+        assert!(report
+            .launches
+            .iter()
+            .any(|launch| matches!(&launch.value.target, LaunchTarget::Jar { path } if path.ends_with("paper-26.2.jar"))));
+    }
+
+    #[test]
+    fn discovers_a_proxy_root_archive_without_a_server_filename() {
+        let root = temporary_path("velocity-root");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar_entries(
+            &root.join("velocity.jar"),
+            &[
+                (
+                    "META-INF/MANIFEST.MF",
+                    "Main-Class: com.velocitypowered.proxy.Velocity\r\nImplementation-Title: Velocity\r\nImplementation-Version: 4.1.0\r\n\r\n",
+                ),
+            ],
+        );
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("inspect Velocity root archive");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("velocity"));
+        assert!(report
+            .launches
+            .iter()
+            .any(|launch| matches!(&launch.value.target, LaunchTarget::Jar { path } if path.ends_with("velocity.jar"))));
+    }
+
+    #[test]
+    fn root_archives_are_checked_when_nested_depth_is_zero() {
+        let root = temporary_path("root-depth-zero");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar(
+            &root.join("server.jar"),
+            "Main-Class: net.minecraft.bundler.Main\r\n\r\n",
+            r#"{"id":"26.2","world_version":4903,"java_version":25}"#,
+        );
+        let options = InspectionOptions {
+            max_archive_depth: 0,
+            ..InspectionOptions::default()
+        };
+
+        let report = inspect_server_artifact(&root, &options).expect("inspect root archive");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("vanilla"));
+        assert_eq!(
+            report
+                .minecraft
+                .as_ref()
+                .and_then(|minecraft| minecraft.version.value.as_deref()),
+            Some("26.2")
+        );
+    }
+
+    #[test]
+    fn corrupt_optional_root_archives_do_not_abort_directory_inspection() {
+        let root = temporary_path("corrupt-root");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar(
+            &root.join("server.jar"),
+            "Main-Class: net.minecraft.bundler.Main\r\n\r\n",
+            r#"{"id":"26.2","world_version":4903}"#,
+        );
+        fs::write(root.join("other.jar"), b"not a zip archive")
+            .expect("write corrupt root archive");
+
+        let report = inspect_server_artifact(&root, &InspectionOptions::default())
+            .expect("corrupt optional root should be skipped");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("vanilla"));
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "root_archive_unreadable"));
+    }
+
+    #[test]
+    fn root_archive_limit_is_reported_without_losing_the_first_candidate() {
+        let root = temporary_path("root-limit");
+        fs::create_dir(&root).expect("create root directory");
+        write_test_jar(
+            &root.join("server.jar"),
+            "Main-Class: net.minecraft.bundler.Main\r\n\r\n",
+            r#"{"id":"26.2","world_version":4903}"#,
+        );
+        write_test_jar_entries(
+            &root.join("paper.jar"),
+            &[("META-INF/MANIFEST.MF", "Main-Class: io.papermc.paperclip.Main\r\n\r\n")],
+        );
+        let options = InspectionOptions {
+            max_root_archives: 1,
+            ..InspectionOptions::default()
+        };
+
+        let report =
+            inspect_server_artifact(&root, &options).expect("inspect capped root directory");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert_eq!(product_key(&report), Some("vanilla"));
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "root_archive_limit_reached"));
+    }
+
+    #[test]
+    fn rejects_an_empty_root_archive_budget() {
+        let root = temporary_path("invalid-root-budget");
+        fs::create_dir(&root).expect("create root directory");
+        let options = InspectionOptions {
+            max_root_archives: 0,
+            ..InspectionOptions::default()
+        };
+
+        let error =
+            inspect_server_artifact(&root, &options).expect_err("zero root budget must fail");
+        fs::remove_dir_all(&root).expect("remove root directory");
+
+        assert!(matches!(error, ServerInspectionError::InvalidOptions { .. }));
     }
 }

--- a/crates/core/src/provisioning/server_inspection/resolver.rs
+++ b/crates/core/src/provisioning/server_inspection/resolver.rs
@@ -19,10 +19,10 @@ struct CandidateState<T> {
 /// 同一候选的独立来源只提供有限加分，避免同一文件中的重复字段淹没冲突证据。
 pub(crate) fn resolve<T>(claims: Vec<DetectionClaim<T>>) -> Detected<T>
 where
-    T: Clone + Eq,
+    T: Eq,
 {
     let candidates = rank_candidates(claims);
-    let Some(winner) = candidates.first().cloned() else {
+    let Some(winner) = candidates.first() else {
         return Detected::default();
     };
     let conflicts = candidates.get(1).is_some_and(|runner_up| {
@@ -40,17 +40,21 @@ where
         };
     }
 
+    let mut candidates = candidates.into_iter();
+    let Some(winner) = candidates.next() else {
+        return Detected::default();
+    };
     Detected {
         value: Some(winner.value),
         confidence: winner.confidence,
         evidence: winner.evidence,
-        alternatives: candidates.into_iter().skip(1).collect(),
+        alternatives: candidates.collect(),
     }
 }
 
 pub(crate) fn resolve_attributed<T>(claims: Vec<DetectionClaim<T>>) -> Vec<Attributed<T>>
 where
-    T: Clone + Eq,
+    T: Eq,
 {
     rank_candidates(claims)
         .into_iter()
@@ -64,7 +68,7 @@ where
 
 fn rank_candidates<T>(claims: Vec<DetectionClaim<T>>) -> Vec<DetectionCandidate<T>>
 where
-    T: Clone + Eq,
+    T: Eq,
 {
     let mut candidates: Vec<CandidateState<T>> = Vec::new();
     for claim in claims {

--- a/crates/core/src/provisioning/startup_parsing.rs
+++ b/crates/core/src/provisioning/startup_parsing.rs
@@ -51,11 +51,30 @@ pub struct StartupScriptInfo {
 
 /// 从文件解析启动脚本，不执行它。
 pub fn parse_startup_script_file(path: &Path) -> Result<StartupScriptInfo, StartupParseError> {
+    tracing::debug!(
+        target: "sealantern.core.provisioning.startup",
+        path = %path.display(),
+        "reading startup script for static parsing"
+    );
     let kind = StartupScriptKind::from_path(path)
         .ok_or_else(|| StartupParseError::UnsupportedScript { path: path.to_path_buf() })?;
-    let content = fs::read_to_string(path)
-        .map_err(|source| StartupParseError::Read { path: path.to_path_buf(), source })?;
-    Ok(parse_startup_script_content(kind, &content))
+    let content = fs::read_to_string(path).map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.core.provisioning.startup",
+            path = %path.display(),
+            error = %source,
+            "could not read startup script"
+        );
+        StartupParseError::Read { path: path.to_path_buf(), source }
+    })?;
+    let result = parse_startup_script_content(kind, &content);
+    tracing::debug!(
+        target: "sealantern.core.provisioning.startup",
+        path = %path.display(),
+        launches = result.launches.len(),
+        "startup script parsing completed"
+    );
+    Ok(result)
 }
 
 /// 解析启动脚本内容，不执行命令或展开变量。


### PR DESCRIPTION
合并服务端检查导入元数据、启动候选、可选快照和目录根归档发现。主机导入 I/O 命令仍未注册，脚本不会被执行或展开。

## Summary by Sourcery

将服务器检查结果集成到实例导入元数据和启动规划中，同时扩展基于目录的服务器检测，并添加轻量级服务器元数据快照。

New Features:
- 将项目中的服务器检查报告投射到导入元数据和启动候选中，并提供用于保留或采用启动配置的策略。
- 在实例上持久化摘要化的服务器元数据快照，包括标识信息、Minecraft、Java、组件、启动记录和诊断信息。
- 支持从目录中检查根服务器归档以及可选的嵌套模组加载器归档，包括在不依赖固定文件名的情况下检测原版、基于 Paperclip 的、代理以及自定义运行时。

Bug Fixes:
- 确保损坏或不可读的可选根归档和模组加载器 JAR 不会导致检查中止，而是发出诊断信息。
- 将可选启动脚本和 Forge/NeoForge 安装元数据视为尽力而为，当文件或嵌套归档不可读时进行日志记录并保存诊断信息。

Enhancements:
- 加强目录服务器检查，通过筛选和优先排序根 JAR 候选、识别已知服务器产品和主类，并将可选元数据失败视为非致命诊断。
- 丰富在整个资源准备流程中的追踪（导入、创建、复制、模组包规划、启动脚本解析、运行目录解析以及服务器检查），以提升可观测性。
- 允许服务器检查选项限制扫描的根归档数量，并验证根归档配额。
- 优化检测声明的解析，避免不必要的克隆操作，并更清晰地暴露备选候选项。

Tests:
- 为服务器检查中的根归档发现、筛选、限制以及错误处理增加覆盖，包括多种服务器和代理 JAR 布局。
- 添加关于可选嵌套模组加载器归档的测试，确保损坏的加载器会在发出诊断的同时被跳过，但仍允许生态系统检测。
- 添加验证导入元数据投射行为的测试，包括冲突处理、启动配置采用以及快照指纹有效性。
- 扩展与实例相关的测试，覆盖服务器元数据的存在以及在没有新字段时的向后兼容反序列化。
- 添加错误来源传播测试，覆盖模组包、复制、创建、导入以及现有实例资源准备中的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate server inspection results into instance import metadata and launch planning, while expanding directory-based server detection and adding lightweight server metadata snapshots.

New Features:
- Project server inspection reports into import metadata and launch candidates, with policies for preserving or adopting launch profiles.
- Persist summarized server metadata snapshots on instances, including identity, Minecraft, Java, components, launches, and diagnostics.
- Support inspecting root server archives and optional nested modloader archives from directories, including detection of vanilla, Paperclip-derived, proxy, and custom runtimes without requiring fixed filenames.

Bug Fixes:
- Ensure corrupt or unreadable optional root archives and modloader JARs do not abort inspection, instead emitting diagnostics.
- Treat optional startup scripts and Forge/NeoForge installation metadata as best-effort, logging and recording diagnostics when files or nested archives are unreadable.

Enhancements:
- Strengthen directory server inspection by filtering and prioritizing root JAR candidates, recognizing known server products and main classes, and handling optional metadata failures as non-fatal diagnostics.
- Enrich tracing across provisioning flows (import, create, copy, modpack planning, startup script parsing, run directory resolution, and server inspection) for better observability.
- Allow server inspection options to constrain the number of root archives scanned and validate the root archive budget.
- Refine resolution of detection claims to avoid unnecessary cloning and expose alternative candidates more clearly.

Tests:
- Add coverage for root archive discovery, filtering, limits, and error handling in server inspection, including various server and proxy JAR layouts.
- Add tests for optional nested modloader archives, ensuring corrupt loaders are skipped with diagnostics but still allow ecosystem detection.
- Add tests verifying import metadata projection behavior, including conflict handling, launch profile adoption, and snapshot fingerprint validity.
- Extend instance-related tests to cover server metadata presence and backwards-compatible deserialization without the new field.
- Add error source propagation tests for modpack, copy, create, import, and existing instance provisioning errors.

</details>