### PR TITLE
fix(infra): 修复 APP_DIR_NAME 未覆盖 macos，导致build不成功的问题

### DIFF
--- a/crates/infra/src/platform/locations.rs
+++ b/crates/infra/src/platform/locations.rs
@@ -14,7 +14,7 @@ use crate::observability;
 const APP_DATA_DIR_ENV: &str = "SEALANTERN_DATA_DIR";
 
 /// 标准安装的应用目录名（macOS 和 Windows MSI 安装使用）。
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const APP_DIR_NAME: &str = "SeaLantern";
 
 /// Linux 平台的应用目录名（遵循 XDG 规范使用小写）。


### PR DESCRIPTION
- APP_DIR_NAME 仅限 windows 定义，但 macOS 分支也在使用导致 E0425
- 修正 cfg 为 any(windows, macos)，与常量注释语义一致

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

依旧懒得写
