### PR TITLE
 refactor(server): 拆分实例记录管理与服务器进程管理服务

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5223,6 +5223,7 @@ dependencies = [
  "sealantern-infra",
  "sealantern-interface",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 async-trait = "0.1.91"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "sync", "fs", "time"] }
+tracing = "0.1"
 sealantern-core = { path = "../crates/core" }
 sealantern-interface = { path = "../crates/interface" }
 sealantern-extra = { path = "../crates/extra" }

--- a/application/src/error/server.rs
+++ b/application/src/error/server.rs
@@ -1,12 +1,31 @@
-//! 服务器管理领域的主错误。
-//!
-//! 当前占位：待服务器控制台/生命周期服务接入后补充领域错误与契约转换。
+//! 服务器进程管理领域的主错误。
 
 use std::fmt;
 
-/// 服务器管理操作失败的应用层主错误（占位）。
+use sealantern_interface::error::ServerServiceError;
+
+/// 服务器进程管理操作失败的应用层主错误。
+///
+/// 携带底层失败细节（source），供应用层日志排查；向 [`ServerServiceError`]
+/// 转换时收敛为分类，不向宿主泄漏敏感信息。
 #[derive(Debug)]
 pub enum ServerError {
+    /// 指定的实例不存在。
+    InstanceNotFound,
+    /// 服务器进程当前状态不允许该操作。
+    InvalidState,
+    /// 客户端提供的输入不合法。
+    InvalidInput,
+    /// 底层进程 / IO 操作失败。
+    OperationFailed {
+        /// 底层来源错误。
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// 内部异步任务失败（如阻塞任务被取消或 panic）。
+    Internal {
+        /// 底层来源错误。
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
     /// 该能力尚未实现（占位）。
     Unsupported,
 }
@@ -14,9 +33,55 @@ pub enum ServerError {
 impl fmt::Display for ServerError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InstanceNotFound => write!(formatter, "server instance not found"),
+            Self::InvalidState => {
+                write!(formatter, "server is in an invalid state for this operation")
+            }
+            Self::InvalidInput => write!(formatter, "invalid input"),
+            Self::OperationFailed { source } => {
+                write!(formatter, "server operation failed: {source}")
+            }
+            Self::Internal { source } => write!(formatter, "internal server task failed: {source}"),
             Self::Unsupported => write!(formatter, "operation not supported"),
         }
     }
 }
 
-impl std::error::Error for ServerError {}
+impl std::error::Error for ServerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::OperationFailed { source } => Some(source.as_ref()),
+            Self::Internal { source } => Some(source.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ServerError {
+    fn from(source: std::io::Error) -> Self {
+        Self::OperationFailed { source: Box::new(source) }
+    }
+}
+
+impl From<tokio::task::JoinError> for ServerError {
+    fn from(source: tokio::task::JoinError) -> Self {
+        Self::Internal { source: Box::new(source) }
+    }
+}
+
+/// 应用层主错误 → 接口契约错误的收敛转换。
+///
+/// 细节被抹平为分类，敏感字段不跨传输面。
+impl From<ServerError> for ServerServiceError {
+    fn from(error: ServerError) -> Self {
+        match error {
+            ServerError::InstanceNotFound => Self::InstanceNotFound,
+            ServerError::InvalidState => Self::InvalidState,
+            ServerError::InvalidInput => Self::InvalidInput,
+            ServerError::OperationFailed { .. } | ServerError::Internal { .. } => {
+                Self::OperationFailed
+            }
+            ServerError::Unsupported => Self::Unsupported,
+        }
+    }
+}

--- a/application/src/service/instance.rs
+++ b/application/src/service/instance.rs
@@ -1,9 +1,9 @@
-//! 服务器实例管理服务实现。
+//! 服务器实例记录管理服务实现。
 //!
 //! 实现 [`sealantern_interface::InstanceService`] 能力端口，用 `extra` 的
 //! [`InstanceRegistry`](sealantern_extra::config::InstanceRegistry)（持久化到
-//! `sea_lantern_servers.json`）驱动查询与 CRUD。进程管理（Daemon）接入后补全
-//! 生命周期（当前返回 [`InstanceError::Unsupported`]）。
+//! `sea_lantern_servers.json`）驱动实例记录的查询与 CRUD。服务器进程生命周期
+//! 由 [`sealantern_interface::ServerService`] 负责（见 `service/server.rs`）。
 //!
 //! 错误分层：内部以应用层主错误 [`InstanceError`] 为源头，沿
 //! `core/extra/infra` → `application::error::instance` → `interface::error`
@@ -13,7 +13,6 @@ use async_trait::async_trait;
 use std::path::PathBuf;
 
 use sealantern_core::instance::{Instance, InstanceId, InstanceSpec};
-use sealantern_core::server::ServerStatus;
 use sealantern_extra::config::InstanceRegistry;
 use sealantern_infra::platform::get_app_data_dir;
 use sealantern_interface::{InstanceService, InstanceServiceError};
@@ -43,6 +42,22 @@ impl CoreInstanceService {
         Ok(Self {
             registry: tokio::sync::Mutex::new(registry),
         })
+    }
+
+    /// 更新实例的最后启动时间（服务器进程成功拉起后调用）。
+    pub async fn update_last_started(&self, id: &InstanceId) -> Result<(), InstanceError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let mut registry = self.registry.lock().await;
+        let edited = registry
+            .edit_instance(id, |instance| instance.last_started_at_unix_secs = Some(now))
+            .await?;
+        if !edited {
+            return Err(InstanceError::NotFound);
+        }
+        Ok(())
     }
 
     /// 内部创建实例：core 校验规范化后持久化登记，返回应用层主错误。
