### PR TITLE
feat: 系统资源使用情况信息获取

### DIFF
--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1.91"
-tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "sync", "fs"] }
+tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "sync", "fs", "time"] }
 sealantern-core = { path = "../crates/core" }
 sealantern-interface = { path = "../crates/interface" }
 sealantern-extra = { path = "../crates/extra" }

--- a/application/src/error/mod.rs
+++ b/application/src/error/mod.rs
@@ -12,8 +12,11 @@ pub mod instance;
 pub mod plugin;
 /// 服务器管理领域错误。
 pub mod server;
+/// 系统资源信息领域错误。
+pub mod system;
 
 pub use config::ConfigError;
 pub use instance::InstanceError;
 pub use plugin::PluginError;
 pub use server::ServerError;
+pub use system::SystemError;

--- a/application/src/error/system.rs
+++ b/application/src/error/system.rs
@@ -1,0 +1,66 @@
+//! 系统资源信息领域的主错误。
+
+use std::fmt;
+
+use sealantern_interface::error::SystemServiceError;
+
+/// 系统资源信息操作失败的应用层主错误。
+///
+/// 携带底层失败细节（source），供应用层日志排查；向 [`SystemServiceError`]
+/// 转换时收敛为分类，不向宿主泄漏敏感信息。
+#[derive(Debug)]
+pub enum SystemError {
+    /// 指定的进程不存在或无权访问。
+    ProcessNotFound,
+    /// 指定的路径不存在或不可访问。
+    PathNotFound,
+    /// 底层系统采集 / IO 操作失败。
+    OperationFailed {
+        /// 底层来源错误。
+        source: std::io::Error,
+    },
+    /// 该能力尚未实现（占位）。
+    Unsupported,
+}
+
+impl fmt::Display for SystemError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProcessNotFound => write!(formatter, "process not found"),
+            Self::PathNotFound => write!(formatter, "path not found"),
+            Self::OperationFailed { source } => {
+                write!(formatter, "system operation failed: {source}")
+            }
+            Self::Unsupported => write!(formatter, "operation not supported"),
+        }
+    }
+}
+
+impl std::error::Error for SystemError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::OperationFailed { source } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for SystemError {
+    fn from(source: std::io::Error) -> Self {
+        Self::OperationFailed { source }
+    }
+}
+
+/// 应用层主错误 → 接口契约错误的收敛转换。
+///
+/// 细节被抹平为分类，敏感字段不跨传输面。
+impl From<SystemError> for SystemServiceError {
+    fn from(error: SystemError) -> Self {
+        match error {
+            SystemError::ProcessNotFound => Self::ProcessNotFound,
+            SystemError::PathNotFound => Self::PathNotFound,
+            SystemError::OperationFailed { .. } => Self::OperationFailed,
+            SystemError::Unsupported => Self::Unsupported,
+        }
+    }
+}

--- a/application/src/error/system.rs
+++ b/application/src/error/system.rs
@@ -19,6 +19,11 @@ pub enum SystemError {
         /// 底层来源错误。
         source: std::io::Error,
     },
+    /// 内部异步任务失败（如阻塞任务被取消或 panic）。
+    Internal {
+        /// 底层来源错误。
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     /// 该能力尚未实现（占位）。
     Unsupported,
 }
@@ -31,6 +36,7 @@ impl fmt::Display for SystemError {
             Self::OperationFailed { source } => {
                 write!(formatter, "system operation failed: {source}")
             }
+            Self::Internal { source } => write!(formatter, "internal system task failed: {source}"),
             Self::Unsupported => write!(formatter, "operation not supported"),
         }
     }
@@ -40,6 +46,7 @@ impl std::error::Error for SystemError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::OperationFailed { source } => Some(source),
+            Self::Internal { source } => Some(source.as_ref()),
             _ => None,
         }
     }
@@ -51,6 +58,12 @@ impl From<std::io::Error> for SystemError {
     }
 }
 
+impl From<tokio::task::JoinError> for SystemError {
+    fn from(source: tokio::task::JoinError) -> Self {
+        Self::Internal { source: Box::new(source) }
+    }
+}
+
 /// 应用层主错误 → 接口契约错误的收敛转换。
 ///
 /// 细节被抹平为分类，敏感字段不跨传输面。
@@ -59,7 +72,9 @@ impl From<SystemError> for SystemServiceError {
         match error {
             SystemError::ProcessNotFound => Self::ProcessNotFound,
             SystemError::PathNotFound => Self::PathNotFound,
-            SystemError::OperationFailed { .. } => Self::OperationFailed,
+            SystemError::OperationFailed { .. } | SystemError::Internal { .. } => {
+                Self::OperationFailed
+            }
             SystemError::Unsupported => Self::Unsupported,
         }
     }

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -1,8 +1,10 @@
 //! 应用层服务实现模块。
 //!
-//! 存放各类宿主能力的默认实现（如 [`CoreInstanceService`]），
+//! 存放各类宿主能力的默认实现（如 [`CoreInstanceService`]、[`CoreSystemService`]），
 //! 实现 `interface` 的能力端口，由 `services` 装配层组装进全局容器。
 
 mod instance;
+mod system;
 
 pub use instance::CoreInstanceService;
