### PR TITLE
feat: 接入桌面dialog能力并临时禁用前端右键屏蔽功能

### DIFF
--- a/src-tauri/src/desktop/dialog.rs
+++ b/src-tauri/src/desktop/dialog.rs
@@ -1,9 +1,9 @@
 //! 文件对话框命令。
 //!
 //! 实现 system 模块的文件选择、保存与文件夹选择接口：
-//! `pick_jar_file` / `pick_archive_file` / `pick_startup_file` /
-//! `pick_server_executable` / `pick_java_file` / `pick_save_file` /
-//! `pick_folder` / `pick_image_file`。
+//! `desktop_pick_jar_file` / `desktop_pick_archive_file` / `desktop_pick_startup_file` /
+//! `desktop_pick_server_executable` / `desktop_pick_java_file` / `desktop_pick_save_file` /
+//! `desktop_pick_folder` / `desktop_pick_image_file`。
 //!
 //! 对话框由 `tauri-plugin-dialog` 提供，采用回调 + 通道转发结果：
 //! 选中返回路径字符串，取消返回 `null`。
@@ -16,7 +16,8 @@ use tauri_plugin_dialog::DialogExt;
 /// 打开系统文件选择器选择 JAR 文件。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-pub fn pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -34,7 +35,8 @@ pub fn pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
 /// 打开系统文件选择器选择压缩包文件（.zip/.tar/.tar.gz/.tgz/.jar）。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-pub fn pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -57,7 +59,11 @@ pub fn pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String
 ///
 /// `mode` 决定过滤器：`"jar"` / `"bat"` / `"sh"`，未知模式按 JAR 处理。
 /// 返回选中文件的路径，取消则返回 `null`。
-pub fn pick_startup_file(app: tauri::AppHandle, mode: String) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_startup_file(
+    app: tauri::AppHandle,
+    mode: String,
+) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
     let mode = mode.to_ascii_lowercase();
 
@@ -92,7 +98,10 @@ pub fn pick_startup_file(app: tauri::AppHandle, mode: String) -> Result<Option<S
 /// 打开系统文件选择器选择服务端可执行文件，同时返回启动模式。
 ///
 /// 返回 `[路径, 启动模式]`，模式为 `"jar" | "bat" | "sh"`；取消则返回 `null`。
