### PR TITLE
ci: 修复 nightly 删除过时 tag 和 release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -299,8 +299,8 @@ jobs:
       - validate-nightly
       - publish-tauri-nightly
     if: >-
-      needs.validate-nightly.outputs.should_build == 'true' &&
-      needs.publish-tauri-nightly.result == 'success'
+      always() &&
+      needs.validate-nightly.outputs.should_build == 'true'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -309,6 +309,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_TAG: ${{ needs.validate-nightly.outputs.tag }}
+          PUBLISH_RESULT: ${{ needs.publish-tauri-nightly.result }}
         run: |
           set -euo pipefail
 
@@ -318,7 +319,7 @@ jobs:
 
           deleted=0
           for tag in "${NIGHTLY_TAGS[@]}"; do
-            if [ "$tag" = "$CURRENT_TAG" ]; then
+            if [ "$tag" = "$CURRENT_TAG" ] && [ "$PUBLISH_RESULT" = "success" ]; then
               continue
             fi
 


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

修复 nightly 删除过时 tag 和 release

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

CI:
- 无论发布步骤结果如何都运行夜间清理任务；仅在发布步骤成功时跳过删除当前标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Run the nightly cleanup job regardless of publish step result while only skipping deletion of the current tag when the publish step succeeds.

</details>