+pub use system::CoreSystemService;

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -32,12 +32,12 @@ pub struct CoreSystemService;
 
 impl CoreSystemService {
     /// 采集整机资源快照，返回应用层主错误。
-    fn snapshot_inner() -> Result<SystemSnapshot, SystemError> {
+    async fn snapshot_inner() -> Result<SystemSnapshot, SystemError> {
         let info = collect_system_info();
 
-        // CPU 间隔两次采样，取后一次的平滑使用率。
+        // CPU 间隔两次采样，取后一次的平滑使用率（异步等待，不阻塞 runtime）。
         let _ = collect_resource_snapshot();
-        std::thread::sleep(CPU_SAMPLE_INTERVAL);
+        tokio::time::sleep(CPU_SAMPLE_INTERVAL).await;
         let second = collect_resource_snapshot();
 
         let memory = MemoryInfo {
@@ -109,10 +109,10 @@ impl CoreSystemService {
     }
 
     /// 采集指定进程资源使用，返回应用层主错误。
-    fn process_usage_inner(pid: u32) -> Result<ProcessResourceUsage, SystemError> {
-        // CPU 间隔两次采样，取后一次的平滑使用率。
+    async fn process_usage_inner(pid: u32) -> Result<ProcessResourceUsage, SystemError> {
+        // CPU 间隔两次采样，取后一次的平滑使用率（异步等待，不阻塞 runtime）。
         let _ = collect_process_usage(pid);
-        std::thread::sleep(CPU_SAMPLE_INTERVAL);
+        tokio::time::sleep(CPU_SAMPLE_INTERVAL).await;
         let usage = collect_process_usage(pid);
 
         let Some(usage) = usage else {
@@ -137,7 +137,7 @@ impl CoreSystemService {
     }
 
     /// 计算目录磁盘占用，返回应用层主错误。
-    fn directory_usage_inner(path: &PathBuf) -> Result<DirectoryUsage, SystemError> {
+    async fn directory_usage_inner(path: &PathBuf) -> Result<DirectoryUsage, SystemError> {
         if !path.exists() {
             return Err(SystemError::PathNotFound);
         }
@@ -159,15 +159,15 @@ impl CoreSystemService {
 #[async_trait]
 impl SystemService for CoreSystemService {
     async fn system_snapshot(&self) -> Result<SystemSnapshot, SystemServiceError> {
-        Self::snapshot_inner().map_err(Into::into)
+        Self::snapshot_inner().await.map_err(Into::into)
     }
 
     async fn process_usage(&self, pid: u32) -> Result<ProcessResourceUsage, SystemServiceError> {
-        Self::process_usage_inner(pid).map_err(Into::into)
+        Self::process_usage_inner(pid).await.map_err(Into::into)
     }
 
     async fn directory_usage(&self, path: &PathBuf) -> Result<DirectoryUsage, SystemServiceError> {
-        Self::directory_usage_inner(path).map_err(Into::into)
+        Self::directory_usage_inner(path).await.map_err(Into::into)
     }
 }
 

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -32,13 +32,23 @@ pub struct CoreSystemService;
 
 impl CoreSystemService {
     /// 采集整机资源快照，返回应用层主错误。
+    ///
+    /// 同步的 sysinfo 采集经 `spawn_blocking` 调度到阻塞线程池，CPU 采样
+    /// 间隔等待留在异步侧，避免阻塞运行时的核心线程。
     async fn snapshot_inner() -> Result<SystemSnapshot, SystemError> {
-        let info = collect_system_info();
+        // 静态系统信息与首次 CPU 采样（同步采集，阻塞线程池执行）。
+        let info = tokio::task::spawn_blocking(collect_system_info)
+            .await
+            .map_err(SystemError::from)?;
+        let _ = tokio::task::spawn_blocking(collect_resource_snapshot)
+            .await
+            .map_err(SystemError::from)?;
 
         // CPU 间隔两次采样，取后一次的平滑使用率（异步等待，不阻塞 runtime）。
-        let _ = collect_resource_snapshot();
         tokio::time::sleep(CPU_SAMPLE_INTERVAL).await;
-        let second = collect_resource_snapshot();
+        let second = tokio::task::spawn_blocking(collect_resource_snapshot)
+            .await
+            .map_err(SystemError::from)?;
 
         let memory = MemoryInfo {
             total: second.total_memory_bytes,
@@ -55,18 +65,33 @@ impl CoreSystemService {
             usage: percent(second.used_swap_bytes, second.total_swap_bytes),
         };
 
-        let disks: Vec<DiskInfo> = collect_disks()
-            .into_iter()
-            .map(|disk| DiskInfo {
-                name: disk.name,
-                mount_point: disk.mount_point,
-                file_system: disk.file_system,
-                total: disk.total_bytes,
-                used: disk.used_bytes,
-                available: disk.available_bytes,
-                is_removable: disk.is_removable,
-            })
-            .collect();
+        let (disks, networks, cpu_brand) = tokio::task::spawn_blocking(|| {
+            let disks: Vec<DiskInfo> = collect_disks()
+                .into_iter()
+                .map(|disk| DiskInfo {
+                    name: disk.name,
+                    mount_point: disk.mount_point,
+                    file_system: disk.file_system,
+                    total: disk.total_bytes,
+                    used: disk.used_bytes,
+                    available: disk.available_bytes,
+                    is_removable: disk.is_removable,
+                })
+                .collect();
+            let networks: Vec<NetworkInfo> = collect_networks()
+                .into_iter()
+                .map(|network| NetworkInfo {
+                    interface: network.interface,
+                    received: network.received_bytes,
+                    transmitted: network.transmitted_bytes,
+                })
+                .collect();
+            let cpu_brand = cpu_brand_name();
+            (disks, networks, cpu_brand)
+        })
+        .await
+        .map_err(SystemError::from)?;
+
         let disk_total: u64 = disks.iter().map(|d| d.total).sum();
         let disk_used: u64 = disks.iter().map(|d| d.used).sum();
         let disk_available: u64 = disks.iter().map(|d| d.available).sum();
@@ -78,14 +103,9 @@ impl CoreSystemService {
             disks,
         };
 
-        let networks: Vec<NetworkInfo> = collect_networks()
-            .into_iter()
-            .map(|network| NetworkInfo {
-                interface: network.interface,
-                received: network.received_bytes,
-                transmitted: network.transmitted_bytes,
-            })
-            .collect();
+        let process_count = tokio::task::spawn_blocking(process_count)
+            .await
+            .map_err(SystemError::from)?;
 
         Ok(SystemSnapshot {
             os: info.operating_system,
@@ -95,7 +115,7 @@ impl CoreSystemService {
             kernel_version: info.kernel_version.unwrap_or_else(|| "Unknown".into()),
             host_name: info.host_name.unwrap_or_else(|| "Unknown".into()),
             cpu: CpuInfo {
-                name: cpu_brand_name(),
+                name: cpu_brand,
                 count: info.logical_cpu_count,
                 usage: second.cpu_usage.clamp(0.0, 100.0),
             },
@@ -104,16 +124,21 @@ impl CoreSystemService {
             disk,
             networks,
             uptime: info.uptime_seconds,
-            process_count: process_count(),
+            process_count,
         })
     }
 
     /// 采集指定进程资源使用，返回应用层主错误。
     async fn process_usage_inner(pid: u32) -> Result<ProcessResourceUsage, SystemError> {
-        // CPU 间隔两次采样，取后一次的平滑使用率（异步等待，不阻塞 runtime）。
-        let _ = collect_process_usage(pid);
+        // CPU 间隔两次采样，取后一次的平滑使用率。采集为同步 sysinfo 调用，
+        // 经 spawn_blocking 调度；间隔等待留在异步侧。
+        let _ = tokio::task::spawn_blocking(move || collect_process_usage(pid))
+            .await
+            .map_err(SystemError::from)?;
         tokio::time::sleep(CPU_SAMPLE_INTERVAL).await;
-        let usage = collect_process_usage(pid);
+        let usage = tokio::task::spawn_blocking(move || collect_process_usage(pid))
+            .await
+            .map_err(SystemError::from)?;
 
         let Some(usage) = usage else {
             return Ok(ProcessResourceUsage {
@@ -125,7 +150,9 @@ impl CoreSystemService {
             });
         };
 
-        let snapshot = collect_resource_snapshot();
+        let snapshot = tokio::task::spawn_blocking(collect_resource_snapshot)
+            .await
+            .map_err(SystemError::from)?;
         let memory_total = snapshot.total_memory_bytes;
         Ok(ProcessResourceUsage {
             pid: Some(usage.pid),
@@ -137,17 +164,26 @@ impl CoreSystemService {
     }
 
     /// 计算目录磁盘占用，返回应用层主错误。
+    ///
+    /// 目录遍历与容量查询是同步且可能耗时的操作，经 `spawn_blocking` 调度到
+    /// 阻塞线程池，避免阻塞异步运行时的核心线程。
     async fn directory_usage_inner(path: &Path) -> Result<DirectoryUsage, SystemError> {
-        if !path.exists() {
-            return Err(SystemError::PathNotFound);
-        }
+        let path_owned = path.to_path_buf();
+        let (path, used, total, available) =
+            tokio::task::spawn_blocking(move || -> Result<_, SystemError> {
+                if !path_owned.exists() {
+                    return Err(SystemError::PathNotFound);
+                }
 
-        let used = directory_size(path);
-        let (total, available) = path_disk_capacity(path);
+                let used = directory_size(&path_owned);
+                let (total, available) = path_disk_capacity(&path_owned);
+                Ok((path_owned, used, total, available))
+            })
+            .await??;
+
         let total_effective = if total > 0 { total } else { used.max(1) };
-
         Ok(DirectoryUsage {
-            path: path.to_path_buf(),
+            path,
             used,
             total: total_effective,
             available,

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -7,7 +7,7 @@
 //! 错误分层：内部以应用层主错误 [`SystemError`] 为源头，暴露
 //! [`SystemService`] 时统一转为接口契约错误 [`SystemServiceError`]。
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -137,7 +137,7 @@ impl CoreSystemService {
     }
 
     /// 计算目录磁盘占用，返回应用层主错误。
-    async fn directory_usage_inner(path: &PathBuf) -> Result<DirectoryUsage, SystemError> {
+    async fn directory_usage_inner(path: &Path) -> Result<DirectoryUsage, SystemError> {
         if !path.exists() {
             return Err(SystemError::PathNotFound);
         }
@@ -147,7 +147,7 @@ impl CoreSystemService {
         let total_effective = if total > 0 { total } else { used.max(1) };
 
         Ok(DirectoryUsage {
-            path: path.clone(),
+            path: path.to_path_buf(),
             used,
             total: total_effective,
             available,
@@ -166,7 +166,7 @@ impl SystemService for CoreSystemService {
         Self::process_usage_inner(pid).await.map_err(Into::into)
     }
 
-    async fn directory_usage(&self, path: &PathBuf) -> Result<DirectoryUsage, SystemServiceError> {
+    async fn directory_usage(&self, path: &Path) -> Result<DirectoryUsage, SystemServiceError> {
         Self::directory_usage_inner(path).await.map_err(Into::into)
     }
 }
@@ -220,7 +220,7 @@ mod tests {
     async fn missing_directory_reports_path_not_found() {
         let service = CoreSystemService;
         let result = service
-            .directory_usage(&PathBuf::from("/nonexistent/sl-path"))
+            .directory_usage(Path::new("/nonexistent/sl-path"))
             .await;
 
         assert_eq!(result, Err(SystemServiceError::PathNotFound));

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -1,0 +1,228 @@
+//! 系统资源信息服务实现。
+//!
+//! 实现 [`sealantern_interface::SystemService`] 能力端口，组合 `infra` 的
+//! 平台系统采集能力（CPU / 内存 / 磁盘 / 网络 / 进程 / 目录占用），
+//! 向宿主提供整机快照、进程资源与目录磁盘占用。
+//!
+//! 错误分层：内部以应用层主错误 [`SystemError`] 为源头，暴露
+//! [`SystemService`] 时统一转为接口契约错误 [`SystemServiceError`]。
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use sealantern_infra::platform::{
+    collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
+    collect_system_info, cpu_brand_name, directory_size, path_disk_capacity, process_count,
+};
+use sealantern_interface::system::{
+    CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
+    SystemSnapshot,
+};
+use sealantern_interface::{SystemService, SystemServiceError};
+
+use crate::error::SystemError;
+
+/// CPU 采样间隔：`sysinfo` 的 CPU 使用率是增量值，需间隔两次采样取后一次。
+const CPU_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
+
+/// 基于 `infra` 平台采集能力的系统资源信息服务实现。
+#[derive(Debug, Default)]
+pub struct CoreSystemService;
+
+impl CoreSystemService {
+    /// 采集整机资源快照，返回应用层主错误。
+    fn snapshot_inner() -> Result<SystemSnapshot, SystemError> {
+        let info = collect_system_info();
+
+        // CPU 间隔两次采样，取后一次的平滑使用率。
+        let _ = collect_resource_snapshot();
+        std::thread::sleep(CPU_SAMPLE_INTERVAL);
+        let second = collect_resource_snapshot();
+
+        let memory = MemoryInfo {
+            total: second.total_memory_bytes,
+            used: second.used_memory_bytes,
+            available: second.available_memory_bytes,
+            usage: percent(second.used_memory_bytes, second.total_memory_bytes),
+        };
+        let swap = MemoryInfo {
+            total: second.total_swap_bytes,
+            used: second.used_swap_bytes,
+            available: second
+                .total_swap_bytes
+                .saturating_sub(second.used_swap_bytes),
+            usage: percent(second.used_swap_bytes, second.total_swap_bytes),
+        };
+
+        let disks: Vec<DiskInfo> = collect_disks()
+            .into_iter()
+            .map(|disk| DiskInfo {
+                name: disk.name,
+                mount_point: disk.mount_point,
+                file_system: disk.file_system,
+                total: disk.total_bytes,
+                used: disk.used_bytes,
+                available: disk.available_bytes,
+                is_removable: disk.is_removable,
+            })
+            .collect();
+        let disk_total: u64 = disks.iter().map(|d| d.total).sum();
+        let disk_used: u64 = disks.iter().map(|d| d.used).sum();
+        let disk_available: u64 = disks.iter().map(|d| d.available).sum();
+        let disk = DiskSummary {
+            total: disk_total,
+            used: disk_used,
+            available: disk_available,
+            usage: percent(disk_used, disk_total),
+            disks,
+        };
+
+        let networks: Vec<NetworkInfo> = collect_networks()
+            .into_iter()
+            .map(|network| NetworkInfo {
+                interface: network.interface,
+                received: network.received_bytes,
+                transmitted: network.transmitted_bytes,
+            })
+            .collect();
+
+        Ok(SystemSnapshot {
+            os: info.operating_system,
+            arch: info.architecture,
+            os_name: info.name.unwrap_or_else(|| "Unknown".into()),
+            os_version: info.version.unwrap_or_else(|| "Unknown".into()),
+            kernel_version: info.kernel_version.unwrap_or_else(|| "Unknown".into()),
+            host_name: info.host_name.unwrap_or_else(|| "Unknown".into()),
+            cpu: CpuInfo {
+                name: cpu_brand_name(),
+                count: info.logical_cpu_count,
+                usage: second.cpu_usage.clamp(0.0, 100.0),
+            },
+            memory,
+            swap,
+            disk,
+            networks,
+            uptime: info.uptime_seconds,
+            process_count: process_count(),
+        })
+    }
+
+    /// 采集指定进程资源使用，返回应用层主错误。
+    fn process_usage_inner(pid: u32) -> Result<ProcessResourceUsage, SystemError> {
+        // CPU 间隔两次采样，取后一次的平滑使用率。
+        let _ = collect_process_usage(pid);
+        std::thread::sleep(CPU_SAMPLE_INTERVAL);
+        let usage = collect_process_usage(pid);
+
+        let Some(usage) = usage else {
+            return Ok(ProcessResourceUsage {
+                pid: None,
+                cpu_usage: 0.0,
+                memory_used: 0,
+                memory_total: 0,
+                memory_usage: 0.0,
+            });
+        };
+
+        let snapshot = collect_resource_snapshot();
+        let memory_total = snapshot.total_memory_bytes;
+        Ok(ProcessResourceUsage {
+            pid: Some(usage.pid),
+            cpu_usage: usage.cpu_usage.clamp(0.0, 100.0),
+            memory_used: usage.memory_bytes,
+            memory_total,
+            memory_usage: percent(usage.memory_bytes, memory_total),
+        })
+    }
+
+    /// 计算目录磁盘占用，返回应用层主错误。
+    fn directory_usage_inner(path: &PathBuf) -> Result<DirectoryUsage, SystemError> {
+        if !path.exists() {
+            return Err(SystemError::PathNotFound);
+        }
+
+        let used = directory_size(path);
+        let (total, available) = path_disk_capacity(path);
+        let total_effective = if total > 0 { total } else { used.max(1) };
+
+        Ok(DirectoryUsage {
+            path: path.clone(),
+            used,
+            total: total_effective,
+            available,
+            usage: percent(used, total_effective),
+        })
+    }
+}
+
+#[async_trait]
+impl SystemService for CoreSystemService {
+    async fn system_snapshot(&self) -> Result<SystemSnapshot, SystemServiceError> {
+        Self::snapshot_inner().map_err(Into::into)
+    }
+
+    async fn process_usage(&self, pid: u32) -> Result<ProcessResourceUsage, SystemServiceError> {
+        Self::process_usage_inner(pid).map_err(Into::into)
+    }
+
+    async fn directory_usage(&self, path: &PathBuf) -> Result<DirectoryUsage, SystemServiceError> {
+        Self::directory_usage_inner(path).map_err(Into::into)
+    }
+}
+
+/// 计算使用率（百分比，0.0 - 100.0）。
+fn percent(used: u64, total: u64) -> f32 {
+    if total > 0 {
+        (used as f64 / total as f64 * 100.0) as f32
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn snapshot_reports_realistic_values() {
+        let service = CoreSystemService;
+        let snapshot = service.system_snapshot().await.expect("snapshot");
+
+        assert!(!snapshot.os.is_empty());
+        assert!(snapshot.cpu.count > 0);
+        assert!(snapshot.cpu.usage >= 0.0 && snapshot.cpu.usage <= 100.0);
+        assert!(snapshot.memory.total > 0);
+        assert!(snapshot.memory.used <= snapshot.memory.total);
+    }
+
+    #[tokio::test]
+    async fn current_process_usage_is_reported() {
+        let service = CoreSystemService;
+        let usage = service
+            .process_usage(std::process::id())
+            .await
+            .expect("process usage");
+
+        assert!(usage.pid.is_some());
+        assert!(usage.cpu_usage >= 0.0 && usage.cpu_usage <= 100.0);
+    }
+
+    #[tokio::test]
+    async fn missing_process_returns_none_pid() {
+        let service = CoreSystemService;
+        let usage = service.process_usage(u32::MAX).await.expect("usage");
+
+        assert_eq!(usage.pid, None);
+    }
+
+    #[tokio::test]
+    async fn missing_directory_reports_path_not_found() {
+        let service = CoreSystemService;
+        let result = service
+            .directory_usage(&PathBuf::from("/nonexistent/sl-path"))
+            .await;
+
+        assert_eq!(result, Err(SystemServiceError::PathNotFound));
+    }
+}

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use crate::error::InstanceError;
-use crate::service::CoreInstanceService;
+use crate::service::{CoreInstanceService, CoreSystemService};
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
 #[derive(Clone)]
@@ -30,6 +30,8 @@ pub struct AppServices {
 pub struct AppServicesInner {
     /// 服务器实例管理服务。
     pub instance: Arc<CoreInstanceService>,
+    /// 系统资源信息服务。
+    pub system: Arc<CoreSystemService>,
 }
 
 /// 进程级全局容器。惰性初始化，可替换。
@@ -38,9 +40,14 @@ static SERVICES: tokio::sync::RwLock<Option<Arc<AppServicesInner>>> =
 
 impl AppServices {
     /// 从既有实例构造句柄（供测试/重载注入 `register`）。
+    ///
+    /// 系统资源服务为无状态实现，内部自动构造，无需外部传入。
     pub fn from_inner(instance: CoreInstanceService) -> Self {
         Self {
-            inner: Arc::new(AppServicesInner { instance: Arc::new(instance) }),
+            inner: Arc::new(AppServicesInner {
+                instance: Arc::new(instance),
+                system: Arc::new(CoreSystemService),
+            }),
         }
     }
 
@@ -94,5 +101,15 @@ impl AppServices {
     /// 便捷访问入口：一步拿到实例管理服务的共享句柄（惰性初始化 + 可替换）。
     pub async fn instance_service() -> Result<Arc<CoreInstanceService>, InstanceError> {
         Ok(Self::get().await?.instance().clone())
+    }
+
+    /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn system(&self) -> &Arc<CoreSystemService> {
+        &self.inner.system
+    }
+
+    /// 便捷访问入口：一步拿到系统资源信息服务的共享句柄（惰性初始化 + 可替换）。
+    pub async fn system_service() -> Result<Arc<CoreSystemService>, InstanceError> {
+        Ok(Self::get().await?.system().clone())
     }
 }

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -19,6 +19,6 @@ pub use error::PlatformError;
 pub use locations::{get_app_data_dir, get_or_create_app_data_dir};
 pub use system::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
-    collect_system_info, directory_size, path_disk_capacity, DiskUsage, NetworkUsage, ProcessUsage,
-    ResourceSnapshot, SystemInfo,
+    collect_system_info, cpu_brand_name, directory_size, path_disk_capacity, process_count,
+    DiskUsage, NetworkUsage, ProcessUsage, ResourceSnapshot, SystemInfo,
 };

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -17,4 +17,8 @@ pub use elevation::{is_elevated, request_elevation, ElevationLaunch};
 pub use environment::{Environment, EnvironmentError};
 pub use error::PlatformError;
 pub use locations::{get_app_data_dir, get_or_create_app_data_dir};
-pub use system::{collect_system_info, SystemInfo};
+pub use system::{
+    collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
+    collect_system_info, directory_size, path_disk_capacity, DiskUsage, NetworkUsage, ProcessUsage,
+    ResourceSnapshot, SystemInfo,
+};

--- a/crates/infra/src/platform/system.rs
+++ b/crates/infra/src/platform/system.rs
@@ -241,6 +241,24 @@ pub fn path_disk_capacity(path: &Path) -> (u64, u64) {
         .unwrap_or((0, 0))
 }
 
+/// 获取 CPU 型号名称（如 `Intel(R) Core(TM) i7-9700K`）。
+///
+/// 无法获取时返回 `"Unknown"`。
+pub fn cpu_brand_name() -> String {
+    let mut system = System::new();
+    system.refresh_cpu_all();
+    system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().to_string())
+        .unwrap_or_else(|| "Unknown".into())
+}
+
+/// 获取当前运行的进程数。
+pub fn process_count() -> usize {
+    System::new_all().processes().len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/infra/src/platform/system.rs
+++ b/crates/infra/src/platform/system.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 
@@ -220,13 +220,16 @@ pub fn directory_size(path: &Path) -> u64 {
 /// 路径不匹配任何已知挂载点时返回 `(0, 0)`。
 pub fn path_disk_capacity(path: &Path) -> (u64, u64) {
     let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    // Windows canonicalize 可能产生 \\?\C:\... verbatim 前缀，与 sysinfo 的
+    // 挂载点（C:\）无法 starts_with 匹配，这里统一归一化。
+    let match_path = normalize_for_mount_match(&canonical_path);
     let disks = Disks::new_with_refreshed_list();
 
     let mut best_match: Option<(usize, u64, u64)> = None;
 
     for disk in disks.iter() {
         let mount_point = disk.mount_point();
-        if canonical_path.starts_with(mount_point) {
+        if match_path.starts_with(mount_point) {
             let mount_len = mount_point.as_os_str().to_string_lossy().len();
             let candidate = (mount_len, disk.total_space(), disk.available_space());
             match best_match {
@@ -239,6 +242,20 @@ pub fn path_disk_capacity(path: &Path) -> (u64, u64) {
     best_match
         .map(|(_, total, available)| (total, available))
         .unwrap_or((0, 0))
+}
+
+/// 归一化路径以匹配挂载点前缀：Windows 上去掉 `\\?\` verbatim 前缀。
+fn normalize_for_mount_match(path: &Path) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        let as_str = path.to_string_lossy();
+        let stripped = as_str.strip_prefix(r"\\?\").unwrap_or(&as_str);
+        PathBuf::from(stripped)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        path.to_path_buf()
+    }
 }
 
 /// 获取 CPU 型号名称（如 `Intel(R) Core(TM) i7-9700K`）。
@@ -324,9 +341,19 @@ mod tests {
     }
 
     #[test]
-    fn missing_path_has_zero_size_and_capacity() {
+    fn missing_path_has_zero_size() {
         let missing = Path::new("/nonexistent/sl-path");
         assert_eq!(directory_size(missing), 0);
-        assert_eq!(path_disk_capacity(missing), (0, 0));
+    }
+
+    #[test]
+    fn existing_path_resolves_disk_capacity() {
+        // 路径不存在时 canonicalize 回退原始路径，可能解析到根挂载点（Linux）；
+        // 因此容量断言只针对真实存在的目录，保证跨平台稳定。
+        let existing = std::env::temp_dir();
+        let (total, available) = path_disk_capacity(&existing);
+
+        assert!(total > 0);
+        assert!(available <= total);
     }
 }

--- a/crates/infra/src/platform/system.rs
+++ b/crates/infra/src/platform/system.rs
@@ -1,7 +1,9 @@
-use sysinfo::System;
+use std::path::Path;
+
+use sysinfo::{Disks, Networks, Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 
 /// 当前机器的稳定系统信息快照。
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct SystemInfo {
     pub operating_system: &'static str,
     pub architecture: &'static str,
@@ -42,6 +44,203 @@ pub fn collect_system_info() -> SystemInfo {
     }
 }
 
+/// 单次采样的 CPU / 内存 / 交换用量快照。
+///
+/// `cpu_usage` 为采样时刻的瞬时值：`sysinfo` 的 CPU 使用率是「上次刷新到本次
+/// 刷新」之间的增量，因此需要调用方在两次采样后自行取差值（通常间隔数百毫秒）。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ResourceSnapshot {
+    /// CPU 使用率（0.0 - 100.0，瞬时采样值）。
+    pub cpu_usage: f32,
+    /// 物理内存总量（字节）。
+    pub total_memory_bytes: u64,
+    /// 已用物理内存（字节）。
+    pub used_memory_bytes: u64,
+    /// 可用物理内存（字节）。
+    pub available_memory_bytes: u64,
+    /// 交换分区总量（字节）。
+    pub total_swap_bytes: u64,
+    /// 已用交换分区（字节）。
+    pub used_swap_bytes: u64,
+}
+
+/// 采集一次 CPU / 内存 / 交换用量快照。
+///
+/// 调用方如需平滑的 CPU 使用率，应间隔一段时间连续调用两次并取后一次的
+/// `cpu_usage`（或自行做差值计算）。
+pub fn collect_resource_snapshot() -> ResourceSnapshot {
+    let mut system = System::new();
+    system.refresh_memory();
+    system.refresh_cpu_usage();
+
+    ResourceSnapshot {
+        cpu_usage: system.global_cpu_usage(),
+        total_memory_bytes: system.total_memory(),
+        used_memory_bytes: system.used_memory(),
+        available_memory_bytes: system.available_memory(),
+        total_swap_bytes: system.total_swap(),
+        used_swap_bytes: system.used_swap(),
+    }
+}
+
+/// 单个磁盘分区的用量信息。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DiskUsage {
+    /// 磁盘名称（如 `C:`、`/dev/sda1`）。
+    pub name: String,
+    /// 挂载点路径。
+    pub mount_point: std::path::PathBuf,
+    /// 文件系统类型（如 `NTFS`、`ext4`）。
+    pub file_system: String,
+    /// 总容量（字节）。
+    pub total_bytes: u64,
+    /// 已用容量（字节）。
+    pub used_bytes: u64,
+    /// 可用容量（字节）。
+    pub available_bytes: u64,
+    /// 是否为可移动磁盘。
+    pub is_removable: bool,
+}
+
+/// 采集全部磁盘分区的用量信息。
+pub fn collect_disks() -> Vec<DiskUsage> {
+    Disks::new_with_refreshed_list()
+        .iter()
+        .map(|disk| {
+            let total = disk.total_space();
+            let available = disk.available_space();
+            DiskUsage {
+                name: disk.name().to_string_lossy().into_owned(),
+                mount_point: disk.mount_point().to_path_buf(),
+                file_system: disk.file_system().to_string_lossy().into_owned(),
+                total_bytes: total,
+                used_bytes: total.saturating_sub(available),
+                available_bytes: available,
+                is_removable: disk.is_removable(),
+            }
+        })
+        .collect()
+}
+
+/// 单个网络接口的累计收发字节数。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct NetworkUsage {
+    /// 接口名（如 `eth0`、`Wi-Fi`）。
+    pub interface: String,
+    /// 累计接收字节数。
+    pub received_bytes: u64,
+    /// 累计发送字节数。
+    pub transmitted_bytes: u64,
+}
+
+/// 采集全部网络接口的累计收发字节数。
+///
+/// 返回值为接口上电以来的累计值；如需速率，调用方应间隔采样后做差值。
+pub fn collect_networks() -> Vec<NetworkUsage> {
+    Networks::new_with_refreshed_list()
+        .iter()
+        .map(|(interface, data)| NetworkUsage {
+            interface: interface.clone(),
+            received_bytes: data.total_received(),
+            transmitted_bytes: data.total_transmitted(),
+        })
+        .collect()
+}
+
+/// 单个进程的资源使用（瞬时采样值）。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProcessUsage {
+    /// 进程 ID。
+    pub pid: u32,
+    /// CPU 使用率（0.0 - 100.0，瞬时采样值，需二次采样取差值）。
+    pub cpu_usage: f32,
+    /// 进程占用的物理内存（字节）。
+    pub memory_bytes: u64,
+}
+
+/// 采集指定进程的瞬时资源使用。
+///
+/// `cpu_usage` 是「上次刷新到本次刷新」的增量值，单独一次采样意义有限；
+/// 调用方应间隔一段时间连续调用两次并取后一次结果（与
+/// [`collect_resource_snapshot`] 的 CPU 语义一致）。
+///
+/// 进程不存在或无权访问时返回 `None`。
+pub fn collect_process_usage(pid: u32) -> Option<ProcessUsage> {
+    let process_pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_memory();
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[process_pid]),
+        true,
+        ProcessRefreshKind::new().with_cpu().with_memory(),
+    );
+
+    system.process(process_pid).map(|process| ProcessUsage {
+        pid,
+        cpu_usage: process.cpu_usage(),
+        memory_bytes: process.memory(),
+    })
+}
+
+/// 计算目录（含子目录）占用的总字节数。
+///
+/// 递归遍历目录，累加所有常规文件的长度；符号链接与特殊文件按 0 计。
+/// 路径不存在或不可读时返回 0。目录较大时遍历可能较慢，调用方应自行缓存。
+pub fn directory_size(path: &Path) -> u64 {
+    fn walk(path: &Path) -> u64 {
+        let Ok(metadata) = std::fs::symlink_metadata(path) else {
+            return 0;
+        };
+
+        if metadata.is_file() {
+            return metadata.len();
+        }
+        if !metadata.is_dir() {
+            return 0;
+        }
+
+        let Ok(entries) = std::fs::read_dir(path) else {
+            return 0;
+        };
+
+        entries
+            .filter_map(Result::ok)
+            .map(|entry| walk(&entry.path()))
+            .sum()
+    }
+
+    if !path.exists() {
+        return 0;
+    }
+    walk(path)
+}
+
+/// 返回指定路径所在挂载点的磁盘容量 `(总量, 可用量)`。
+///
+/// 路径不匹配任何已知挂载点时返回 `(0, 0)`。
+pub fn path_disk_capacity(path: &Path) -> (u64, u64) {
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let disks = Disks::new_with_refreshed_list();
+
+    let mut best_match: Option<(usize, u64, u64)> = None;
+
+    for disk in disks.iter() {
+        let mount_point = disk.mount_point();
+        if canonical_path.starts_with(mount_point) {
+            let mount_len = mount_point.as_os_str().to_string_lossy().len();
+            let candidate = (mount_len, disk.total_space(), disk.available_space());
+            match best_match {
+                Some((best_len, _, _)) if best_len >= mount_len => {}
+                _ => best_match = Some(candidate),
+            }
+        }
+    }
+
+    best_match
+        .map(|(_, total, available)| (total, available))
+        .unwrap_or((0, 0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,5 +254,61 @@ mod tests {
         assert!(!info.family.is_empty());
         assert!(info.logical_cpu_count > 0);
         assert!(info.total_memory_bytes >= info.available_memory_bytes);
+    }
+
+    #[test]
+    fn resource_snapshot_reports_usable_memory_values() {
+        let snapshot = collect_resource_snapshot();
+
+        assert!(snapshot.cpu_usage >= 0.0 && snapshot.cpu_usage <= 100.0);
+        assert!(snapshot.total_memory_bytes > 0);
+        assert!(snapshot.used_memory_bytes <= snapshot.total_memory_bytes);
+        assert!(snapshot.available_memory_bytes <= snapshot.total_memory_bytes);
+        assert!(snapshot.used_swap_bytes <= snapshot.total_swap_bytes);
+    }
+
+    #[test]
+    fn disks_and_networks_are_serde_serializable() {
+        let disks = collect_disks();
+        let networks = collect_networks();
+
+        // 结构与 serde 序列化兼容性验证：能序列化即满足契约层要求。
+        for disk in &disks {
+            serde_json::to_string(disk).expect("disk must serialize");
+        }
+        for network in &networks {
+            serde_json::to_string(network).expect("network must serialize");
+        }
+    }
+
+    #[test]
+    fn current_process_usage_is_collectable() {
+        let pid = std::process::id();
+        let usage = collect_process_usage(pid);
+
+        assert!(usage.is_some());
+        let usage = usage.expect("current process must exist");
+        assert_eq!(usage.pid, pid);
+        assert!(usage.cpu_usage >= 0.0 && usage.cpu_usage <= 100.0);
+        assert!(usage.memory_bytes > 0);
+    }
+
+    #[test]
+    fn directory_size_counts_files_recursively() {
+        let dir = std::env::temp_dir().join(format!("sl-dirsize-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("sub")).expect("create temp dir");
+        std::fs::write(dir.join("a.txt"), vec![0u8; 10]).expect("write a");
+        std::fs::write(dir.join("sub/b.txt"), vec![0u8; 20]).expect("write b");
+
+        assert_eq!(directory_size(&dir), 30);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_path_has_zero_size_and_capacity() {
+        let missing = Path::new("/nonexistent/sl-path");
+        assert_eq!(directory_size(missing), 0);
+        assert_eq!(path_disk_capacity(missing), (0, 0));
     }
 }

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -39,3 +39,33 @@ impl std::fmt::Display for InstanceServiceError {
 }
 
 impl std::error::Error for InstanceServiceError {}
+
+/// 系统资源信息服务失败的契约错误类别。
+///
+/// 分类风格与 [`InstanceServiceError`] 一致：不携带主机路径、进程细节等敏感
+/// 信息，底层失败详情由应用层写入受控日志。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum SystemServiceError {
+    /// 指定的进程不存在或无权访问。
+    ProcessNotFound,
+    /// 指定的路径不存在或不可访问。
+    PathNotFound,
+    /// 底层系统采集 / IO 操作失败。
+    OperationFailed,
+    /// 该能力尚未实现（占位）。
+    Unsupported,
+}
+
+impl std::fmt::Display for SystemServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::ProcessNotFound => "process not found",
+            Self::PathNotFound => "path not found",
+            Self::OperationFailed => "system operation failed",
+            Self::Unsupported => "operation not supported",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for SystemServiceError {}

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -9,8 +9,14 @@
 pub mod error;
 /// 服务器实例相关模型与服务端口。
 pub mod instance;
+/// 系统资源信息相关模型与服务端口。
+pub mod system;
 
 /// 服务器实例管理错误枚举。
 pub use error::InstanceServiceError;
+/// 系统资源信息服务错误枚举。
+pub use error::SystemServiceError;
 /// 服务器实例管理服务端口。
 pub use instance::InstanceService;
+/// 系统资源信息服务端口。
+pub use system::SystemService;

--- a/crates/interface/src/system/mod.rs
+++ b/crates/interface/src/system/mod.rs
@@ -1,0 +1,13 @@
+//! 系统资源信息服务。
+//!
+//! 提供整机资源快照、进程资源占用与目录磁盘占用的宿主能力端口，
+//! 供 tauri / server 等宿主统一消费，不依赖任何具体系统采集实现。
+
+mod models;
+mod service;
+
+pub use models::{
+    CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
+    SystemSnapshot,
+};
+pub use service::SystemService;

--- a/crates/interface/src/system/models.rs
+++ b/crates/interface/src/system/models.rs
@@ -1,0 +1,138 @@
+//! 系统资源信息契约模型。
+//!
+//! 定义宿主消费的系统资源快照、进程资源与目录磁盘占用等模型，
+//! 全部可序列化，供跨传输面传递。
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// CPU 资源信息。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CpuInfo {
+    /// CPU 型号名称。
+    pub name: String,
+    /// 逻辑核心数。
+    pub count: usize,
+    /// CPU 使用率（0.0 - 100.0，调用方间隔采样后的值）。
+    pub usage: f32,
+}
+
+/// 内存资源信息。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MemoryInfo {
+    /// 总量（字节）。
+    pub total: u64,
+    /// 已用（字节）。
+    pub used: u64,
+    /// 可用（字节）。
+    pub available: u64,
+    /// 使用率（0.0 - 100.0）。
+    pub usage: f32,
+}
+
+/// 单个磁盘分区信息。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DiskInfo {
+    /// 磁盘名称。
+    pub name: String,
+    /// 挂载点。
+    pub mount_point: PathBuf,
+    /// 文件系统类型。
+    pub file_system: String,
+    /// 总容量（字节）。
+    pub total: u64,
+    /// 已用（字节）。
+    pub used: u64,
+    /// 可用（字节）。
+    pub available: u64,
+    /// 是否为可移动磁盘。
+    pub is_removable: bool,
+}
+
+/// 单个网络接口信息。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct NetworkInfo {
+    /// 接口名。
+    pub interface: String,
+    /// 累计接收字节。
+    pub received: u64,
+    /// 累计发送字节。
+    pub transmitted: u64,
+}
+
+/// 磁盘汇总信息。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DiskSummary {
+    /// 全部分区总容量（字节）。
+    pub total: u64,
+    /// 全部分区已用（字节）。
+    pub used: u64,
+    /// 全部分区可用（字节）。
+    pub available: u64,
+    /// 整体使用率（0.0 - 100.0）。
+    pub usage: f32,
+    /// 分区明细。
+    pub disks: Vec<DiskInfo>,
+}
+
+/// 整机系统资源快照（宿主消费的契约模型）。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SystemSnapshot {
+    /// 操作系统（`std::env::consts::OS`，如 `windows` / `linux` / `macos`）。
+    pub os: &'static str,
+    /// 架构（`std::env::consts::ARCH`，如 `x86_64`）。
+    pub arch: &'static str,
+    /// 操作系统名称（如 `Windows 11`）。
+    pub os_name: String,
+    /// 系统版本。
+    pub os_version: String,
+    /// 内核版本。
+    pub kernel_version: String,
+    /// 主机名。
+    pub host_name: String,
+    /// CPU 资源。
+    pub cpu: CpuInfo,
+    /// 内存资源。
+    pub memory: MemoryInfo,
+    /// 交换分区。
+    pub swap: MemoryInfo,
+    /// 磁盘汇总（总量/已用/可用为全部分区求和）。
+    pub disk: DiskSummary,
+    /// 网络接口列表。
+    pub networks: Vec<NetworkInfo>,
+    /// 系统运行时长（秒）。
+    pub uptime: u64,
+    /// 当前进程数。
+    pub process_count: usize,
+}
+
+/// 单进程资源使用（宿主消费的契约模型）。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProcessResourceUsage {
+    /// 进程 ID；进程不存在时为 `None`。
+    pub pid: Option<u32>,
+    /// CPU 使用率（0.0 - 100.0，调用方间隔采样后的值）。
+    pub cpu_usage: f32,
+    /// 进程占用内存（字节）。
+    pub memory_used: u64,
+    /// 系统内存总量（字节），用于计算使用率。
+    pub memory_total: u64,
+    /// 内存使用率（0.0 - 100.0）。
+    pub memory_usage: f32,
+}
+
+/// 目录磁盘占用（宿主消费的契约模型）。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DirectoryUsage {
+    /// 目录路径。
+    pub path: PathBuf,
+    /// 目录占用字节数。
+    pub used: u64,
+    /// 所在挂载点总容量（字节）。
+    pub total: u64,
+    /// 所在挂载点可用容量（字节）。
+    pub available: u64,
+    /// 使用率（0.0 - 100.0）。
+    pub usage: f32,
+}

--- a/crates/interface/src/system/service.rs
+++ b/crates/interface/src/system/service.rs
@@ -1,0 +1,29 @@
+//! 系统资源信息服务端口。
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+
+use crate::error::SystemServiceError;
+
+use super::models::{DirectoryUsage, ProcessResourceUsage, SystemSnapshot};
+
+/// 系统资源信息宿主能力端口。
+///
+/// 方法均为异步：目录遍历等可能涉及阻塞 IO。实现方组合 `infra` 的系统采集
+/// 能力，不依赖任何具体宿主。
+#[async_trait]
+pub trait SystemService: Send + Sync {
+    /// 采集整机资源快照。
+    ///
+    /// CPU 使用率为采样时刻瞬时值，调用方如需平滑值应自行间隔采样。
+    async fn system_snapshot(&self) -> Result<SystemSnapshot, SystemServiceError>;
+
+    /// 采集指定进程的资源使用。
+    ///
+    /// 进程不存在或无权访问时返回 `pid = None` 的空结果。
+    async fn process_usage(&self, pid: u32) -> Result<ProcessResourceUsage, SystemServiceError>;
+
+    /// 计算目录磁盘占用。
+    async fn directory_usage(&self, path: &PathBuf) -> Result<DirectoryUsage, SystemServiceError>;
+}

--- a/crates/interface/src/system/service.rs
+++ b/crates/interface/src/system/service.rs
@@ -1,6 +1,6 @@
 //! 系统资源信息服务端口。
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use async_trait::async_trait;
 
@@ -25,5 +25,5 @@ pub trait SystemService: Send + Sync {
     async fn process_usage(&self, pid: u32) -> Result<ProcessResourceUsage, SystemServiceError>;
 
     /// 计算目录磁盘占用。
-    async fn directory_usage(&self, path: &PathBuf) -> Result<DirectoryUsage, SystemServiceError>;
+    async fn directory_usage(&self, path: &Path) -> Result<DirectoryUsage, SystemServiceError>;
 }

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -9,7 +9,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::Serialize;
 
-use sealantern_interface::InstanceServiceError;
+use sealantern_interface::{InstanceServiceError, SystemServiceError};
 
 /// 展平的 HTTP 错误响应体。
 #[derive(Debug, Serialize)]
@@ -68,6 +68,27 @@ impl HttpError {
         }
     }
 
+    /// 由系统资源信息服务契约错误构建 HTTP 错误。
+    pub fn from_system_error(error: SystemServiceError) -> Self {
+        match error {
+            SystemServiceError::ProcessNotFound | SystemServiceError::PathNotFound => Self {
+                status: StatusCode::NOT_FOUND,
+                code: "system_resource_not_found",
+                message: error.to_string(),
+            },
+            SystemServiceError::OperationFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "system_operation_failed",
+                message: error.to_string(),
+            },
+            SystemServiceError::Unsupported => Self {
+                status: StatusCode::NOT_IMPLEMENTED,
+                code: "operation_unsupported",
+                message: error.to_string(),
+            },
+        }
+    }
+
     /// 构建一个客户端输入错误（400），带具体错误码。
     pub fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
         Self {
@@ -90,6 +111,12 @@ impl HttpError {
 impl From<InstanceServiceError> for HttpError {
     fn from(error: InstanceServiceError) -> Self {
         Self::from_instance_error(error)
+    }
+}
+
+impl From<SystemServiceError> for HttpError {
+    fn from(error: SystemServiceError) -> Self {
+        Self::from_system_error(error)
     }
 }
 

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -3,8 +3,10 @@
 //! handler 只做传输层薄转发：解析请求 → 调用应用层服务 → 收敛错误。
 
 pub mod instance;
+pub mod system;
 
 pub use instance::{
     create_instance, delete_instance, get_instance, list_instances, rename_instance,
     update_instance_path,
 };
+pub use system::{directory_usage, process_usage, system_snapshot};

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -38,9 +38,10 @@ pub async fn process_usage(
         .map_err(HttpError::from)
 }
 
-/// `GET /api/system/directory/{path}` — 计算指定目录的磁盘占用。
+/// `GET /api/system/directory/*path` — 计算指定目录的磁盘占用。
 ///
-/// 路径经 URL 编码传入（如 `/api/system/directory/C%3A%5Cservers%5Cserver-a`）。
+/// 路径使用通配符捕获，支持任意多段路径
+/// （如 `/api/system/directory/var/log`、`/api/system/directory/C:%5Cservers%5Cserver-a`）。
 pub async fn directory_usage(
     State(state): State<AppState>,
     Path(path): Path<String>,

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -45,10 +45,10 @@ pub async fn directory_usage(
     State(state): State<AppState>,
     Path(path): Path<String>,
 ) -> Result<Json<DirectoryUsage>, HttpError> {
-    let path = std::path::PathBuf::from(path);
+    let path = std::path::Path::new(&path);
     state
         .system()
-        .directory_usage(&path)
+        .directory_usage(path)
         .await
         .map(Json)
         .map_err(HttpError::from)

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -1,0 +1,55 @@
+//! 系统资源信息 REST handler。
+//!
+//! 提供系统资源快照、进程资源与目录磁盘占用接口，薄转发到
+//! [`CoreSystemService`](sealantern_application::service::CoreSystemService)
+//! 并收敛错误为 [`HttpError`](super::super::error::HttpError)。
+
+use axum::extract::{Path, State};
+use axum::Json;
+
+use sealantern_interface::system::{DirectoryUsage, ProcessResourceUsage, SystemSnapshot};
+use sealantern_interface::SystemService;
+
+use super::super::error::HttpError;
+use super::super::state::AppState;
+
+/// `GET /api/system` — 采集整机系统资源快照。
+pub async fn system_snapshot(
+    State(state): State<AppState>,
+) -> Result<Json<SystemSnapshot>, HttpError> {
+    state
+        .system()
+        .system_snapshot()
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `GET /api/system/process/{pid}` — 采集指定进程的资源使用。
+pub async fn process_usage(
+    State(state): State<AppState>,
+    Path(pid): Path<u32>,
+) -> Result<Json<ProcessResourceUsage>, HttpError> {
+    state
+        .system()
+        .process_usage(pid)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `GET /api/system/directory/{path}` — 计算指定目录的磁盘占用。
+///
+/// 路径经 URL 编码传入（如 `/api/system/directory/C%3A%5Cservers%5Cserver-a`）。
+pub async fn directory_usage(
+    State(state): State<AppState>,
+    Path(path): Path<String>,
+) -> Result<Json<DirectoryUsage>, HttpError> {
+    let path = std::path::PathBuf::from(path);
+    state
+        .system()
+        .directory_usage(&path)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -42,7 +42,7 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
     let system_routes = Router::new()
         .route("/system", get(handlers::system_snapshot))
         .route("/system/process/{pid}", get(handlers::process_usage))
-        .route("/system/directory/{path}", get(handlers::directory_usage));
+        .route("/system/directory/{*path}", get(handlers::directory_usage));
 
     Router::new()
         .nest(API_PREFIX, instance_routes)

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -39,8 +39,14 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
         //       .route("/instances/{id}/logs", get(handlers::instance_logs))
         .route("/instances/{id}/path", put(handlers::update_instance_path));
 
+    let system_routes = Router::new()
+        .route("/system", get(handlers::system_snapshot))
+        .route("/system/process/{pid}", get(handlers::process_usage))
+        .route("/system/directory/{path}", get(handlers::directory_usage));
+
     Router::new()
         .nest(API_PREFIX, instance_routes)
+        .nest(API_PREFIX, system_routes)
         .merge(spa_router(config))
         .with_state(state)
 }

--- a/server/src/adapter/http/state.rs
+++ b/server/src/adapter/http/state.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use sealantern_application::service::CoreInstanceService;
+use sealantern_application::service::{CoreInstanceService, CoreSystemService};
 use sealantern_application::services::AppServices;
 
 /// HTTP 层的共享应用状态。
@@ -29,5 +29,10 @@ impl AppState {
     /// 访问实例管理服务（`Arc` 共享句柄，clone 廉价）。
     pub fn instance(&self) -> Arc<CoreInstanceService> {
         self.services.instance().clone()
+    }
+
+    /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn system(&self) -> Arc<CoreSystemService> {
+        self.services.system().clone()
     }
 }

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod instance;
+pub mod system;

--- a/src-tauri/src/adapter/tauri/commands/system.rs
+++ b/src-tauri/src/adapter/tauri/commands/system.rs
@@ -1,0 +1,47 @@
+//! 系统资源信息 Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`CoreSystemService`](sealantern_application::service::CoreSystemService)
+//! 采集系统资源快照、进程占用与目录磁盘占用。
+//!
+//! 错误统一为接口契约错误 [`SystemServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use sealantern_application::service::CoreSystemService;
+use sealantern_application::services::AppServices;
+use sealantern_interface::system::{DirectoryUsage, ProcessResourceUsage, SystemSnapshot};
+use sealantern_interface::{SystemService, SystemServiceError};
+
+/// 获取全局系统资源信息服务句柄（惰性初始化容器）。
+async fn system_service() -> Result<Arc<CoreSystemService>, SystemServiceError> {
+    let services = AppServices::get()
+        .await
+        .map_err(|_| SystemServiceError::OperationFailed)?;
+    Ok(services.system().clone())
+}
+
+/// 采集整机系统资源快照。
+#[tauri::command]
+pub async fn get_system_snapshot() -> Result<SystemSnapshot, SystemServiceError> {
+    let service = system_service().await?;
+    service.system_snapshot().await
+}
+
+/// 采集指定进程的资源使用。
+///
+/// 进程不存在或无权访问时返回 `pid = null` 的空结果。
+#[tauri::command]
+pub async fn get_process_usage(pid: u32) -> Result<ProcessResourceUsage, SystemServiceError> {
+    let service = system_service().await?;
+    service.process_usage(pid).await
+}
+
+/// 计算指定目录的磁盘占用。
+#[tauri::command]
+pub async fn get_directory_usage(path: String) -> Result<DirectoryUsage, SystemServiceError> {
+    let service = system_service().await?;
+    service.directory_usage(&PathBuf::from(path)).await
+}

--- a/src-tauri/src/adapter/tauri/commands/system.rs
+++ b/src-tauri/src/adapter/tauri/commands/system.rs
@@ -7,7 +7,7 @@
 //! 错误统一为接口契约错误 [`SystemServiceError`]，可序列化回前端，
 //! 不携带底层敏感细节。
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use sealantern_application::service::CoreSystemService;
@@ -43,5 +43,5 @@ pub async fn get_process_usage(pid: u32) -> Result<ProcessResourceUsage, SystemS
 #[tauri::command]
 pub async fn get_directory_usage(path: String) -> Result<DirectoryUsage, SystemServiceError> {
     let service = system_service().await?;
-    service.directory_usage(&PathBuf::from(path)).await
+    service.directory_usage(Path::new(&path)).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,9 @@ use adapter::tauri::commands::instance::{
     create_instance, delete_instance, force_stop_instance, get_instance, instance_status,
     list_instances, rename_instance, start_instance, stop_instance, update_instance_path,
 };
+use adapter::tauri::commands::system::{
+    get_directory_usage, get_process_usage, get_system_snapshot,
+};
 use desktop::{
     desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
     desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
@@ -41,6 +44,10 @@ pub fn run() {
             start_instance,
             stop_instance,
             update_instance_path,
+            //系统资源能力（由adapter/tauri/commands接入application）
+            get_directory_usage,
+            get_process_usage,
+            get_system_snapshot,
             //桌面端能力（由desktop/dialog提供）
             desktop_pick_archive_file,
             desktop_pick_folder,


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要
懒得写

## Summary by Sourcery

添加新的系统资源信息服务，用于提供机器快照、进程和目录使用情况，并通过 HTTP 和 Tauri 对外暴露，该服务由基础设施层级的系统指标采集能力提供支持。

New Features:
- 引入基础设施层级的工具，用于收集 CPU、内存、交换分区、磁盘、网络、进程和目录使用数据，并将其暴露为可序列化的模型。
- 定义接口层级的系统资源模型，以及异步的 `SystemService` trait，用于描述系统快照、进程使用情况和目录使用情况。
- 在应用层实现 `CoreSystemService`，将基础设施指标聚合为契约模型，并处理领域特定的系统错误。
- 通过新的 HTTP API 路由和 Tauri 命令，暴露系统资源信息，包括快照、进程使用情况和目录磁盘使用情况。
- 将新的系统服务集成到全局应用服务容器以及 HTTP/Tauri 应用状态中，以便共享访问。

Enhancements:
- 通过新增 `SystemServiceError` 枚举扩展错误处理，并将其与现有实例错误一起映射到 HTTP 错误响应。
- 为基础设施系统信息增加额外的辅助方法，例如 CPU 品牌名称查询、进程计数、目录大小统计和磁盘容量查询，并新增测试以验证序列化结果和指标合理性。
- 在应用 crate 中启用 Tokio 时间工具，以支持系统服务实现中的基于时间间隔的 CPU 采样。

Tests:
- 增加基础设施层和应用层测试，用于验证资源快照、进程使用采集、目录大小统计、缺失路径处理以及系统快照值的现实合理性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new system resource information service providing machine snapshots, process and directory usage, and expose it via HTTP and Tauri, backed by infra-level system metrics collection.

New Features:
- Introduce infra-level utilities to collect CPU, memory, swap, disk, network, process, and directory usage data and expose them as serializable models.
- Define interface-level system resource models and an asynchronous SystemService trait to describe system snapshots, process usage, and directory usage.
- Implement CoreSystemService in the application layer to aggregate infra metrics into contract models and handle domain-specific system errors.
- Expose system resource information via new HTTP API routes and Tauri commands for snapshots, process usage, and directory disk usage.
- Integrate the new system service into the global application service container and HTTP/Tauri application state for shared access.

Enhancements:
- Extend error handling with a SystemServiceError enum and map it to HTTP error responses alongside existing instance errors.
- Augment infra system info with additional helpers such as CPU brand name lookup, process counting, directory sizing, and disk capacity lookup, plus tests to validate serialization and metric sanity.
- Enable Tokio time utilities in the application crate to support interval-based CPU sampling in the system service implementation.

Tests:
- Add infra- and application-level tests to validate resource snapshots, process usage collection, directory sizing, missing path handling, and realistic system snapshot values.

</details>