-pub fn pick_server_executable(app: tauri::AppHandle) -> Result<Option<(String, String)>, String> {
+#[tauri::command]
+pub fn desktop_pick_server_executable(
+    app: tauri::AppHandle,
+) -> Result<Option<(String, String)>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -128,7 +137,8 @@ pub fn pick_server_executable(app: tauri::AppHandle) -> Result<Option<(String, S
 ///
 /// Windows 上按 `.exe` 过滤，其他平台不设扩展名过滤器（Java 二进制无扩展名）。
 /// 返回选中文件的路径，取消则返回 `null`。
-pub fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     #[cfg(target_os = "windows")]
@@ -148,7 +158,8 @@ pub fn pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
 /// 打开系统文件保存对话框。
 ///
 /// 返回保存路径，取消则返回 `null`。
-pub fn pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -164,7 +175,8 @@ pub fn pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
 /// 打开系统文件夹选择器。
 ///
 /// 返回选中的文件夹路径，取消则返回 `null`。
-pub fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()
@@ -180,7 +192,8 @@ pub fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
 /// 打开系统文件选择器选择图片文件。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-pub fn pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
+#[tauri::command]
+pub fn desktop_pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
     app.dialog()

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -6,6 +6,7 @@
 pub mod dialog;
 
 pub use dialog::{
-    pick_archive_file, pick_folder, pick_image_file, pick_jar_file, pick_java_file, pick_save_file,
-    pick_server_executable, pick_startup_file,
+    desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
+    desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
+    desktop_pick_startup_file,
 };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,11 @@ use adapter::tauri::commands::instance::{
     create_instance, delete_instance, force_stop_instance, get_instance, instance_status,
     list_instances, rename_instance, start_instance, stop_instance, update_instance_path,
 };
+use desktop::{
+    desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
+    desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
+    desktop_pick_startup_file,
+};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 /// 启动桌面应用。
@@ -25,6 +30,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
+            //instance能力（由adapter/tauri/commands接入application）
             create_instance,
             delete_instance,
             force_stop_instance,
@@ -34,7 +40,16 @@ pub fn run() {
             rename_instance,
             start_instance,
             stop_instance,
-            update_instance_path
+            update_instance_path,
+            //桌面端能力（由desktop/dialog提供）
+            desktop_pick_archive_file,
+            desktop_pick_folder,
+            desktop_pick_image_file,
+            desktop_pick_jar_file,
+            desktop_pick_java_file,
+            desktop_pick_save_file,
+            desktop_pick_server_executable,
+            desktop_pick_startup_file
         ])
         .setup(|app| {
             // 前端提供自定义标题栏；macOS 仍使用 Overlay 承载系统交通灯。

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,22 @@ interface ServerStartFallbackEventPayload {
   reason: string;
 }
 
+// ============================================================
+// TODO: 请在后端重构完成后恢复
+// 临时开关：禁用右键捕获（开发调试用）
+// 原因：右键行为依赖后端 developer_mode 设置，但后端正在重构、
+//       暂时无法提供设置，导致开发者模式下右键仍被错误拦截。
+// 恢复方式：后端重构完成后，将 TEMP_DISABLE_CONTEXT_MENU_CAPTURE
+//          改为 false（或直接删除此开关及相关 return 分支）即可。
+// ============================================================
+const TEMP_DISABLE_CONTEXT_MENU_CAPTURE = true;
+
 async function handleGlobalContextMenu(event: MouseEvent) {
+  // TODO: 请在后端重构完成后恢复（临时禁用右键捕获，见上方开关说明）
+  if (TEMP_DISABLE_CONTEXT_MENU_CAPTURE) {
+    return;
+  }
+
   // 在浏览器环境（Docker 模式）下，不阻止右键菜单，允许开发者工具
   if (isBrowserEnv()) {
     return;
@@ -139,7 +154,7 @@ onMounted(async () => {
     );
   }
 
-  contextMenuStore.initContextMenuListener();
+  await contextMenuStore.initContextMenuListener();
   document.addEventListener("contextmenu", handleGlobalContextMenu);
 
   // 插件事件监听相互独立,并行初始化以缩短启动时间;任一失败不影响其他

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -136,14 +136,14 @@ export const systemApi = {
     if (isUploadSupported()) {
       return this.pickAndUploadBrowserFile(".jar");
     }
-    return tauriInvoke("pick_jar_file");
+    return tauriInvoke("desktop_pick_jar_file");
   },
 
   async pickArchiveFile(): Promise<string | null> {
     if (isUploadSupported()) {
       return this.pickAndUploadBrowserFile(".zip,.tar,.tar.gz,.tgz,.jar");
     }
-    return tauriInvoke("pick_archive_file");
+    return tauriInvoke("desktop_pick_archive_file");
   },
 
   async pickStartupFile(mode: "jar" | "bat" | "sh"): Promise<string | null> {
@@ -160,7 +160,7 @@ export const systemApi = {
       }
       return null;
     }
-    return tauriInvoke("pick_startup_file", { mode });
+    return tauriInvoke("desktop_pick_startup_file", { mode });
   },
 
   async pickServerExecutable(): Promise<{ path: string; mode: "jar" | "bat" | "sh" } | null> {
@@ -174,7 +174,7 @@ export const systemApi = {
       }
       return null;
     }
-    const result = await tauriInvoke<[string, string] | null>("pick_server_executable");
+    const result = await tauriInvoke<[string, string] | null>("desktop_pick_server_executable");
     if (result) {
       return { path: result[0], mode: result[1] as "jar" | "bat" | "sh" };
     }
@@ -190,21 +190,21 @@ export const systemApi = {
       }
       return null;
     }
-    return tauriInvoke("pick_java_file");
+    return tauriInvoke("desktop_pick_java_file");
   },
 
   async pickSaveFile(): Promise<string | null> {
     if (isUploadSupported()) {
       throw new Error("Docker环境不支持原生文件选择器，请使用文件上传功能");
     }
-    return tauriInvoke("pick_save_file");
+    return tauriInvoke("desktop_pick_save_file");
   },
 
   async pickFolder(): Promise<string | null> {
     if (isUploadSupported()) {
       throw new Error("Docker环境不支持原生文件选择器，请使用文件上传功能");
     }
-    return tauriInvoke("pick_folder");
+    return tauriInvoke("desktop_pick_folder");
   },
 
   async pickImageFile(): Promise<string | null> {
@@ -216,7 +216,7 @@ export const systemApi = {
       }
       return null;
     }
-    return tauriInvoke("pick_image_file");
+    return tauriInvoke("desktop_pick_image_file");
   },
 
   async openFile(path: string): Promise<void> {

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -251,18 +251,28 @@ export function applyDeveloperMode(enabled: boolean): void {
 
 /**
  * 阻止右键菜单
+ *
+ * TODO: 请在后端重构完成后恢复（临时置空，开发调试用）
+ * 拦截逻辑依赖后端 developer_mode 设置，但后端正在重构、
+ * 暂时无法提供设置，为避免开发者模式下右键仍被拦截，
+ * 暂时屏蔽此逻辑。恢复 `e.preventDefault()` 即可。
  */
-function blockContextMenu(e: Event): void {
-  e.preventDefault();
+function blockContextMenu(_e: Event): void {
+  // TODO: 请在后端重构完成后恢复
+  // e.preventDefault();
 }
 
 /**
  * 阻止开发者工具快捷键
+ *
+ * TODO: 请在后端重构完成后恢复（临时置空，开发调试用）
+ * 原因同上，恢复 `e.preventDefault()` 即可。
  */
-function blockDevTools(e: KeyboardEvent): void {
-  if (e.key === "F12") {
-    e.preventDefault();
-  }
+function blockDevTools(_e: KeyboardEvent): void {
+  // TODO: 请在后端重构完成后恢复
+  // if (e.key === "F12") {
+  //   e.preventDefault();
+  // }
 }
 
 /**


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要
依旧懒得写（bushi

## Summary by Sourcery

将桌面对话框能力集成为 tauri 命令，并将其接入系统 API；同时在前端暂时禁用右键菜单和开发者工具拦截，以适配正在进行的后端重构。

New Features:
- 通过重命名后的 tauri 命令，将桌面文件和文件夹对话框命令暴露给前端，用于选择 jar、archive、startup、server executable、Java、保存文件、文件夹以及图片。

Bug Fixes:
- 将前端 system API 与新的桌面对话框命令名称对齐，确保桌面文件对话框正常工作。

Enhancements:
- 在 App.vue 中通过开关，暂时禁用前端的上下文菜单（右键菜单）和开发者工具快捷键拦截，以支持在后端 developer_mode 重构期间的开发工作。
- 异步初始化 context menu store 监听器，以便更好地与全局上下文菜单处理进行协调。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate desktop dialog capabilities as tauri commands and wire them into the system API, while temporarily disabling right-click and devtools interception on the frontend to accommodate ongoing backend refactoring.

New Features:
- Expose desktop file and folder dialog commands to the frontend via renamed tauri commands for jar, archive, startup, server executable, Java, save file, folder, and image selection.

Bug Fixes:
- Align frontend system API with the new desktop dialog command names to ensure desktop file dialogs function correctly.

Enhancements:
- Temporarily disable frontend context menu and devtools shortcut blocking (behind a toggle in App.vue) to support development while backend developer_mode is being refactored.
- Initialize the context menu store listener asynchronously to better coordinate with global context menu handling.

</details>