@@ -100,22 +115,6 @@ impl InstanceService for CoreInstanceService {
     async fn find(&self, id: &InstanceId) -> Result<Option<Instance>, InstanceServiceError> {
         let registry = self.registry.lock().await;
         Ok(registry.get(id).cloned())
-    }
-
-    async fn status(&self, _id: &InstanceId) -> Result<ServerStatus, InstanceServiceError> {
-        Err(InstanceError::Unsupported.into())
-    }
-
-    async fn start(&self, _id: &InstanceId) -> Result<(), InstanceServiceError> {
-        Err(InstanceError::Unsupported.into())
-    }
-
-    async fn stop(&self, _id: &InstanceId) -> Result<(), InstanceServiceError> {
-        Err(InstanceError::Unsupported.into())
-    }
-
-    async fn force_stop(&self, _id: &InstanceId) -> Result<(), InstanceServiceError> {
-        Err(InstanceError::Unsupported.into())
     }
 
     async fn create(&self, spec: InstanceSpec) -> Result<Instance, InstanceServiceError> {

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -1,10 +1,13 @@
 //! 应用层服务实现模块。
 //!
-//! 存放各类宿主能力的默认实现（如 [`CoreInstanceService`]、[`CoreSystemService`]），
-//! 实现 `interface` 的能力端口，由 `services` 装配层组装进全局容器。
+//! 存放各类宿主能力的默认实现（如 [`CoreInstanceService`]、[`CoreSystemService`]、
+//! [`CoreServerService`]），实现 `interface` 的能力端口，由 `services` 装配层
+//! 组装进全局容器。
 
 mod instance;
+mod server;
 mod system;
 
 pub use instance::CoreInstanceService;
+pub use server::CoreServerService;
 pub use system::CoreSystemService;

--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -1,0 +1,378 @@
+//! 服务器进程管理服务实现。
+//!
+//! 实现 [`sealantern_interface::ServerService`] 能力端口，管理实例对应的
+//! 服务器进程生命周期（启动/停止/强制停止/状态/控制台命令）。
+//!
+//! 进程管理基于 `core` 的 `process` 原语（[`Daemon`]、[`Terminal`]、
+//! [`build_command`]）；启动配置来自实例记录（[`CoreInstanceService`]）。
+//!
+//! 错误分层：内部以应用层主错误 [`ServerError`] 为源头，暴露
+//! [`ServerService`] 时统一转为接口契约错误 [`ServerServiceError`]。
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use sealantern_core::instance::{Instance, InstanceId, StartupMode};
+use sealantern_core::process::{
+    build_command, CommandBuildMode, CommandBuildRequest, Daemon, Terminal, TerminalOutput,
+    TerminalStream,
+};
+use sealantern_interface::server::{ServerSnapshot, ServerState};
+use sealantern_interface::{InstanceService, ServerService, ServerServiceError};
+
+use crate::error::ServerError;
+
+use super::CoreInstanceService;
+
+/// 优雅停止时等待进程退出的最长时长。
+const STOP_GRACEFUL_TIMEOUT: Duration = Duration::from_secs(10);
+/// 状态轮询间隔。
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// 一个受管服务器进程：守护进程 + 已转移的标准流终端。
+struct ManagedProcess {
+    daemon: Daemon,
+    terminal: Terminal,
+}
+
+/// 基于 `core` 进程原语的服务器进程管理服务实现。
+pub struct CoreServerService {
+    /// 实例记录服务（读取启动配置与更新状态）。
+    instance_service: Arc<CoreInstanceService>,
+    /// 进程注册表：实例 ID → 受管进程。
+    processes: Mutex<HashMap<String, ManagedProcess>>,
+    /// 启动中的实例集合。
+    starting: Mutex<HashSet<String>>,
+    /// 停止中的实例集合。
+    stopping: Mutex<HashSet<String>>,
+}
+
+impl CoreServerService {
+    /// 构造服务器进程管理服务。
+    pub fn new(instance_service: Arc<CoreInstanceService>) -> Self {
+        Self {
+            instance_service,
+            processes: Mutex::new(HashMap::new()),
+            starting: Mutex::new(HashSet::new()),
+            stopping: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// 按实例 ID 查找实例记录。
+    async fn find_instance(&self, id: &InstanceId) -> Result<Instance, ServerError> {
+        self.instance_service
+            .find(id)
+            .await
+            .map_err(|_| ServerError::OperationFailed {
+                source: Box::new(std::io::Error::other("instance lookup failed")),
+            })?
+            .ok_or(ServerError::InstanceNotFound)
+    }
+
+    /// 由实例启动配置构建进程命令。
+    fn build_process_command(
+        &self,
+        instance: &Instance,
+    ) -> Result<std::process::Command, ServerError> {
+        let launch = &instance.launch;
+        let mode = match launch.startup_mode {
+            StartupMode::Jar | StartupMode::Starter => CommandBuildMode::DirectJar,
+            StartupMode::Batch => CommandBuildMode::Batch,
+            StartupMode::Shell => CommandBuildMode::Shell,
+            StartupMode::PowerShell => CommandBuildMode::PowerShell,
+            StartupMode::Custom => CommandBuildMode::Custom,
+        };
+
+        let request = CommandBuildRequest {
+            mode,
+            working_directory: Path::new(&instance.directory),
+            java_executable: launch.java_executable.as_deref(),
+            java_environment: None,
+            jvm_arguments: &[],
+            entry_path: launch.startup_target.as_deref(),
+            custom_command: launch.custom_command.as_deref(),
+            custom_executable: launch.custom_executable.as_deref(),
+            custom_arguments: &[],
+            installer_url: None,
+            windows_console_encoding: sealantern_core::process::WindowsConsoleEncoding::Utf8,
+        };
+
+        build_command(&request).map_err(|e| ServerError::OperationFailed { source: Box::new(e) })
+    }
+
+    fn processes_lock(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<String, ManagedProcess>>, ServerError> {
+        self.processes.lock().map_err(|_| ServerError::Internal {
+            source: Box::new(std::io::Error::other("processes lock poisoned")),
+        })
+    }
+
+    fn is_starting(&self, id: &str) -> bool {
+        self.starting
+            .lock()
+            .map(|s| s.contains(id))
+            .unwrap_or(false)
+    }
+
+    fn is_stopping(&self, id: &str) -> bool {
+        self.stopping
+            .lock()
+            .map(|s| s.contains(id))
+            .unwrap_or(false)
+    }
+
+    fn mark_starting(&self, id: &str) {
+        if let Ok(mut s) = self.starting.lock() {
+            s.insert(id.to_string());
+        }
+    }
+
+    fn clear_starting(&self, id: &str) {
+        if let Ok(mut s) = self.starting.lock() {
+            s.remove(id);
+        }
+    }
+
+    fn mark_stopping(&self, id: &str) {
+        if let Ok(mut s) = self.stopping.lock() {
+            s.insert(id.to_string());
+        }
+    }
+
+    fn clear_stopping(&self, id: &str) {
+        if let Ok(mut s) = self.stopping.lock() {
+            s.remove(id);
+        }
+    }
+}
+
+#[async_trait]
+impl ServerService for CoreServerService {
+    async fn status(&self, id: &InstanceId) -> Result<ServerSnapshot, ServerServiceError> {
+        // 确认实例存在。
+        self.find_instance(id).await?;
+
+        let id_str = id.as_str().to_string();
+        let started_at = self
+            .instance_service
+            .find(id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|instance| instance.last_started_at_unix_secs);
+
+        let mut processes = self.processes_lock()?;
+        if let Some(managed) = processes.get_mut(&id_str) {
+            let is_running = managed
+                .daemon
+                .poll()
+                .map(|status| status.is_none())
+                .unwrap_or(false);
+
+            let state = if self.is_stopping(&id_str) {
+                ServerState::Stopping
+            } else if is_running && self.is_starting(&id_str) {
+                ServerState::Starting
+            } else if is_running {
+                ServerState::Running
+            } else {
+                ServerState::Stopped
+            };
+
+            return Ok(ServerSnapshot {
+                instance_id: id_str,
+                state,
+                pid: if is_running {
+                    Some(managed.daemon.id())
+                } else {
+                    None
+                },
+                uptime_secs: started_at.and_then(|t| current_timestamp_secs().checked_sub(t)),
+                error_message: None,
+            });
+        }
+
+        Ok(ServerSnapshot {
+            instance_id: id_str,
+            state: ServerState::Stopped,
+            pid: None,
+            uptime_secs: None,
+            error_message: None,
+        })
+    }
+
+    async fn start(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let instance = self.find_instance(id).await?;
+        let id_str = id.as_str().to_string();
+
+        {
+            let mut processes = self.processes_lock()?;
+            if let Some(managed) = processes.get_mut(&id_str) {
+                if managed.daemon.poll().map(|s| s.is_none()).unwrap_or(false) {
+                    return Err(ServerError::InvalidState.into());
+                }
+                processes.remove(&id_str);
+            }
+        }
+
+        let mut command = self.build_process_command(&instance)?;
+        command.stdin(std::process::Stdio::piped());
+        command.stdout(std::process::Stdio::piped());
+        command.stderr(std::process::Stdio::piped());
+
+        let mut daemon = Daemon::spawn(&mut command)
+            .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+        let terminal = Terminal::from_daemon_with_input(&mut daemon, true);
+
+        self.mark_starting(&id_str);
+        self.processes_lock()?
+            .insert(id_str.clone(), ManagedProcess { daemon, terminal });
+
+        // 更新实例的最后启动时间。
+        let _ = self
+            .instance_service
+            .update_last_started(id)
+            .await
+            .map_err(|_| ServerError::OperationFailed {
+                source: Box::new(std::io::Error::other("failed to update last started")),
+            })?;
+
+        // 后台读取进程输出，避免管道阻塞（当前先消费，后续接入日志管线）。
+        if let Some(managed) = self.processes_lock()?.get_mut(&id_str) {
+            let stdout = managed.terminal.take_output(TerminalStream::Stdout);
+            let stderr = managed.terminal.take_output(TerminalStream::Stderr);
+            spawn_output_reader(id_str.clone(), stdout, stderr);
+        }
+
+        Ok(())
+    }
+
+    async fn stop(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let id_str = id.as_str().to_string();
+        self.find_instance(id).await?;
+
+        // 优雅停止：向控制台发送 stop，等待退出。
+        let _ = self.send_command_inner(id, "stop").await;
+        self.mark_stopping(&id_str);
+
+        let deadline = Instant::now() + STOP_GRACEFUL_TIMEOUT;
+        loop {
+            {
+                let mut processes = self.processes_lock()?;
+                if let Some(managed) = processes.get_mut(&id_str) {
+                    if managed.daemon.poll().map(|s| s.is_some()).unwrap_or(true) {
+                        processes.remove(&id_str);
+                        self.clear_stopping(&id_str);
+                        return Ok(());
+                    }
+                } else {
+                    self.clear_stopping(&id_str);
+                    return Ok(());
+                }
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+
+        // 超时：强制终止进程树。
+        let mut processes = self.processes_lock()?;
+        if let Some(mut managed) = processes.remove(&id_str) {
+            managed
+                .daemon
+                .terminate_tree()
+                .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+        }
+        self.clear_stopping(&id_str);
+        Ok(())
+    }
+
+    async fn force_stop(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let id_str = id.as_str().to_string();
+        self.find_instance(id).await?;
+
+        let mut processes = self.processes_lock()?;
+        if let Some(mut managed) = processes.remove(&id_str) {
+            managed
+                .daemon
+                .terminate_tree()
+                .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+        }
+        self.clear_starting(&id_str);
+        self.clear_stopping(&id_str);
+        Ok(())
+    }
+
+    async fn send_command(&self, id: &InstanceId, command: &str) -> Result<(), ServerServiceError> {
+        self.send_command_inner(id, command).await
+    }
+}
+
+impl CoreServerService {
+    /// 向服务器控制台发送命令（内部实现）。
+    async fn send_command_inner(
+        &self,
+        id: &InstanceId,
+        command: &str,
+    ) -> Result<(), ServerServiceError> {
+        let id_str = id.as_str().to_string();
+        let mut processes = self.processes_lock()?;
+        let Some(managed) = processes.get_mut(&id_str) else {
+            return Err(ServerError::InvalidState.into());
+        };
+        if managed.daemon.poll().map(|s| s.is_some()).unwrap_or(true) {
+            return Err(ServerError::InvalidState.into());
+        }
+
+        // 写入 stdin 是短同步 IO（单行命令），直接持有锁执行。
+        managed
+            .terminal
+            .write_line(command)
+            .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+        Ok(())
+    }
+}
+
+/// 后台读取进程输出流，防止管道阻塞。
+///
+/// 当前仅消费输出；后续接入日志管线（SQLite / 流式推送）时在此扩展。
+fn spawn_output_reader(
+    instance_id: String,
+    stdout: Option<TerminalOutput>,
+    stderr: Option<TerminalOutput>,
+) {
+    std::thread::spawn(move || {
+        let mut readers: Vec<TerminalOutput> = stdout.into_iter().chain(stderr).collect();
+
+        while !readers.is_empty() {
+            let mut next = Vec::with_capacity(readers.len());
+            for mut reader in readers {
+                let mut buffer = [0u8; 4096];
+                match std::io::Read::read(&mut reader, &mut buffer) {
+                    Ok(0) => {} // EOF：丢弃该流。
+                    Ok(_n) => {
+                        // 占位：输出暂不处理。接入日志管线后在此记录。
+                        let _ = instance_id.clone();
+                        next.push(reader);
+                    }
+                    Err(_) => {} // 读取错误：丢弃该流。
+                }
+            }
+            readers = next;
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    });
+}
+
+/// 当前 Unix 时间戳（秒）。
+fn current_timestamp_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -153,17 +153,10 @@ impl CoreServerService {
 #[async_trait]
 impl ServerService for CoreServerService {
     async fn status(&self, id: &InstanceId) -> Result<ServerSnapshot, ServerServiceError> {
-        // 确认实例存在。
-        self.find_instance(id).await?;
-
+        // 确认实例存在，并复用实例信息避免重复查询与状态不一致。
+        let instance = self.find_instance(id).await?;
         let id_str = id.as_str().to_string();
-        let started_at = self
-            .instance_service
-            .find(id)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|instance| instance.last_started_at_unix_secs);
+        let started_at = instance.last_started_at_unix_secs;
 
         let mut processes = self.processes_lock()?;
         if let Some(managed) = processes.get_mut(&id_str) {
@@ -247,6 +240,9 @@ impl ServerService for CoreServerService {
             let stderr = managed.terminal.take_output(TerminalStream::Stderr);
             spawn_output_reader(id_str.clone(), stdout, stderr);
         }
+
+        // 进程已成功拉起并注册，退出 Starting 状态（Starting 仅覆盖 spawn 竞态窗口）。
+        self.clear_starting(&id_str);
 
         Ok(())
     }
@@ -355,9 +351,15 @@ fn spawn_output_reader(
                 let mut buffer = [0u8; 4096];
                 match std::io::Read::read(&mut reader, &mut buffer) {
                     Ok(0) => {} // EOF：丢弃该流。
-                    Ok(_n) => {
-                        // 占位：输出暂不处理。接入日志管线后在此记录。
-                        let _ = instance_id.clone();
+                    Ok(n) => {
+                        // 当前仅消费输出以防管道阻塞；debug 级记录便于诊断进程问题。
+                        let text = String::from_utf8_lossy(&buffer[..n]);
+                        tracing::debug!(
+                            target: "sealantern.application.server",
+                            instance_id,
+                            output = %text.trim_end(),
+                            "server process output"
+                        );
                         next.push(reader);
                     }
                     Err(_) => {} // 读取错误：丢弃该流。

--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -10,6 +10,7 @@
 //! [`ServerService`] 时统一转为接口契约错误 [`ServerServiceError`]。
 
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -17,8 +18,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use sealantern_core::instance::{Instance, InstanceId, StartupMode};
 use sealantern_core::process::{
-    build_command, CommandBuildMode, CommandBuildRequest, Daemon, Terminal, TerminalOutput,
-    TerminalStream,
+    build_command, CommandBuildMode, CommandBuildRequest, Daemon, JavaEnvironment, Terminal,
+    TerminalOutput, TerminalStream, WindowsConsoleEncoding,
 };
 use sealantern_interface::server::{ServerSnapshot, ServerState};
 use sealantern_interface::{InstanceService, ServerService, ServerServiceError};
@@ -66,8 +67,8 @@ impl CoreServerService {
         self.instance_service
             .find(id)
             .await
-            .map_err(|_| ServerError::OperationFailed {
-                source: Box::new(std::io::Error::other("instance lookup failed")),
+            .map_err(|e| ServerError::OperationFailed {
+                source: Box::new(std::io::Error::other(format!("instance lookup failed: {e}"))),
             })?
             .ok_or(ServerError::InstanceNotFound)
     }
@@ -86,18 +87,29 @@ impl CoreServerService {
             StartupMode::Custom => CommandBuildMode::Custom,
         };
 
+        // 组装 JVM 参数（Xmx/Xms/编码 + 实例自定义参数）。
+        // 默认 JVM 参数（全局配置）当前为空，待配置功能恢复后接入。
+        let jvm_arguments = build_jvm_arguments(instance, "");
+        // 从 Java 可执行文件推导 JAVA_HOME / bin（供脚本与自定义模式注入环境）。
+        let java_environment = launch
+            .java_executable
+            .as_deref()
+            .map(JavaEnvironment::from_java_executable)
+            .transpose()
+            .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+
         let request = CommandBuildRequest {
             mode,
             working_directory: Path::new(&instance.directory),
             java_executable: launch.java_executable.as_deref(),
-            java_environment: None,
-            jvm_arguments: &[],
+            java_environment: java_environment.as_ref(),
+            jvm_arguments: &jvm_arguments,
             entry_path: launch.startup_target.as_deref(),
             custom_command: launch.custom_command.as_deref(),
             custom_executable: launch.custom_executable.as_deref(),
             custom_arguments: &[],
             installer_url: None,
-            windows_console_encoding: sealantern_core::process::WindowsConsoleEncoding::Utf8,
+            windows_console_encoding: WindowsConsoleEncoding::Utf8,
         };
 
         build_command(&request).map_err(|e| ServerError::OperationFailed { source: Box::new(e) })
@@ -212,13 +224,34 @@ impl ServerService for CoreServerService {
             }
         }
 
-        let mut command = self.build_process_command(&instance)?;
+        let mut command = match self.build_process_command(&instance) {
+            Ok(command) => command,
+            Err(error) => {
+                tracing::error!(
+                    target: "sealantern.application.server",
+                    instance_id = %id_str,
+                    error = %error,
+                    "failed to build process command"
+                );
+                return Err(error.into());
+            }
+        };
         command.stdin(std::process::Stdio::piped());
         command.stdout(std::process::Stdio::piped());
         command.stderr(std::process::Stdio::piped());
 
-        let mut daemon = Daemon::spawn(&mut command)
-            .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+        let mut daemon = match Daemon::spawn(&mut command) {
+            Ok(daemon) => daemon,
+            Err(error) => {
+                tracing::error!(
+                    target: "sealantern.application.server",
+                    instance_id = %id_str,
+                    error = %error,
+                    "failed to spawn server process"
+                );
+                return Err(ServerError::OperationFailed { source: Box::new(error) }.into());
+            }
+        };
         let terminal = Terminal::from_daemon_with_input(&mut daemon, true);
 
         self.mark_starting(&id_str);
@@ -377,4 +410,29 @@ fn current_timestamp_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+/// 组装服务器进程的 JVM 参数。
+///
+/// 顺序（对齐历史版本 `build_managed_jvm_args`）：
+/// 1. `-Xmx{max}M` / `-Xms{min}M`（来自实例内存配置）
+/// 2. 编码参数（`-Dfile.encoding` 等，当前固定 UTF-8）
+/// 3. 全局默认 JVM 参数（`default_jvm_args`，配置功能恢复前为空）
+/// 4. 实例自定义参数（`launch.jvm_arguments`）
+fn build_jvm_arguments(instance: &Instance, default_jvm_args: &str) -> Vec<OsString> {
+    let mut args = vec![
+        OsString::from(format!("-Xmx{}M", instance.max_memory_mib)),
+        OsString::from(format!("-Xms{}M", instance.min_memory_mib)),
+        OsString::from("-Dfile.encoding=UTF-8"),
+        OsString::from("-Dsun.stdout.encoding=UTF-8"),
+        OsString::from("-Dsun.stderr.encoding=UTF-8"),
+    ];
+
+    // 全局默认 JVM 参数（配置功能恢复后接入真实值）。
+    for arg in default_jvm_args.split_whitespace() {
+        args.push(OsString::from(arg));
+    }
+
+    args.extend(instance.launch.jvm_arguments.iter().map(OsString::from));
+    args
 }

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use crate::error::InstanceError;
-use crate::service::{CoreInstanceService, CoreSystemService};
+use crate::service::{CoreInstanceService, CoreServerService, CoreSystemService};
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
 #[derive(Clone)]
@@ -28,8 +28,10 @@ pub struct AppServices {
 /// 后续新增服务只需在此加一个 `Arc<XxxService>` 字段，在 [`AppServices`]
 /// 下补一条 `pub async fn xxx_service()` 便捷函数即可，无需改动调用方。
 pub struct AppServicesInner {
-    /// 服务器实例管理服务。
+    /// 服务器实例记录管理服务。
     pub instance: Arc<CoreInstanceService>,
+    /// 服务器进程管理服务。
+    pub server: Arc<CoreServerService>,
     /// 系统资源信息服务。
     pub system: Arc<CoreSystemService>,
 }
@@ -41,11 +43,13 @@ static SERVICES: tokio::sync::RwLock<Option<Arc<AppServicesInner>>> =
 impl AppServices {
     /// 从既有实例构造句柄（供测试/重载注入 `register`）。
     ///
-    /// 系统资源服务为无状态实现，内部自动构造，无需外部传入。
+    /// 服务器进程服务共享同一实例服务句柄；系统资源服务为无状态实现，自动构造。
     pub fn from_inner(instance: CoreInstanceService) -> Self {
+        let instance = Arc::new(instance);
         Self {
             inner: Arc::new(AppServicesInner {
-                instance: Arc::new(instance),
+                server: Arc::new(CoreServerService::new(instance.clone())),
+                instance,
                 system: Arc::new(CoreSystemService),
             }),
         }
@@ -101,6 +105,16 @@ impl AppServices {
     /// 便捷访问入口：一步拿到实例管理服务的共享句柄（惰性初始化 + 可替换）。
     pub async fn instance_service() -> Result<Arc<CoreInstanceService>, InstanceError> {
         Ok(Self::get().await?.instance().clone())
+    }
+
+    /// 访问服务器进程管理服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn server(&self) -> &Arc<CoreServerService> {
+        &self.inner.server
+    }
+
+    /// 便捷访问入口：一步拿到服务器进程管理服务的共享句柄（惰性初始化 + 可替换）。
+    pub async fn server_service() -> Result<Arc<CoreServerService>, InstanceError> {
+        Ok(Self::get().await?.server().clone())
     }
 
     /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -69,3 +69,36 @@ impl std::fmt::Display for SystemServiceError {
 }
 
 impl std::error::Error for SystemServiceError {}
+
+/// 服务器进程管理失败的契约错误类别。
+///
+/// 分类风格与其他契约错误一致：不携带主机路径、进程细节等敏感信息，
+/// 底层失败详情由应用层写入受控日志。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum ServerServiceError {
+    /// 指定的实例不存在。
+    InstanceNotFound,
+    /// 服务器进程当前状态不允许该操作（如未运行时停止、已运行时重复启动）。
+    InvalidState,
+    /// 客户端提供的输入不合法。
+    InvalidInput,
+    /// 底层进程 / IO 操作失败。
+    OperationFailed,
+    /// 该能力尚未实现（占位）。
+    Unsupported,
+}
+
+impl std::fmt::Display for ServerServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::InstanceNotFound => "server instance not found",
+            Self::InvalidState => "server is in an invalid state for this operation",
+            Self::InvalidInput => "invalid input",
+            Self::OperationFailed => "server operation failed",
+            Self::Unsupported => "operation not supported",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for ServerServiceError {}

--- a/crates/interface/src/instance/service.rs
+++ b/crates/interface/src/instance/service.rs
@@ -1,14 +1,13 @@
 use crate::error::InstanceServiceError;
 use async_trait::async_trait;
 use sealantern_core::instance::{Instance, InstanceId, InstanceSpec};
-use sealantern_core::server::ServerStatus;
 
-/// 管理服务器实例的宿主能力端口。
+/// 管理服务器实例记录的宿主能力端口。
 ///
-/// 覆盖实例的查询、生命周期（启动/停止/强制停止）与 CRUD（创建/删除/重命名/改路径）。
-/// 方法均为异步：内部涉及持久化 IO 与进程管理。供给（导入、整合包、扫描等）方法在
-/// 后续迭代补充。实现方负责组合 `core` 的 repository、provisioning plan 与 process 能力，
-/// 不依赖任何具体传输。
+/// 覆盖实例记录的查询与 CRUD（创建/删除/重命名/改路径），不涉及进程操作。
+/// 实例的启动/停止/状态等进程生命周期由 [`ServerService`](crate::ServerService)
+/// 提供。方法均为异步：内部涉及持久化 IO。供给（导入、整合包、扫描等）方法在
+/// 后续迭代补充。实现方负责组合 `core` 的 repository 能力，不依赖任何具体传输。
 #[async_trait]
 pub trait InstanceService: Send + Sync {
     /// 列出全部实例。
@@ -16,18 +15,6 @@ pub trait InstanceService: Send + Sync {
 
     /// 按 ID 查找实例，不存在时返回 `None`。
     async fn find(&self, id: &InstanceId) -> Result<Option<Instance>, InstanceServiceError>;
-
-    /// 查询实例的当前运行状态。
-    async fn status(&self, id: &InstanceId) -> Result<ServerStatus, InstanceServiceError>;
-
-    /// 启动实例。
-    async fn start(&self, id: &InstanceId) -> Result<(), InstanceServiceError>;
-
-    /// 优雅停止实例。
-    async fn stop(&self, id: &InstanceId) -> Result<(), InstanceServiceError>;
-
-    /// 强制停止实例（终止进程树）。
-    async fn force_stop(&self, id: &InstanceId) -> Result<(), InstanceServiceError>;
 
     /// 创建新实例并持久化。
     async fn create(&self, spec: InstanceSpec) -> Result<Instance, InstanceServiceError>;
@@ -98,29 +85,6 @@ mod tests {
             Ok(Some(sample_instance()))
         }
 
-        async fn status(&self, _id: &InstanceId) -> Result<ServerStatus, InstanceServiceError> {
-            self.calls.lock().expect("lock").push("status");
-            Ok(ServerStatus {
-                process_id: 0,
-                state: sealantern_core::server::ServerProcessState::Running,
-            })
-        }
-
-        async fn start(&self, _id: &InstanceId) -> Result<(), InstanceServiceError> {
-            self.calls.lock().expect("lock").push("start");
-            Ok(())
-        }
-
-        async fn stop(&self, _id: &InstanceId) -> Result<(), InstanceServiceError> {
-            self.calls.lock().expect("lock").push("stop");
-            Ok(())
-        }
-
-        async fn force_stop(&self, _id: &InstanceId) -> Result<(), InstanceServiceError> {
-            self.calls.lock().expect("lock").push("force_stop");
-            Ok(())
-        }
-
         async fn create(&self, _spec: InstanceSpec) -> Result<Instance, InstanceServiceError> {
             self.calls.lock().expect("lock").push("create");
             Ok(sample_instance())
@@ -147,19 +111,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn service_contract_supports_query_lifecycle_and_crud_calls() {
+    async fn service_contract_supports_query_and_crud_calls() {
         let service = FakeInstanceService { calls: Mutex::new(Vec::new()) };
         let id = InstanceId::new("server-42").expect("valid id");
 
         assert_eq!(service.list().await.expect("list").len(), 1);
         assert!(service.find(&id).await.expect("find").is_some());
-        assert!(matches!(
-            service.status(&id).await.expect("status").state,
-            sealantern_core::server::ServerProcessState::Running
-        ));
-        service.start(&id).await.expect("start");
-        service.stop(&id).await.expect("stop");
-        service.force_stop(&id).await.expect("force_stop");
         service.create(sample_spec()).await.expect("create");
         service.delete(&id).await.expect("delete");
         service.rename(&id, "新名字").await.expect("rename");
@@ -170,18 +127,7 @@ mod tests {
 
         assert_eq!(
             *service.calls.lock().expect("lock"),
-            vec![
-                "list",
-                "find",
-                "status",
-                "start",
-                "stop",
-                "force_stop",
-                "create",
-                "delete",
-                "rename",
-                "update_path"
-            ]
+            vec!["list", "find", "create", "delete", "rename", "update_path"]
         );
     }
 }

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -7,16 +7,22 @@
 
 /// 接口契约错误类型。
 pub mod error;
-/// 服务器实例相关模型与服务端口。
+/// 服务器实例记录相关模型与服务端口。
 pub mod instance;
+/// 服务器进程管理相关模型与服务端口。
+pub mod server;
 /// 系统资源信息相关模型与服务端口。
 pub mod system;
 
 /// 服务器实例管理错误枚举。
 pub use error::InstanceServiceError;
+/// 服务器进程管理错误枚举。
+pub use error::ServerServiceError;
 /// 系统资源信息服务错误枚举。
 pub use error::SystemServiceError;
-/// 服务器实例管理服务端口。
+/// 服务器实例记录管理服务端口。
 pub use instance::InstanceService;
+/// 服务器进程管理服务端口。
+pub use server::ServerService;
 /// 系统资源信息服务端口。
 pub use system::SystemService;

--- a/crates/interface/src/server/mod.rs
+++ b/crates/interface/src/server/mod.rs
@@ -1,0 +1,10 @@
+//! 服务器进程管理服务。
+//!
+//! 提供服务器进程生命周期（启动/停止/强制停止/状态/控制台命令）的宿主能力端口，
+//! 供 tauri / server 等宿主统一消费。实例记录管理见 [`crate::instance`]。
+
+mod models;
+mod service;
+
+pub use models::{ServerSnapshot, ServerState};
+pub use service::ServerService;

--- a/crates/interface/src/server/models.rs
+++ b/crates/interface/src/server/models.rs
@@ -1,0 +1,34 @@
+//! 服务器进程契约模型。
+//!
+//! 定义宿主消费的服务器进程状态快照等模型，全部可序列化，供跨传输面传递。
+
+use serde::Serialize;
+
+/// 服务器进程运行状态。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServerState {
+    /// 正在启动（进程已拉起，尚未就绪）。
+    Starting,
+    /// 运行中。
+    Running,
+    /// 正在优雅停止。
+    Stopping,
+    /// 已停止。
+    Stopped,
+}
+
+/// 服务器进程状态快照（宿主消费的契约模型）。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ServerSnapshot {
+    /// 实例标识。
+    pub instance_id: String,
+    /// 运行状态。
+    pub state: ServerState,
+    /// 进程 ID；未运行时为 `None`。
+    pub pid: Option<u32>,
+    /// 本次运行的启动时长（秒）；未运行时为 `None`。
+    pub uptime_secs: Option<u64>,
+    /// 异常退出信息；正常状态为 `None`。
+    pub error_message: Option<String>,
+}

--- a/crates/interface/src/server/service.rs
+++ b/crates/interface/src/server/service.rs
@@ -1,0 +1,34 @@
+//! 服务器进程管理服务端口。
+
+use async_trait::async_trait;
+use sealantern_core::instance::InstanceId;
+
+use crate::error::ServerServiceError;
+
+use super::models::ServerSnapshot;
+
+/// 服务器进程管理宿主能力端口。
+///
+/// 管理实例对应的服务器进程生命周期：启动、优雅停止、强制停止、状态查询与
+/// 控制台命令。实例记录本身（CRUD）由 [`InstanceService`](crate::InstanceService)
+/// 负责；本端口以实例标识定位进程，实现方需从实例记录读取启动配置。
+///
+/// 方法均为异步：涉及进程 IO 与状态轮询。实现方组合 `core` 的 process 能力，
+/// 不依赖任何具体宿主。
+#[async_trait]
+pub trait ServerService: Send + Sync {
+    /// 查询实例对应服务器进程的状态快照。
+    async fn status(&self, id: &InstanceId) -> Result<ServerSnapshot, ServerServiceError>;
+
+    /// 启动实例对应的服务器进程。
+    async fn start(&self, id: &InstanceId) -> Result<(), ServerServiceError>;
+
+    /// 优雅停止服务器进程（向控制台发送 stop 并等待退出，超时后强制终止）。
+    async fn stop(&self, id: &InstanceId) -> Result<(), ServerServiceError>;
+
+    /// 强制停止服务器进程（终止整个进程树）。
+    async fn force_stop(&self, id: &InstanceId) -> Result<(), ServerServiceError>;
+
+    /// 向服务器控制台发送单行命令。
+    async fn send_command(&self, id: &InstanceId, command: &str) -> Result<(), ServerServiceError>;
+}

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -9,7 +9,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::Serialize;
 
-use sealantern_interface::{InstanceServiceError, SystemServiceError};
+use sealantern_interface::{InstanceServiceError, ServerServiceError, SystemServiceError};
 
 /// 展平的 HTTP 错误响应体。
 #[derive(Debug, Serialize)]
@@ -89,6 +89,37 @@ impl HttpError {
         }
     }
 
+    /// 由服务器进程管理契约错误构建 HTTP 错误。
+    pub fn from_server_error(error: ServerServiceError) -> Self {
+        match error {
+            ServerServiceError::InstanceNotFound => Self {
+                status: StatusCode::NOT_FOUND,
+                code: "instance_not_found",
+                message: error.to_string(),
+            },
+            ServerServiceError::InvalidState => Self {
+                status: StatusCode::CONFLICT,
+                code: "server_invalid_state",
+                message: error.to_string(),
+            },
+            ServerServiceError::InvalidInput => Self {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_input",
+                message: error.to_string(),
+            },
+            ServerServiceError::OperationFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "server_operation_failed",
+                message: error.to_string(),
+            },
+            ServerServiceError::Unsupported => Self {
+                status: StatusCode::NOT_IMPLEMENTED,
+                code: "operation_unsupported",
+                message: error.to_string(),
+            },
+        }
+    }
+
     /// 构建一个客户端输入错误（400），带具体错误码。
     pub fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
         Self {
@@ -117,6 +148,12 @@ impl From<InstanceServiceError> for HttpError {
 impl From<SystemServiceError> for HttpError {
     fn from(error: SystemServiceError) -> Self {
         Self::from_system_error(error)
+    }
+}
+
+impl From<ServerServiceError> for HttpError {
+    fn from(error: ServerServiceError) -> Self {
+        Self::from_server_error(error)
     }
 }
 

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -3,10 +3,14 @@
 //! handler 只做传输层薄转发：解析请求 → 调用应用层服务 → 收敛错误。
 
 pub mod instance;
+pub mod server;
 pub mod system;
 
 pub use instance::{
     create_instance, delete_instance, get_instance, list_instances, rename_instance,
     update_instance_path,
+};
+pub use server::{
+    force_stop_server, send_server_command, server_status, start_server, stop_server,
 };
 pub use system::{directory_usage, process_usage, system_snapshot};

--- a/server/src/adapter/http/handlers/server.rs
+++ b/server/src/adapter/http/handlers/server.rs
@@ -1,0 +1,102 @@
+//! 服务器进程管理 REST handler。
+//!
+//! 提供服务器进程生命周期（状态/启动/停止/强制停止/控制台命令）接口，
+//! 薄转发到 [`CoreServerService`](sealantern_application::service::CoreServerService)
+//! 并收敛错误为 [`HttpError`](super::super::error::HttpError)。
+
+use axum::extract::{Path, State};
+use axum::Json;
+
+use sealantern_core::instance::InstanceId;
+use sealantern_interface::server::ServerSnapshot;
+use sealantern_interface::ServerService;
+
+use super::super::error::HttpError;
+use super::super::state::AppState;
+
+/// 解析路径参数中的实例 ID，非法输入视为客户端错误。
+fn parse_id(raw: &str) -> Result<InstanceId, HttpError> {
+    InstanceId::new(raw.to_owned())
+        .map_err(|_| HttpError::bad_request("invalid_instance_id", "invalid instance id"))
+}
+
+/// `GET /api/instances/{id}/status` — 查询服务器进程状态。
+pub async fn server_status(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ServerSnapshot>, HttpError> {
+    let id = parse_id(&id)?;
+    state
+        .server()
+        .status(&id)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `POST /api/instances/{id}/start` — 启动服务器进程。
+pub async fn start_server(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ServerSnapshot>, HttpError> {
+    let id = parse_id(&id)?;
+    state.server().start(&id).await?;
+    state
+        .server()
+        .status(&id)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `POST /api/instances/{id}/stop` — 优雅停止服务器进程。
+pub async fn stop_server(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ServerSnapshot>, HttpError> {
+    let id = parse_id(&id)?;
+    state.server().stop(&id).await?;
+    state
+        .server()
+        .status(&id)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `POST /api/instances/{id}/force-stop` — 强制停止服务器进程。
+pub async fn force_stop_server(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ServerSnapshot>, HttpError> {
+    let id = parse_id(&id)?;
+    state.server().force_stop(&id).await?;
+    state
+        .server()
+        .status(&id)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// 控制台命令请求体。
+#[derive(Debug, serde::Deserialize)]
+pub struct SendCommandRequest {
+    /// 要发送的控制台命令。
+    pub command: String,
+}
+
+/// `POST /api/instances/{id}/command` — 向服务器控制台发送命令。
+pub async fn send_server_command(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(request): Json<SendCommandRequest>,
+) -> Result<Json<()>, HttpError> {
+    let id = parse_id(&id)?;
+    state
+        .server()
+        .send_command(&id, &request.command)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -34,9 +34,20 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
         .route("/instances/{id}", get(handlers::get_instance))
         .route("/instances/{id}", delete(handlers::delete_instance))
         .route("/instances/{id}", patch(handlers::rename_instance))
+        // ── 嵌套子资源（服务器进程生命周期） ──
+        .route("/instances/{id}/status", get(handlers::server_status))
+        .route("/instances/{id}/start", post(handlers::start_server))
+        .route("/instances/{id}/stop", post(handlers::stop_server))
+        .route(
+            "/instances/{id}/force-stop",
+            post(handlers::force_stop_server),
+        )
+        .route(
+            "/instances/{id}/command",
+            post(handlers::send_server_command),
+        )
         // ── 嵌套子资源（后续扩展） ──
-        // 示例：.route("/instances/{id}/status", get(handlers::instance_status))
-        //       .route("/instances/{id}/logs", get(handlers::instance_logs))
+        // 示例：.route("/instances/{id}/logs", get(handlers::instance_logs))
         .route("/instances/{id}/path", put(handlers::update_instance_path));
 
     let system_routes = Router::new()

--- a/server/src/adapter/http/state.rs
+++ b/server/src/adapter/http/state.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use sealantern_application::service::{CoreInstanceService, CoreSystemService};
+use sealantern_application::service::{CoreInstanceService, CoreServerService, CoreSystemService};
 use sealantern_application::services::AppServices;
 
 /// HTTP 层的共享应用状态。
@@ -26,9 +26,14 @@ impl AppState {
         Self { services }
     }
 
-    /// 访问实例管理服务（`Arc` 共享句柄，clone 廉价）。
+    /// 访问实例记录管理服务（`Arc` 共享句柄，clone 廉价）。
     pub fn instance(&self) -> Arc<CoreInstanceService> {
         self.services.instance().clone()
+    }
+
+    /// 访问服务器进程管理服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn server(&self) -> Arc<CoreServerService> {
+        self.services.server().clone()
     }
 
     /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。

--- a/src-tauri/src/adapter/tauri/commands/compat/adapter.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/adapter.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use sealantern_core::instance::{Instance, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
-use sealantern_core::server::{ServerProcessState, ServerStatus};
 use sealantern_infra::platform::get_app_data_dir;
+use sealantern_interface::server::{ServerSnapshot, ServerState};
 use sealantern_interface::system::{
     CpuInfo, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage, SystemSnapshot,
 };
@@ -193,31 +193,33 @@ pub(crate) fn system_snapshot_to_frontend(snapshot: SystemSnapshot) -> FrontendS
     }
 }
 
-/// `ServerStatus` → 前端 `ServerStatusInfo`。
+/// `ServerSnapshot` → 前端 `ServerStatusInfo`。
 ///
-/// - `Running → "Running"`、`Exited(0) → "Stopped"`、`Exited(非0) → "Error"`、`Exited(无码) → "Stopped"`
-/// - `pid`：Running 时 `Some(process_id)`，Exited 时 `None`
-/// - `uptime`：后端无此信息，恒 `None`
+/// - 状态映射：`Starting → "Starting"`、`Running → "Running"`、
+///   `Stopping → "Stopping"`、`Stopped → "Stopped"`
+/// - `error_message` 非空时 → `"Error"`
+/// - `pid`：非 Stopped 时 `Some(process_id)`，否则 `None`
+/// - `uptime`：`uptime_secs`
 pub(crate) fn server_status_to_frontend(
     id: String,
-    status: ServerStatus,
+    status: ServerSnapshot,
 ) -> FrontendServerStatusInfo {
-    let (status_str, pid) = match status.state {
-        ServerProcessState::Running => ("Running".to_string(), Some(status.process_id)),
-        ServerProcessState::Exited(exit_status) => {
-            let mapped = exit_status
-                .code()
-                .map(|code| if code == 0 { "Stopped" } else { "Error" })
-                .unwrap_or("Stopped");
-            (mapped.to_string(), None)
+    let status_str = if status.error_message.is_some() {
+        "Error".to_string()
+    } else {
+        match status.state {
+            ServerState::Starting => "Starting".to_string(),
+            ServerState::Running => "Running".to_string(),
+            ServerState::Stopping => "Stopping".to_string(),
+            ServerState::Stopped => "Stopped".to_string(),
         }
     };
 
     FrontendServerStatusInfo {
         id,
         status: status_str,
-        pid,
-        uptime: None,
+        pid: status.pid,
+        uptime: status.uptime_secs,
     }
 }
 

--- a/src-tauri/src/adapter/tauri/commands/compat/adapter.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/adapter.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use sealantern_core::instance::{Instance, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
-use sealantern_infra::platform::get_app_data_dir;
 use sealantern_interface::server::{ServerSnapshot, ServerState};
 use sealantern_interface::system::{
     CpuInfo, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage, SystemSnapshot,
@@ -75,7 +74,13 @@ pub(crate) fn create_params_to_spec(
 ) -> Result<InstanceSpec, InstanceServiceError> {
     let id_str = uuid::Uuid::new_v4().to_string();
     let id = InstanceId::new(id_str).map_err(|_| InstanceServiceError::InvalidInput)?;
-    let directory = get_app_data_dir().join("servers").join(id.as_str());
+    // 服务器目录取 jar 文件所在目录（进程工作目录需真实存在，否则 spawn 失败）。
+    let jar_path_obj = PathBuf::from(&params.jar_path);
+    let directory = jar_path_obj
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(|path| path.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
     let created_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -443,9 +448,8 @@ mod tests {
         let spec = create_params_to_spec(params).expect("spec should build");
         // UUID 非空
         assert!(!spec.id.as_str().is_empty());
-        // 目录以 servers/{id} 结尾
-        assert!(spec.directory.ends_with(spec.id.as_str()));
-        assert!(spec.directory.starts_with(get_app_data_dir()));
+        // 服务器目录为 jar 所在目录（进程工作目录）
+        assert_eq!(spec.directory, PathBuf::from("/tmp"));
         // created_at > 0（除非系统时钟异常）
         assert!(spec.created_at_unix_secs > 0);
         // core_version 留空

--- a/src-tauri/src/adapter/tauri/commands/compat/instance_compat.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/instance_compat.rs
@@ -9,10 +9,12 @@
 use std::sync::Arc;
 
 use sealantern_application::error::InstanceError;
-use sealantern_application::service::CoreInstanceService;
+use sealantern_application::service::{CoreInstanceService, CoreServerService};
 use sealantern_application::services::AppServices;
 use sealantern_core::instance::InstanceId;
-use sealantern_interface::{InstanceService, InstanceServiceError};
+use sealantern_interface::{
+    InstanceService, InstanceServiceError, ServerService, ServerServiceError,
+};
 
 use super::adapter::{
     add_existing_params_to_spec, create_params_to_spec, instance_to_frontend,
@@ -25,7 +27,7 @@ use super::models::{
 
 // ── 服务句柄获取（复用 instance.rs 的模式）────────────────────────────
 
-/// 获取全局实例管理服务句柄（惰性初始化容器）。
+/// 获取全局实例记录管理服务句柄（惰性初始化容器）。
 ///
 /// 应用层主错误 [`InstanceError`] 经 `From` 收敛为契约错误 [`InstanceServiceError`]。
 async fn instance_service() -> Result<Arc<CoreInstanceService>, InstanceServiceError> {
@@ -33,11 +35,24 @@ async fn instance_service() -> Result<Arc<CoreInstanceService>, InstanceServiceE
     Ok(services.instance().clone())
 }
 
+/// 获取全局服务器进程管理服务句柄（惰性初始化容器）。
+async fn server_service() -> Result<Arc<CoreServerService>, ServerServiceError> {
+    let services = AppServices::get()
+        .await
+        .map_err(|_| ServerServiceError::OperationFailed)?;
+    Ok(services.server().clone())
+}
+
 /// 解析实例 ID 字符串。
 fn parse_id(id: String) -> Result<InstanceId, InstanceServiceError> {
     InstanceId::new(id)
         .map_err(InstanceError::from)
         .map_err(InstanceServiceError::from)
+}
+
+/// 解析实例 ID 字符串（服务器进程命令用，错误为 `ServerServiceError`）。
+fn parse_id_server(id: String) -> Result<InstanceId, ServerServiceError> {
+    InstanceId::new(id).map_err(|_| ServerServiceError::InvalidInput)
 }
 
 // ── 可用命令（后端已对接）──────────────────────────────────────────────
@@ -105,21 +120,21 @@ pub async fn update_server_path(
     Ok(instance_to_frontend(&instance))
 }
 
-// ── 前向就绪但后端暂 Unsupported（生命周期未接 Daemon）────────────────
+// ── 服务器进程生命周期（经 ServerService 接入）────────────────────────
 
 /// 启动服务器（兼容 `start_server`）。
 #[tauri::command]
-pub async fn start_server(id: String) -> Result<(), InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id(id)?;
+pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_server(id)?;
     service.start(&id).await
 }
 
 /// 停止服务器（兼容 `stop_server`）。
 #[tauri::command]
-pub async fn stop_server(id: String) -> Result<(), InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id(id)?;
+pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_server(id)?;
     service.stop(&id).await
 }
 
@@ -128,21 +143,27 @@ pub async fn stop_server(id: String) -> Result<(), InstanceServiceError> {
 /// Phase 1 后端无 Daemon，无法验证 token；`prepare_force_stop_server` 同样返回
 /// Unsupported，故此处 token 一并忽略。Phase 2 接入 Daemon 后需恢复 token 校验链路。
 #[tauri::command]
-pub async fn force_stop_server(params: ForceStopServerParams) -> Result<(), InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id(params.id)?;
+pub async fn force_stop_server(params: ForceStopServerParams) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_server(params.id)?;
     service.force_stop(&id).await
 }
 
 /// 获取服务器状态（兼容 `get_server_status`）。
 #[tauri::command]
-pub async fn get_server_status(
-    id: String,
-) -> Result<FrontendServerStatusInfo, InstanceServiceError> {
-    let service = instance_service().await?;
-    let instance_id = parse_id(id.clone())?;
+pub async fn get_server_status(id: String) -> Result<FrontendServerStatusInfo, ServerServiceError> {
+    let service = server_service().await?;
+    let instance_id = parse_id_server(id.clone())?;
     let status = service.status(&instance_id).await?;
     Ok(server_status_to_frontend(id, status))
+}
+
+/// 发送控制台命令（兼容 `send_command`）。
+#[tauri::command]
+pub async fn send_command(id: String, command: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let instance_id = parse_id_server(id)?;
+    service.send_command(&instance_id, &command).await
 }
 
 // ── 显式 Unsupported（后端能力未装配）─────────────────────────────────
@@ -186,12 +207,6 @@ pub async fn copy_directory_contents() -> Result<(), InstanceServiceError> {
 /// 准备强制停止（与 force_stop 一致返回 Unsupported，避免 token 流半通）。
 #[tauri::command]
 pub async fn prepare_force_stop_server() -> Result<(), InstanceServiceError> {
-    Err(InstanceServiceError::Unsupported)
-}
-
-/// 发送控制台命令（Phase 2 接 RPC console 服务）。
-#[tauri::command]
-pub async fn send_command() -> Result<(), InstanceServiceError> {
     Err(InstanceServiceError::Unsupported)
 }
 

--- a/src-tauri/src/adapter/tauri/commands/compat/instance_compat.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/instance_compat.rs
@@ -21,8 +21,7 @@ use super::adapter::{
     server_status_to_frontend,
 };
 use super::models::{
-    AddExistingServerParams, CreateServerParams, ForceStopServerParams, FrontendServerInstance,
-    FrontendServerStatusInfo, UpdateServerPathParams,
+    AddExistingServerParams, CreateServerParams, FrontendServerInstance, FrontendServerStatusInfo,
 };
 
 // ── 服务句柄获取（复用 instance.rs 的模式）────────────────────────────
@@ -58,10 +57,32 @@ fn parse_id_server(id: String) -> Result<InstanceId, ServerServiceError> {
 // ── 可用命令（后端已对接）──────────────────────────────────────────────
 
 /// 创建新服务器实例（兼容 `create_server`）。
-#[tauri::command]
+///
+/// `rename_all = "camelCase"` 使前端键名对齐 `src/api/server.ts` 的调用形状。
+#[allow(clippy::too_many_arguments)]
+#[tauri::command(rename_all = "camelCase")]
 pub async fn create_server(
-    params: CreateServerParams,
+    name: String,
+    core_type: String,
+    mc_version: String,
+    max_memory: u32,
+    min_memory: u32,
+    port: u16,
+    java_path: String,
+    jar_path: String,
+    startup_mode: String,
 ) -> Result<FrontendServerInstance, InstanceServiceError> {
+    let params = CreateServerParams {
+        name,
+        core_type,
+        mc_version,
+        max_memory,
+        min_memory,
+        port,
+        java_path,
+        jar_path,
+        startup_mode,
+    };
     let spec = create_params_to_spec(params)?;
     let service = instance_service().await?;
     let instance = service.create(spec).await?;
@@ -69,10 +90,30 @@ pub async fn create_server(
 }
 
 /// 添加已存在的服务器（兼容 `add_existing_server`）。
-#[tauri::command]
+///
+/// `rename_all = "camelCase"` 使前端键名对齐 `src/api/server.ts` 的调用形状。
+#[allow(clippy::too_many_arguments)]
+#[tauri::command(rename_all = "camelCase")]
 pub async fn add_existing_server(
-    params: AddExistingServerParams,
+    name: String,
+    server_path: String,
+    java_path: String,
+    max_memory: u32,
+    min_memory: u32,
+    port: u16,
+    startup_mode: String,
+    executable_path: Option<String>,
 ) -> Result<FrontendServerInstance, InstanceServiceError> {
+    let params = AddExistingServerParams {
+        name,
+        server_path,
+        java_path,
+        max_memory,
+        min_memory,
+        port,
+        startup_mode,
+        executable_path,
+    };
     let spec = add_existing_params_to_spec(params)?;
     let service = instance_service().await?;
     let instance = service.create(spec).await?;
@@ -106,13 +147,17 @@ pub async fn update_server_name(id: String, name: String) -> Result<(), Instance
 /// 更新服务器路径（兼容 `update_server_path`）。
 ///
 /// 第一阶段只改目录，丢弃 `newJarPath`/`newStartupMode`（待 Phase 2 扩展）。
-#[tauri::command]
+#[tauri::command(rename_all = "camelCase")]
 pub async fn update_server_path(
-    params: UpdateServerPathParams,
+    id: String,
+    new_path: String,
+    new_jar_path: Option<String>,
+    new_startup_mode: Option<String>,
 ) -> Result<FrontendServerInstance, InstanceServiceError> {
+    let _ = (new_jar_path, new_startup_mode);
     let service = instance_service().await?;
-    let id = parse_id(params.id)?;
-    service.update_path(&id, &params.new_path).await?;
+    let id = parse_id(id)?;
+    service.update_path(&id, &new_path).await?;
     let instance = service
         .find(&id)
         .await?
@@ -142,10 +187,14 @@ pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
 ///
 /// Phase 1 后端无 Daemon，无法验证 token；`prepare_force_stop_server` 同样返回
 /// Unsupported，故此处 token 一并忽略。Phase 2 接入 Daemon 后需恢复 token 校验链路。
-#[tauri::command]
-pub async fn force_stop_server(params: ForceStopServerParams) -> Result<(), ServerServiceError> {
+#[tauri::command(rename_all = "camelCase")]
+pub async fn force_stop_server(
+    id: String,
+    confirmation_token: String,
+) -> Result<(), ServerServiceError> {
+    let _ = confirmation_token;
     let service = server_service().await?;
-    let id = parse_id_server(params.id)?;
+    let id = parse_id_server(id)?;
     service.force_stop(&id).await
 }
 

--- a/src-tauri/src/adapter/tauri/commands/compat/system_compat.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/system_compat.rs
@@ -16,9 +16,7 @@ use tauri_plugin_opener::OpenerExt;
 
 use super::adapter::{process_usage_to_resource_usage, system_snapshot_to_frontend};
 use super::error::instance_err_to_system;
-use super::models::{
-    FrontendServerResourceUsage, FrontendSystemInfo, GetServerResourceUsageParams,
-};
+use super::models::{FrontendServerResourceUsage, FrontendSystemInfo};
 
 // ── 可用命令 ──────────────────────────────────────────────────────────
 
@@ -68,17 +66,16 @@ pub async fn open_folder(app: tauri::AppHandle, path: String) -> Result<(), Syst
 
 /// 获取服务器资源占用（兼容 `get_server_resource_usage`）。
 ///
-/// 跨域调用：先调 instance 服务取 pid，再调 system 服务取进程占用。
-/// 第一阶段因 instance.status 未接 Daemon 而返回 Unsupported；适配代码前向就绪。
-#[tauri::command]
+/// 跨域调用：先经 server 服务取进程状态与 pid，再调 system 服务取进程占用。
+#[tauri::command(rename_all = "camelCase")]
 pub async fn get_server_resource_usage(
-    params: GetServerResourceUsageParams,
+    server_id: String,
 ) -> Result<FrontendServerResourceUsage, SystemServiceError> {
     let services = AppServices::get()
         .await
         .map_err(|_| SystemServiceError::OperationFailed)?;
-    let instance_id = InstanceId::new(params.server_id.clone())
-        .map_err(|_| SystemServiceError::OperationFailed)?;
+    let instance_id =
+        InstanceId::new(server_id.clone()).map_err(|_| SystemServiceError::OperationFailed)?;
 
     // 取实例状态获取 pid（经服务器进程管理服务）。
     let status = services
@@ -103,7 +100,7 @@ pub async fn get_server_resource_usage(
         .ok_or(SystemServiceError::OperationFailed)?;
 
     Ok(process_usage_to_resource_usage(
-        params.server_id,
+        server_id,
         instance.name,
         "Running".to_string(),
         usage,

--- a/src-tauri/src/adapter/tauri/commands/compat/system_compat.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/system_compat.rs
@@ -9,9 +9,9 @@
 
 use sealantern_application::services::AppServices;
 use sealantern_core::instance::InstanceId;
-use sealantern_core::server::ServerProcessState;
 use sealantern_infra::platform::get_app_data_dir;
-use sealantern_interface::{InstanceService, SystemService, SystemServiceError};
+use sealantern_interface::server::ServerState;
+use sealantern_interface::{InstanceService, ServerService, SystemService, SystemServiceError};
 use tauri_plugin_opener::OpenerExt;
 
 use super::adapter::{process_usage_to_resource_usage, system_snapshot_to_frontend};
@@ -80,18 +80,18 @@ pub async fn get_server_resource_usage(
     let instance_id = InstanceId::new(params.server_id.clone())
         .map_err(|_| SystemServiceError::OperationFailed)?;
 
-    // 取实例状态获取 pid
+    // 取实例状态获取 pid（经服务器进程管理服务）。
     let status = services
-        .instance()
+        .server()
         .status(&instance_id)
         .await
-        .map_err(instance_err_to_system)?;
+        .map_err(|_| SystemServiceError::ProcessNotFound)?;
 
-    // 仅 Running 时才有有效 pid；Exited 时 process_id 为 stale 值，不可用于查询
-    if !matches!(status.state, ServerProcessState::Running) {
+    // 仅 Running 时才有有效 pid；其余状态不可用于进程资源查询。
+    if status.state != ServerState::Running {
         return Err(SystemServiceError::ProcessNotFound);
     }
-    let pid = status.process_id;
+    let pid = status.pid.ok_or(SystemServiceError::ProcessNotFound)?;
     let usage = services.system().process_usage(pid).await?;
 
     // 取实例名

--- a/src-tauri/src/adapter/tauri/commands/instance.rs
+++ b/src-tauri/src/adapter/tauri/commands/instance.rs
@@ -13,7 +13,6 @@ use sealantern_application::error::InstanceError;
 use sealantern_application::service::CoreInstanceService;
 use sealantern_application::services::AppServices;
 use sealantern_core::instance::{Instance, InstanceId, InstanceSpec};
-use sealantern_core::server::ServerStatus;
 use sealantern_interface::{InstanceService, InstanceServiceError};
 
 /// 获取全局实例管理服务句柄（惰性初始化容器）。
@@ -47,38 +46,6 @@ pub async fn get_instance(id: String) -> Result<Option<Instance>, InstanceServic
     let service = instance_service().await?;
     let id = parse_id_for_tauri(id)?;
     service.find(&id).await
-}
-
-/// 查询实例的当前运行状态。
-#[tauri::command]
-pub async fn instance_status(id: String) -> Result<ServerStatus, InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id_for_tauri(id)?;
-    service.status(&id).await
-}
-
-/// 启动实例。
-#[tauri::command]
-pub async fn start_instance(id: String) -> Result<(), InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id_for_tauri(id)?;
-    service.start(&id).await
-}
-
-/// 优雅停止实例。
-#[tauri::command]
-pub async fn stop_instance(id: String) -> Result<(), InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id_for_tauri(id)?;
-    service.stop(&id).await
-}
-
-/// 强制停止实例（终止进程树）。
-#[tauri::command]
-pub async fn force_stop_instance(id: String) -> Result<(), InstanceServiceError> {
-    let service = instance_service().await?;
-    let id = parse_id_for_tauri(id)?;
-    service.force_stop(&id).await
 }
 
 /// 创建新实例并持久化。

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,3 +1,3 @@
-pub mod compat;
 pub mod instance;
+pub mod server;
 pub mod system;

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod compat;
 pub mod instance;
 pub mod server;
 pub mod system;

--- a/src-tauri/src/adapter/tauri/commands/server.rs
+++ b/src-tauri/src/adapter/tauri/commands/server.rs
@@ -1,11 +1,9 @@
-//! 服务器进程管理 Tauri 命令。
+//! 服务器进程管理（后端语义 API，保留参考）。
 //!
-//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
-//! [`CoreServerService`](sealantern_application::service::CoreServerService)
-//! 管理服务器进程生命周期（启动/停止/强制停止/状态/控制台命令）。
-//!
-//! 错误统一为接口契约错误 [`ServerServiceError`]，可序列化回前端，
-//! 不携带底层敏感细节。
+//! 前端命令名已由 `compat` 兼容层接管（`start_server`/`stop_server`/...），
+//! 本文件保留新命名的服务调用函数作为后端语义 API，不注册为 Tauri 命令，
+//! 供未来前端适配新版本命令时使用。
+#![allow(dead_code)]
 
 use std::sync::Arc;
 
@@ -31,7 +29,6 @@ fn parse_id_for_tauri(id: String) -> Result<InstanceId, ServerServiceError> {
 }
 
 /// 查询服务器进程状态。
-#[tauri::command]
 pub async fn server_status(id: String) -> Result<ServerSnapshot, ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -39,7 +36,6 @@ pub async fn server_status(id: String) -> Result<ServerSnapshot, ServerServiceEr
 }
 
 /// 启动服务器进程。
-#[tauri::command]
 pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -47,7 +43,6 @@ pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 优雅停止服务器进程。
-#[tauri::command]
 pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -55,7 +50,6 @@ pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 强制停止服务器进程（终止进程树）。
-#[tauri::command]
 pub async fn force_stop_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -63,7 +57,6 @@ pub async fn force_stop_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 向服务器控制台发送单行命令。
-#[tauri::command]
 pub async fn send_server_command(id: String, command: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;

--- a/src-tauri/src/adapter/tauri/commands/server.rs
+++ b/src-tauri/src/adapter/tauri/commands/server.rs
@@ -1,0 +1,71 @@
+//! 服务器进程管理 Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`CoreServerService`](sealantern_application::service::CoreServerService)
+//! 管理服务器进程生命周期（启动/停止/强制停止/状态/控制台命令）。
+//!
+//! 错误统一为接口契约错误 [`ServerServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
+
+use std::sync::Arc;
+
+use sealantern_application::service::CoreServerService;
+use sealantern_application::services::AppServices;
+use sealantern_core::instance::InstanceId;
+use sealantern_interface::server::ServerSnapshot;
+use sealantern_interface::{ServerService, ServerServiceError};
+
+/// 获取全局服务器进程管理服务句柄（惰性初始化容器）。
+async fn server_service() -> Result<Arc<CoreServerService>, ServerServiceError> {
+    let services = AppServices::get()
+        .await
+        .map_err(|_| ServerServiceError::OperationFailed)?;
+    Ok(services.server().clone())
+}
+
+/// 解析 Tauri 命令传入的实例 ID 字符串。
+///
+/// 统一映射解析错误为 [`ServerServiceError::InvalidInput`]。
+fn parse_id_for_tauri(id: String) -> Result<InstanceId, ServerServiceError> {
+    InstanceId::new(id).map_err(|_| ServerServiceError::InvalidInput)
+}
+
+/// 查询服务器进程状态。
+#[tauri::command]
+pub async fn server_status(id: String) -> Result<ServerSnapshot, ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_for_tauri(id)?;
+    service.status(&id).await
+}
+
+/// 启动服务器进程。
+#[tauri::command]
+pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_for_tauri(id)?;
+    service.start(&id).await
+}
+
+/// 优雅停止服务器进程。
+#[tauri::command]
+pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_for_tauri(id)?;
+    service.stop(&id).await
+}
+
+/// 强制停止服务器进程（终止进程树）。
+#[tauri::command]
+pub async fn force_stop_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_for_tauri(id)?;
+    service.force_stop(&id).await
+}
+
+/// 向服务器控制台发送单行命令。
+#[tauri::command]
+pub async fn send_server_command(id: String, command: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_for_tauri(id)?;
+    service.send_command(&id, &command).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,20 +6,12 @@ pub mod observability;
 
 use tauri::Manager;
 
-use adapter::tauri::commands::compat::instance_compat::{
-    add_existing_server, collect_copy_conflicts, copy_directory_contents, create_server,
-    delete_server, force_stop_server, get_server_list, get_server_logs, get_server_status,
-    import_modpack, import_server, parse_server_core_type, prepare_force_stop_server,
-    scan_startup_candidates, send_command, start_server, stop_server, update_server_name,
-    update_server_path, validate_server_path,
-};
-use adapter::tauri::commands::compat::system_compat::{
-    get_default_run_path, get_safe_mode_status, get_server_resource_usage, get_system_info,
-    open_file, open_folder, remove_file, test_ipv6_connectivity,
-};
 use adapter::tauri::commands::instance::{
-    create_instance, delete_instance, force_stop_instance, get_instance, instance_status,
-    list_instances, rename_instance, start_instance, stop_instance, update_instance_path,
+    create_instance, delete_instance, get_instance, list_instances, rename_instance,
+    update_instance_path,
+};
+use adapter::tauri::commands::server::{
+    force_stop_server, send_server_command, server_status, start_server, stop_server,
 };
 use adapter::tauri::commands::system::{
     get_directory_usage, get_process_usage, get_system_snapshot,
@@ -44,17 +36,19 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
-            //instance能力（由adapter/tauri/commands接入application）
+            //实例能力（由adapter/tauri/commands接入application）
             create_instance,
             delete_instance,
-            force_stop_instance,
             get_instance,
-            instance_status,
             list_instances,
             rename_instance,
-            start_instance,
-            stop_instance,
             update_instance_path,
+            //服务器进程能力（由adapter/tauri/commands接入application）
+            force_stop_server,
+            send_server_command,
+            server_status,
+            start_server,
+            stop_server,
             //系统资源能力（由adapter/tauri/commands接入application）
             get_directory_usage,
             get_process_usage,
@@ -67,36 +61,7 @@ pub fn run() {
             desktop_pick_java_file,
             desktop_pick_save_file,
             desktop_pick_server_executable,
-            desktop_pick_startup_file,
-            //兼容层（前端旧命令名 → 新服务，由adapter/tauri/commands/compat提供）
-            add_existing_server,
-            collect_copy_conflicts,
-            copy_directory_contents,
-            create_server,
-            delete_server,
-            force_stop_server,
-            get_default_run_path,
-            get_safe_mode_status,
-            get_server_list,
-            get_server_logs,
-            get_server_resource_usage,
-            get_server_status,
-            get_system_info,
-            import_modpack,
-            import_server,
-            open_file,
-            open_folder,
-            parse_server_core_type,
-            prepare_force_stop_server,
-            remove_file,
-            scan_startup_candidates,
-            send_command,
-            start_server,
-            stop_server,
-            test_ipv6_connectivity,
-            update_server_name,
-            update_server_path,
-            validate_server_path
+            desktop_pick_startup_file
         ])
         .setup(|app| {
             // 前端提供自定义标题栏；macOS 仍使用 Overlay 承载系统交通灯。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,15 +6,16 @@ pub mod observability;
 
 use tauri::Manager;
 
-use adapter::tauri::commands::instance::{
-    create_instance, delete_instance, get_instance, list_instances, rename_instance,
-    update_instance_path,
+use adapter::tauri::commands::compat::instance_compat::{
+    add_existing_server, collect_copy_conflicts, copy_directory_contents, create_server,
+    delete_server, force_stop_server, get_server_list, get_server_logs, get_server_status,
+    import_modpack, import_server, parse_server_core_type, prepare_force_stop_server,
+    scan_startup_candidates, send_command, start_server, stop_server, update_server_name,
+    update_server_path, validate_server_path,
 };
-use adapter::tauri::commands::server::{
-    force_stop_server, send_server_command, server_status, start_server, stop_server,
-};
-use adapter::tauri::commands::system::{
-    get_directory_usage, get_process_usage, get_system_snapshot,
+use adapter::tauri::commands::compat::system_compat::{
+    get_default_run_path, get_safe_mode_status, get_server_resource_usage, get_system_info,
+    open_file, open_folder, remove_file, test_ipv6_connectivity,
 };
 use desktop::{
     desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
@@ -36,23 +37,6 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
-            //实例能力（由adapter/tauri/commands接入application）
-            create_instance,
-            delete_instance,
-            get_instance,
-            list_instances,
-            rename_instance,
-            update_instance_path,
-            //服务器进程能力（由adapter/tauri/commands接入application）
-            force_stop_server,
-            send_server_command,
-            server_status,
-            start_server,
-            stop_server,
-            //系统资源能力（由adapter/tauri/commands接入application）
-            get_directory_usage,
-            get_process_usage,
-            get_system_snapshot,
             //桌面端能力（由desktop/dialog提供）
             desktop_pick_archive_file,
             desktop_pick_folder,
@@ -61,7 +45,36 @@ pub fn run() {
             desktop_pick_java_file,
             desktop_pick_save_file,
             desktop_pick_server_executable,
-            desktop_pick_startup_file
+            desktop_pick_startup_file,
+            //兼容层（前端旧命令名 → 新服务，由adapter/tauri/commands/compat提供）
+            add_existing_server,
+            collect_copy_conflicts,
+            copy_directory_contents,
+            create_server,
+            delete_server,
+            force_stop_server,
+            get_default_run_path,
+            get_safe_mode_status,
+            get_server_list,
+            get_server_logs,
+            get_server_resource_usage,
+            get_server_status,
+            get_system_info,
+            import_modpack,
+            import_server,
+            open_file,
+            open_folder,
+            parse_server_core_type,
+            prepare_force_stop_server,
+            remove_file,
+            scan_startup_candidates,
+            send_command,
+            start_server,
+            stop_server,
+            test_ipv6_connectivity,
+            update_server_name,
+            update_server_path,
+            validate_server_path
         ])
         .setup(|app| {
             // 前端提供自定义标题栏；macOS 仍使用 Overlay 承载系统交通灯。


### PR DESCRIPTION
- interface：InstanceService 收敛为纯实例 CRUD；新增 ServerService 端口（status/start/stop/force_stop/send_command）与 ServerSnapshot 模型
- interface error 新增 ServerServiceError 契约错误
- application：CoreInstanceService 移除生命周期占位；新增 CoreServerService（组合 core 的 Daemon/Terminal/build_command 实现进程管理）
- application error 新增 ServerError；AppServices 容器接入 server 服务
- tauri：新增 commands/server 生命周期命令，instance 命令移除 4 个生命周期入口
- server HTTP：新增 handlers/server，注册 /api/instances/{id}/status|start|stop|force-stop|command 路由
- 错误映射：ServerServiceError → HTTP（404/409/400/500/501）

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

将实例记录管理与服务器进程管理拆分，引入专门的服务器进程服务，并将其接入 Tauri 和 HTTP API。

New Features:
- 添加 `ServerService` 接口及 `ServerSnapshot` 模型，用于在独立于实例 CRUD 的前提下管理服务器进程生命周期。
- 通过新的 Tauri 命令以及位于 `/api/instances/{id}/…` 下的 REST 端点，暴露服务器进程生命周期相关的命令（`status`/`start`/`stop`/`force-stop`/`send_command`）。

Enhancements:
- 优化 `InstanceService`，使其仅负责实例记录的 CRUD，并在服务器成功启动后更新 `last-started` 元数据。
- 引入基于核心进程原语实现的 `CoreServerService`，并将其集成进全局的 `AppServices` 容器。
- 添加分层的服务器进程错误处理机制，将 `ServerError` 映射为 `ServerServiceError` 以及相应的 HTTP 错误响应。

Tests:
- 更新实例服务契约测试，以反映从 `InstanceService` 中移除生命周期相关操作后的行为变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split instance record management from server process management, introducing a dedicated server process service and wiring it into Tauri and HTTP APIs.

New Features:
- Add a ServerService interface with ServerSnapshot models to manage server process lifecycle independently from instance CRUD.
- Expose server process lifecycle commands (status/start/stop/force-stop/send_command) via new Tauri commands and REST endpoints under /api/instances/{id}/….

Enhancements:
- Refine InstanceService to handle only instance record CRUD and update last-started metadata after successful server startup.
- Introduce CoreServerService implementation using core process primitives and integrate it into the global AppServices container.
- Add layered server process error handling with ServerError mapped to ServerServiceError and HTTP error responses.

Tests:
- Update instance service contract tests to reflect removal of lifecycle operations from InstanceService.

</details>