### PR TITLE
fix(core): 收紧服务端身份置信度判定

### DIFF
--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use super::server_inspection::{
     inspect_server_artifact, Attributed, Detected, InspectionOptions, ReleaseChannel,
     ServerEcosystem, ServerInspectionError, ServerInspectionReport,
+    MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
 };
 
 /// 一个可识别的服务端核心系列。
@@ -157,8 +158,9 @@ impl CoreFileInfo {
         let fallback_kind = fallback.kind;
         let fallback_core_version = fallback.core_version;
         let fallback_minecraft_version = fallback.minecraft_version;
-        let implementation_is_ambiguous = is_ambiguous(&report.identity.implementation);
-        let kind = if has_detection_evidence(&report.identity.implementation) {
+        let implementation_is_ambiguous =
+            is_ambiguous_implementation(&report.identity.implementation);
+        let kind = if has_decisive_implementation_evidence(&report.identity.implementation) {
             legacy_kind_from_report(report, fallback_kind)
         } else {
             fallback_kind
@@ -187,11 +189,17 @@ impl CoreFileInfo {
 }
 
 fn has_detection_evidence<T>(detected: &Detected<T>) -> bool {
-    detected.value.is_some() || detected.alternatives.len() > 1
+    detected.value.is_some() || !detected.alternatives.is_empty()
 }
 
-fn is_ambiguous<T>(detected: &Detected<T>) -> bool {
-    detected.value.is_none() && detected.alternatives.len() > 1
+fn has_decisive_implementation_evidence<T>(detected: &Detected<T>) -> bool {
+    detected.value.is_some() || is_ambiguous_implementation(detected)
+}
+
+fn is_ambiguous_implementation<T>(detected: &Detected<T>) -> bool {
+    detected.value.is_none()
+        && detected.alternatives.len() > 1
+        && detected.confidence >= MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE
 }
 
 fn selected_or_fallback<T: Clone>(detected: &Detected<T>, fallback: Option<T>) -> Option<T> {

--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -187,11 +187,11 @@ impl CoreFileInfo {
 }
 
 fn has_detection_evidence<T>(detected: &Detected<T>) -> bool {
-    detected.value.is_some() || !detected.alternatives.is_empty()
+    detected.value.is_some() || detected.alternatives.len() > 1
 }
 
 fn is_ambiguous<T>(detected: &Detected<T>) -> bool {
-    detected.value.is_none() && !detected.alternatives.is_empty()
+    detected.value.is_none() && detected.alternatives.len() > 1
 }
 
 fn selected_or_fallback<T: Clone>(detected: &Detected<T>, fallback: Option<T>) -> Option<T> {

--- a/crates/core/src/provisioning/core_parsing.rs
+++ b/crates/core/src/provisioning/core_parsing.rs
@@ -2,9 +2,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 
 use super::server_inspection::{
-    inspect_server_artifact, Attributed, Detected, InspectionOptions, ReleaseChannel,
-    ServerEcosystem, ServerInspectionError, ServerInspectionReport,
-    MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
+    inspect_server_artifact, server_implementation_outcome, Attributed, Detected, DetectionOutcome,
+    InspectionOptions, ReleaseChannel, ServerEcosystem, ServerInspectionError,
+    ServerInspectionReport,
 };
 
 /// 一个可识别的服务端核心系列。
@@ -158,9 +158,12 @@ impl CoreFileInfo {
         let fallback_kind = fallback.kind;
         let fallback_core_version = fallback.core_version;
         let fallback_minecraft_version = fallback.minecraft_version;
-        let implementation_is_ambiguous =
-            is_ambiguous_implementation(&report.identity.implementation);
-        let kind = if has_decisive_implementation_evidence(&report.identity.implementation) {
+        let implementation_outcome = server_implementation_outcome(&report.identity.implementation);
+        let implementation_is_ambiguous = implementation_outcome == DetectionOutcome::Conflict;
+        let kind = if matches!(
+            implementation_outcome,
+            DetectionOutcome::Selected | DetectionOutcome::Conflict
+        ) {
             legacy_kind_from_report(report, fallback_kind)
         } else {
             fallback_kind
@@ -190,16 +193,6 @@ impl CoreFileInfo {
 
 fn has_detection_evidence<T>(detected: &Detected<T>) -> bool {
     detected.value.is_some() || !detected.alternatives.is_empty()
-}
-
-fn has_decisive_implementation_evidence<T>(detected: &Detected<T>) -> bool {
-    detected.value.is_some() || is_ambiguous_implementation(detected)
-}
-
-fn is_ambiguous_implementation<T>(detected: &Detected<T>) -> bool {
-    detected.value.is_none()
-        && detected.alternatives.len() > 1
-        && detected.confidence >= MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE
 }
 
 fn selected_or_fallback<T: Clone>(detected: &Detected<T>, fallback: Option<T>) -> Option<T> {

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -10,9 +11,9 @@ use crate::instance::{
 
 use super::launch_adapter::adapt_launch_profile;
 use super::server_inspection::{
-    inspect_server_artifact, Detected, DiagnosticSeverity, InspectionDiagnostic, InspectionOptions,
-    LaunchPlatform, LaunchProfile, LaunchTarget, ReleaseChannel, ServerInspectionError,
-    ServerInspectionReport, MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
+    detection_outcome, inspect_server_artifact, server_implementation_outcome, Detected,
+    DetectionOutcome, DiagnosticSeverity, InspectionDiagnostic, InspectionOptions, LaunchPlatform,
+    LaunchProfile, LaunchTarget, ReleaseChannel, ServerInspectionError, ServerInspectionReport,
 };
 
 /// 控制检查结果是否可以替换已有的启动配置。
@@ -115,8 +116,8 @@ pub fn apply_server_inspection_with_options(
         diagnostics.push(unresolved_diagnostic(
             "server implementation",
             &report.identity.implementation,
-            Some(MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE),
-            |product| product.key.as_str(),
+            server_implementation_outcome(&report.identity.implementation),
+            |product| Cow::Borrowed(product.key.as_str()),
         ));
     }
 
@@ -132,8 +133,8 @@ pub fn apply_server_inspection_with_options(
         diagnostics.push(unresolved_diagnostic(
             "server implementation version",
             &report.identity.version,
-            None,
-            String::as_str,
+            detection_outcome(&report.identity.version),
+            |version| Cow::Borrowed(version.as_str()),
         ));
     }
 
@@ -150,8 +151,8 @@ pub fn apply_server_inspection_with_options(
                 diagnostics.push(unresolved_diagnostic(
                     "Minecraft version",
                     &minecraft.version,
-                    None,
-                    String::as_str,
+                    detection_outcome(&minecraft.version),
+                    |version| Cow::Borrowed(version.as_str()),
                 ));
             }
         }
@@ -527,13 +528,13 @@ fn diagnostic_severity_name(severity: DiagnosticSeverity) -> &'static str {
 fn unresolved_diagnostic<'a, T, F>(
     field: &str,
     detected: &'a Detected<T>,
-    minimum_confidence: Option<u8>,
+    outcome: DetectionOutcome,
     format_candidate: F,
 ) -> InspectionDiagnostic
 where
-    F: Fn(&'a T) -> &'a str,
+    F: Fn(&'a T) -> Cow<'a, str>,
 {
-    if detected.alternatives.is_empty() {
+    if outcome == DetectionOutcome::Missing {
         return missing_diagnostic(field);
     }
 
@@ -545,7 +546,7 @@ where
         })
         .collect::<Vec<_>>()
         .join(", ");
-    if minimum_confidence.is_some_and(|minimum| detected.confidence < minimum) {
+    if matches!(outcome, DetectionOutcome::InsufficientEvidence { .. }) {
         return InspectionDiagnostic {
             severity: DiagnosticSeverity::Warning,
             code: format!(
@@ -588,6 +589,7 @@ fn missing_diagnostic(field: &str) -> InspectionDiagnostic {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
@@ -599,8 +601,8 @@ mod tests {
     };
     use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
     use crate::provisioning::server_inspection::{
-        Attributed, Detected, DetectionCandidate, LaunchPlatform, LaunchProfile, LaunchTarget,
-        MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
+        server_implementation_outcome, Attributed, Detected, DetectionCandidate, LaunchPlatform,
+        LaunchProfile, LaunchTarget,
     };
     use crate::provisioning::{inspect_server_artifact, InspectionOptions};
     use zip::write::FileOptions;
@@ -729,14 +731,15 @@ mod tests {
         let diagnostic = unresolved_diagnostic(
             "server implementation",
             &detected,
-            Some(MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE),
-            String::as_str,
+            server_implementation_outcome(&detected),
+            |value| Cow::Owned(format!("product:{value}")),
         );
 
         assert_eq!(
             diagnostic.code,
             "server_inspection_server_implementation_insufficient_evidence"
         );
+        assert!(diagnostic.message.contains("product:paper"));
     }
 
     #[test]

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -12,7 +12,7 @@ use super::launch_adapter::adapt_launch_profile;
 use super::server_inspection::{
     inspect_server_artifact, Detected, DiagnosticSeverity, InspectionDiagnostic, InspectionOptions,
     LaunchPlatform, LaunchProfile, LaunchTarget, ReleaseChannel, ServerInspectionError,
-    ServerInspectionReport,
+    ServerInspectionReport, MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
 };
 
 /// 控制检查结果是否可以替换已有的启动配置。
@@ -115,7 +115,8 @@ pub fn apply_server_inspection_with_options(
         diagnostics.push(unresolved_diagnostic(
             "server implementation",
             &report.identity.implementation,
-            |product| product.key.clone(),
+            Some(MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE),
+            |product| product.key.as_str(),
         ));
     }
 
@@ -131,7 +132,8 @@ pub fn apply_server_inspection_with_options(
         diagnostics.push(unresolved_diagnostic(
             "server implementation version",
             &report.identity.version,
-            |version| version.clone(),
+            None,
+            String::as_str,
         ));
     }
 
@@ -148,7 +150,8 @@ pub fn apply_server_inspection_with_options(
                 diagnostics.push(unresolved_diagnostic(
                     "Minecraft version",
                     &minecraft.version,
-                    |version| version.clone(),
+                    None,
+                    String::as_str,
                 ));
             }
         }
@@ -521,13 +524,14 @@ fn diagnostic_severity_name(severity: DiagnosticSeverity) -> &'static str {
     }
 }
 
-fn unresolved_diagnostic<T, F>(
+fn unresolved_diagnostic<'a, T, F>(
     field: &str,
-    detected: &Detected<T>,
+    detected: &'a Detected<T>,
+    minimum_confidence: Option<u8>,
     format_candidate: F,
 ) -> InspectionDiagnostic
 where
-    F: Fn(&T) -> String,
+    F: Fn(&'a T) -> &'a str,
 {
     if detected.alternatives.is_empty() {
         return missing_diagnostic(field);
@@ -541,7 +545,7 @@ where
         })
         .collect::<Vec<_>>()
         .join(", ");
-    if detected.alternatives.len() == 1 {
+    if minimum_confidence.is_some_and(|minimum| detected.confidence < minimum) {
         return InspectionDiagnostic {
             severity: DiagnosticSeverity::Warning,
             code: format!(
@@ -591,11 +595,12 @@ mod tests {
 
     use super::{
         apply_server_inspection, apply_server_inspection_with_options, compatible_launch_candidate,
-        LaunchProfilePolicy, ServerInspectionProjectionOptions,
+        unresolved_diagnostic, LaunchProfilePolicy, ServerInspectionProjectionOptions,
     };
     use crate::instance::{InstanceId, InstanceSpec, LocalLaunch, StartupMode};
     use crate::provisioning::server_inspection::{
-        Attributed, LaunchPlatform, LaunchProfile, LaunchTarget,
+        Attributed, Detected, DetectionCandidate, LaunchPlatform, LaunchProfile, LaunchTarget,
+        MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
     };
     use crate::provisioning::{inspect_server_artifact, InspectionOptions};
     use zip::write::FileOptions;
@@ -699,6 +704,39 @@ mod tests {
         assert!(!diagnostics.iter().any(|diagnostic| {
             diagnostic.code == "server_inspection_server_implementation_ambiguous"
         }));
+    }
+
+    #[test]
+    fn multiple_low_confidence_candidates_are_reported_as_insufficient() {
+        let detected = Detected {
+            value: None,
+            confidence: 25,
+            evidence: Vec::new(),
+            alternatives: vec![
+                DetectionCandidate {
+                    value: "paper".to_string(),
+                    confidence: 25,
+                    evidence: Vec::new(),
+                },
+                DetectionCandidate {
+                    value: "purpur".to_string(),
+                    confidence: 20,
+                    evidence: Vec::new(),
+                },
+            ],
+        };
+
+        let diagnostic = unresolved_diagnostic(
+            "server implementation",
+            &detected,
+            Some(MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE),
+            String::as_str,
+        );
+
+        assert_eq!(
+            diagnostic.code,
+            "server_inspection_server_implementation_insufficient_evidence"
+        );
     }
 
     #[test]

--- a/crates/core/src/provisioning/import_metadata.rs
+++ b/crates/core/src/provisioning/import_metadata.rs
@@ -541,6 +541,20 @@ where
         })
         .collect::<Vec<_>>()
         .join(", ");
+    if detected.alternatives.len() == 1 {
+        return InspectionDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: format!(
+                "server_inspection_{}_insufficient_evidence",
+                field.replace(' ', "_").to_ascii_lowercase()
+            ),
+            message: format!(
+                "{field} has insufficient evidence ({candidates}); existing import metadata was preserved; provide stronger metadata or choose a value manually"
+            ),
+            evidence: detected.evidence.clone(),
+        };
+    }
+
     InspectionDiagnostic {
         severity: DiagnosticSeverity::Warning,
         code: format!(
@@ -666,6 +680,25 @@ mod tests {
         assert_eq!(instance.core_type, "custom-fork");
         assert_eq!(instance.core_version, "26.2.build.1-stable");
         assert_eq!(instance.game_version, "26.2");
+    }
+
+    #[test]
+    fn preserves_existing_product_when_filename_is_the_only_evidence() {
+        let mut instance = instance_spec();
+        let path = write_test_jar("purpur.jar", &[("empty", "")]);
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect metadata-free JAR");
+        std::fs::remove_file(&path).expect("remove metadata-free JAR");
+
+        let diagnostics = apply_server_inspection(&mut instance, Ok(&report));
+
+        assert_eq!(instance.core_type, "paper");
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "server_inspection_server_implementation_insufficient_evidence"
+        }));
+        assert!(!diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "server_inspection_server_implementation_ambiguous"
+        }));
     }
 
     #[test]

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -21,7 +21,11 @@ use super::model::{
     MinecraftVersionInfo, ReleaseChannel, ServerCategory, ServerComponent, ServerComponentKind,
     ServerEcosystem, ServerIdentityInfo, ServerProduct,
 };
-use super::resolver::{resolve, resolve_attributed, DetectionClaim};
+use super::resolver::{
+    resolve, resolve_attributed, resolve_with_minimum_confidence, DetectionClaim,
+};
+
+const MINIMUM_IMPLEMENTATION_CONFIDENCE: u8 = 50;
 
 const PAPER_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Paper, ServerEcosystem::Bukkit];
 const VANILLA_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Vanilla];
@@ -491,7 +495,7 @@ fn finalize(
     existing_java_major: Option<&Detected<u16>>,
     evidence: &mut EvidenceCollector,
 ) -> DetectorOutput {
-    let implementation = resolve(
+    let implementation = resolve_with_minimum_confidence(
         findings
             .products
             .iter()
@@ -504,6 +508,7 @@ fn finalize(
                 )
             })
             .collect(),
+        MINIMUM_IMPLEMENTATION_CONFIDENCE,
     );
     let selected_key = implementation
         .value
@@ -660,6 +665,14 @@ fn finalize(
         &implementation,
         &mut diagnostics,
     );
+    add_insufficient_evidence_diagnostic(
+        path,
+        "insufficient_server_implementation_evidence",
+        "server implementation",
+        &implementation,
+        MINIMUM_IMPLEMENTATION_CONFIDENCE,
+        &mut diagnostics,
+    );
     add_conflict_diagnostic(
         path,
         "conflicting_server_versions",
@@ -801,6 +814,29 @@ fn add_conflict_diagnostic<T>(
             .iter()
             .flat_map(|candidate| candidate.evidence.iter().copied())
             .collect(),
+    });
+}
+
+fn add_insufficient_evidence_diagnostic<T>(
+    path: &Path,
+    code: &str,
+    label: &str,
+    detected: &Detected<T>,
+    minimum_confidence: u8,
+    diagnostics: &mut Vec<InspectionDiagnostic>,
+) {
+    if detected.value.is_some() || detected.alternatives.len() != 1 {
+        return;
+    }
+    diagnostics.push(InspectionDiagnostic {
+        severity: DiagnosticSeverity::Info,
+        code: code.to_string(),
+        message: format!(
+            "{label} evidence in {} has confidence {}, below the required {minimum_confidence}",
+            path.display(),
+            detected.confidence
+        ),
+        evidence: detected.evidence.clone(),
     });
 }
 

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -24,8 +24,7 @@ use super::model::{
 use super::resolver::{
     resolve, resolve_attributed, resolve_with_minimum_confidence, DetectionClaim,
 };
-
-const MINIMUM_IMPLEMENTATION_CONFIDENCE: u8 = 50;
+use super::MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE;
 
 const PAPER_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Paper, ServerEcosystem::Bukkit];
 const VANILLA_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Vanilla];
@@ -508,7 +507,7 @@ fn finalize(
                 )
             })
             .collect(),
-        MINIMUM_IMPLEMENTATION_CONFIDENCE,
+        MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
     );
     let selected_key = implementation
         .value
@@ -658,19 +657,13 @@ fn finalize(
     let java_major = resolve(java_claims);
 
     let mut diagnostics = Vec::new();
-    add_conflict_diagnostic(
+    add_thresholded_resolution_diagnostic(
         path,
         "conflicting_server_implementations",
-        "server implementation",
-        &implementation,
-        &mut diagnostics,
-    );
-    add_insufficient_evidence_diagnostic(
-        path,
         "insufficient_server_implementation_evidence",
         "server implementation",
         &implementation,
-        MINIMUM_IMPLEMENTATION_CONFIDENCE,
+        MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
         &mut diagnostics,
     );
     add_conflict_diagnostic(
@@ -817,20 +810,25 @@ fn add_conflict_diagnostic<T>(
     });
 }
 
-fn add_insufficient_evidence_diagnostic<T>(
+fn add_thresholded_resolution_diagnostic<T>(
     path: &Path,
-    code: &str,
+    conflict_code: &str,
+    insufficient_code: &str,
     label: &str,
     detected: &Detected<T>,
     minimum_confidence: u8,
     diagnostics: &mut Vec<InspectionDiagnostic>,
 ) {
-    if detected.value.is_some() || detected.alternatives.len() != 1 {
+    if detected.value.is_some() || detected.alternatives.is_empty() {
+        return;
+    }
+    if detected.confidence >= minimum_confidence {
+        add_conflict_diagnostic(path, conflict_code, label, detected, diagnostics);
         return;
     }
     diagnostics.push(InspectionDiagnostic {
         severity: DiagnosticSeverity::Info,
-        code: code.to_string(),
+        code: insufficient_code.to_string(),
         message: format!(
             "{label} evidence in {} has confidence {}, below the required {minimum_confidence}",
             path.display(),

--- a/crates/core/src/provisioning/server_inspection/detectors/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/detectors/lib.rs
@@ -21,10 +21,8 @@ use super::model::{
     MinecraftVersionInfo, ReleaseChannel, ServerCategory, ServerComponent, ServerComponentKind,
     ServerEcosystem, ServerIdentityInfo, ServerProduct,
 };
-use super::resolver::{
-    resolve, resolve_attributed, resolve_with_minimum_confidence, DetectionClaim,
-};
-use super::MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE;
+use super::resolver::{resolve, resolve_attributed, resolve_server_implementation, DetectionClaim};
+use super::{detection_outcome, server_implementation_outcome, DetectionOutcome};
 
 const PAPER_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Paper, ServerEcosystem::Bukkit];
 const VANILLA_ECOSYSTEMS: &[ServerEcosystem] = &[ServerEcosystem::Vanilla];
@@ -494,7 +492,7 @@ fn finalize(
     existing_java_major: Option<&Detected<u16>>,
     evidence: &mut EvidenceCollector,
 ) -> DetectorOutput {
-    let implementation = resolve_with_minimum_confidence(
+    let implementation = resolve_server_implementation(
         findings
             .products
             .iter()
@@ -507,7 +505,6 @@ fn finalize(
                 )
             })
             .collect(),
-        MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
     );
     let selected_key = implementation
         .value
@@ -663,7 +660,6 @@ fn finalize(
         "insufficient_server_implementation_evidence",
         "server implementation",
         &implementation,
-        MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE,
         &mut diagnostics,
     );
     add_conflict_diagnostic(
@@ -795,7 +791,7 @@ fn add_conflict_diagnostic<T>(
     detected: &Detected<T>,
     diagnostics: &mut Vec<InspectionDiagnostic>,
 ) {
-    if detected.value.is_some() || detected.alternatives.len() < 2 {
+    if detection_outcome(detected) != DetectionOutcome::Conflict {
         return;
     }
     diagnostics.push(InspectionDiagnostic {
@@ -816,26 +812,26 @@ fn add_thresholded_resolution_diagnostic<T>(
     insufficient_code: &str,
     label: &str,
     detected: &Detected<T>,
-    minimum_confidence: u8,
     diagnostics: &mut Vec<InspectionDiagnostic>,
 ) {
-    if detected.value.is_some() || detected.alternatives.is_empty() {
-        return;
+    match server_implementation_outcome(detected) {
+        DetectionOutcome::Conflict => {
+            add_conflict_diagnostic(path, conflict_code, label, detected, diagnostics);
+        }
+        DetectionOutcome::InsufficientEvidence { minimum_confidence } => {
+            diagnostics.push(InspectionDiagnostic {
+                severity: DiagnosticSeverity::Info,
+                code: insufficient_code.to_string(),
+                message: format!(
+                "{label} evidence in {} has confidence {}, below the required {minimum_confidence}",
+                path.display(),
+                detected.confidence
+            ),
+                evidence: detected.evidence.clone(),
+            })
+        }
+        DetectionOutcome::Missing | DetectionOutcome::Selected => {}
     }
-    if detected.confidence >= minimum_confidence {
-        add_conflict_diagnostic(path, conflict_code, label, detected, diagnostics);
-        return;
-    }
-    diagnostics.push(InspectionDiagnostic {
-        severity: DiagnosticSeverity::Info,
-        code: insufficient_code.to_string(),
-        message: format!(
-            "{label} evidence in {} has confidence {}, below the required {minimum_confidence}",
-            path.display(),
-            detected.confidence
-        ),
-        evidence: detected.evidence.clone(),
-    });
 }
 
 fn detect_filename(path: &Path, findings: &mut Findings) {

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -22,12 +22,13 @@ pub use model::*;
 use evidence::{EvidenceCollector, NewEvidence};
 use formats::manifest::ParsedManifest;
 use formats::mojang_version::MojangVersionDocument;
+pub(crate) use resolver::{detection_outcome, server_implementation_outcome, DetectionOutcome};
 use resolver::{resolve, DetectionClaim};
 
 const MANIFEST_ENTRY: &str = "META-INF/MANIFEST.MF";
 const MOJANG_VERSION_ENTRY: &str = "version.json";
 const SERVER_INSPECTION_TARGET: &str = "sealantern.core.provisioning.server_inspection";
-pub(crate) const MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE: u8 = 50;
+const MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE: u8 = 50;
 
 /// 控制静态检查的资源预算；检查过程不会执行 JAR、脚本或 shell 展开。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -27,6 +27,7 @@ use resolver::{resolve, DetectionClaim};
 const MANIFEST_ENTRY: &str = "META-INF/MANIFEST.MF";
 const MOJANG_VERSION_ENTRY: &str = "version.json";
 const SERVER_INSPECTION_TARGET: &str = "sealantern.core.provisioning.server_inspection";
+pub(crate) const MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE: u8 = 50;
 
 /// 控制静态检查的资源预算；检查过程不会执行 JAR、脚本或 shell 展开。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/provisioning/server_inspection/lib.rs
+++ b/crates/core/src/provisioning/server_inspection/lib.rs
@@ -1942,6 +1942,28 @@ mod tests {
     }
 
     #[test]
+    fn filename_only_product_remains_an_unselected_candidate() {
+        let path = temporary_path("paper.jar");
+        write_test_jar_entries(&path, &[("empty", "")]);
+
+        let report = inspect_server_artifact(&path, &InspectionOptions::default())
+            .expect("inspect metadata-free JAR");
+        fs::remove_file(&path).expect("remove metadata-free JAR");
+
+        assert!(report.identity.implementation.value.is_none());
+        assert_eq!(report.identity.implementation.confidence, 25);
+        assert_eq!(report.identity.implementation.alternatives.len(), 1);
+        assert_eq!(report.identity.implementation.alternatives[0].value.key, "paper");
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "insufficient_server_implementation_evidence"
+        }));
+        assert!(!report
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "conflicting_server_implementations" }));
+    }
+
+    #[test]
     fn empty_directories_are_reported_without_false_identity_claims() {
         let path = temporary_path("directory");
         fs::create_dir(&path).expect("create test directory");

--- a/crates/core/src/provisioning/server_inspection/resolver.rs
+++ b/crates/core/src/provisioning/server_inspection/resolver.rs
@@ -205,4 +205,16 @@ mod tests {
         assert_eq!(detected.alternatives.len(), 1);
         assert_eq!(detected.alternatives[0].value, "paper");
     }
+
+    #[test]
+    fn multiple_low_confidence_candidates_remain_insufficient() {
+        let detected = resolve_with_minimum_confidence(
+            vec![claim("paper", 0, 25, "file-name"), claim("purpur", 1, 20, "weak-metadata")],
+            50,
+        );
+
+        assert_eq!(detected.value, None);
+        assert_eq!(detected.confidence, 25);
+        assert_eq!(detected.alternatives.len(), 2);
+    }
 }

--- a/crates/core/src/provisioning/server_inspection/resolver.rs
+++ b/crates/core/src/provisioning/server_inspection/resolver.rs
@@ -1,4 +1,13 @@
 use super::model::{Attributed, Detected, DetectionCandidate, EvidenceId};
+use super::MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DetectionOutcome {
+    Missing,
+    Selected,
+    InsufficientEvidence { minimum_confidence: u8 },
+    Conflict,
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct DetectionClaim<T> {
@@ -69,6 +78,37 @@ where
         evidence: winner.evidence,
         alternatives: candidates.collect(),
     }
+}
+
+pub(crate) fn resolve_server_implementation<T>(claims: Vec<DetectionClaim<T>>) -> Detected<T>
+where
+    T: Eq,
+{
+    resolve_with_minimum_confidence(claims, MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE)
+}
+
+pub(crate) fn detection_outcome<T>(detected: &Detected<T>) -> DetectionOutcome {
+    detection_outcome_with_minimum_confidence(detected, 0)
+}
+
+pub(crate) fn server_implementation_outcome<T>(detected: &Detected<T>) -> DetectionOutcome {
+    detection_outcome_with_minimum_confidence(detected, MINIMUM_SERVER_IMPLEMENTATION_CONFIDENCE)
+}
+
+fn detection_outcome_with_minimum_confidence<T>(
+    detected: &Detected<T>,
+    minimum_confidence: u8,
+) -> DetectionOutcome {
+    if detected.value.is_some() {
+        return DetectionOutcome::Selected;
+    }
+    if detected.alternatives.is_empty() {
+        return DetectionOutcome::Missing;
+    }
+    if detected.confidence < minimum_confidence || detected.alternatives.len() == 1 {
+        return DetectionOutcome::InsufficientEvidence { minimum_confidence };
+    }
+    DetectionOutcome::Conflict
 }
 
 pub(crate) fn resolve_attributed<T>(claims: Vec<DetectionClaim<T>>) -> Vec<Attributed<T>>
@@ -155,7 +195,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve, resolve_with_minimum_confidence, DetectionClaim};
+    use super::{
+        resolve, resolve_with_minimum_confidence, server_implementation_outcome, DetectionClaim,
+        DetectionOutcome,
+    };
     use crate::provisioning::server_inspection::EvidenceId;
 
     fn claim(value: &str, id: u32, weight: u8, group: &str) -> DetectionClaim<String> {
@@ -216,5 +259,9 @@ mod tests {
         assert_eq!(detected.value, None);
         assert_eq!(detected.confidence, 25);
         assert_eq!(detected.alternatives.len(), 2);
+        assert_eq!(
+            server_implementation_outcome(&detected),
+            DetectionOutcome::InsufficientEvidence { minimum_confidence: 50 }
+        );
     }
 }

--- a/crates/core/src/provisioning/server_inspection/resolver.rs
+++ b/crates/core/src/provisioning/server_inspection/resolver.rs
@@ -21,6 +21,16 @@ pub(crate) fn resolve<T>(claims: Vec<DetectionClaim<T>>) -> Detected<T>
 where
     T: Eq,
 {
+    resolve_with_minimum_confidence(claims, 0)
+}
+
+pub(crate) fn resolve_with_minimum_confidence<T>(
+    claims: Vec<DetectionClaim<T>>,
+    minimum_confidence: u8,
+) -> Detected<T>
+where
+    T: Eq,
+{
     let candidates = rank_candidates(claims);
     let Some(winner) = candidates.first() else {
         return Detected::default();
@@ -32,6 +42,15 @@ where
     });
 
     if conflicts {
+        return Detected {
+            value: None,
+            confidence: winner.confidence,
+            evidence: winner.evidence.clone(),
+            alternatives: candidates,
+        };
+    }
+
+    if winner.confidence < minimum_confidence.min(100) {
         return Detected {
             value: None,
             confidence: winner.confidence,
@@ -136,7 +155,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve, DetectionClaim};
+    use super::{resolve, resolve_with_minimum_confidence, DetectionClaim};
     use crate::provisioning::server_inspection::EvidenceId;
 
     fn claim(value: &str, id: u32, weight: u8, group: &str) -> DetectionClaim<String> {
@@ -173,5 +192,17 @@ mod tests {
         assert_eq!(detected.value, None);
         assert_eq!(detected.confidence, 95);
         assert_eq!(detected.alternatives.len(), 2);
+    }
+
+    #[test]
+    fn low_confidence_candidate_remains_available_without_being_selected() {
+        let detected =
+            resolve_with_minimum_confidence(vec![claim("paper", 0, 25, "file-name")], 50);
+
+        assert_eq!(detected.value, None);
+        assert_eq!(detected.confidence, 25);
+        assert_eq!(detected.evidence, vec![EvidenceId(0)]);
+        assert_eq!(detected.alternatives.len(), 1);
+        assert_eq!(detected.alternatives[0].value, "paper");
     }
 }


### PR DESCRIPTION
## 摘要
- 避免低置信度服务端身份覆盖已有信息
- 区分证据不足与候选冲突
- 保持陌生服务端和兼容解析行为稳定

## 验证
- 服务端检查相关测试通过
- 导入投影相关测试通过
- 兼容解析相关测试通过
- core 库编译检查通过

## Summary by Sourcery

收紧服务器实现置信度处理逻辑，使低证据的检测结果不会覆盖已有元数据，并能与真实冲突区分开来进行报告。

Bug Fixes:
- 防止在导入和核心解析过程中，低置信度的服务器实现检测结果替换现有实例元数据。
- 确保仅基于文件名及其他弱证据的服务器实现判断被视为“证据不足”，而不是“存在模糊冲突”。

Enhancements:
- 在服务器检查、检测器以及核心解析的服务器实现解析和诊断中引入最低置信度阈值。
- 优化诊断信息，以区分服务器实现之间的真实冲突与证据不足的情况，同时保留候选实现的信息。

Tests:
- 添加单元测试，覆盖低置信度服务器实现解析与诊断，以及针对无元数据 JAR 和多弱候选场景下的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten server implementation confidence handling so low-evidence detections do not override existing metadata and are reported distinctly from true conflicts.

Bug Fixes:
- Prevent low-confidence server implementation detections from replacing existing instance metadata during import and core parsing.
- Ensure filename-only and other weak evidence for server implementation is treated as insufficient rather than as an ambiguous conflict.

Enhancements:
- Introduce a minimum confidence threshold for server implementation resolution and diagnostics across server inspection, detectors, and core parsing.
- Refine diagnostics to distinguish between conflicting server implementations and insufficient evidence cases while preserving candidate information.

Tests:
- Add unit tests covering low-confidence server implementation resolution, diagnostics, and behavior for metadata-free JARs and multiple weak candidates.

</details>