### PR TITLE
chore(frontend): 移除前端heartbeat逻辑

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import { createApp } from "vue";
 import { invoke } from "@tauri-apps/api/core";
-import { tauriInvoke } from "@api/tauri";
 import App from "@src/App.vue";
 import router from "@src/router";
 import pinia from "@src/stores";
@@ -30,17 +29,6 @@ import {
 } from "cmzya-modern-ui";
 
 // ECharts 已改为按需懒加载,见 src/components/views/home/SystemStatsCard.vue
-
-const HEARTBEAT_INTERVAL = 5000;
-
-function startHeartbeat() {
-  // 在普通浏览器环境下，Tauri 后端不存在，调用会直接失败，这里静默忽略错误
-  setInterval(() => {
-    tauriInvoke("frontend_heartbeat", undefined, { silent: true }).catch(() => {
-      // 后端可能已退出或当前不在 Tauri 环境中
-    });
-  }, HEARTBEAT_INTERVAL);
-}
 
 const app = createApp(App);
 
@@ -84,5 +72,3 @@ if (import.meta.env.DEV) {
 app.use(pinia);
 app.use(router);
 app.mount("#app");
-
-startHeartbeat();


### PR DESCRIPTION
- 删除 startHeartbeat 定时调用与 HEARTBEAT_INTERVAL 常量
- 移除仅用于 heartbeat 的 tauriInvoke import

<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要
懒得写

## Summary by Sourcery

从主 Vue 应用的启动流程中移除已废弃的前端心跳机制。

Enhancements:
- 从前端入口中清理未使用的心跳常量和调度逻辑。
- 在心跳不再由前端触发的前提下，移除未使用的 tauri 特定 `invoke` 引用。

Chores:
- 通过删除心跳初始化调用来简化应用启动流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove obsolete frontend heartbeat mechanism from the main Vue application bootstrap.

Enhancements:
- Clean up unused heartbeat constants and scheduling logic from the frontend entrypoint.
- Remove unused tauri-specific invoke import now that heartbeat is no longer triggered from the frontend.

Chores:
- Simplify application startup by eliminating the heartbeat initialization call.

</details>