### PR TITLE
refactor: 完善服务器重启契约

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,9 +5230,11 @@ dependencies = [
 name = "sealantern-core"
 version = "1.2.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tokio",
  "tracing",
  "zip",
 ]

--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -16,7 +16,10 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use sealantern_core::instance::{Instance, InstanceId, StartupMode};
+use sealantern_core::instance::{
+    restart_instance, Instance, InstanceId, InstanceLifecycleState, InstanceRestartDriver,
+    RestartPolicy, StartupMode,
+};
 use sealantern_core::process::{
     build_command, CommandBuildMode, CommandBuildRequest, Daemon, JavaEnvironment, Terminal,
     TerminalOutput, TerminalStream, WindowsConsoleEncoding,
@@ -37,6 +40,41 @@ const POLL_INTERVAL: Duration = Duration::from_millis(200);
 struct ManagedProcess {
     daemon: Daemon,
     terminal: Terminal,
+}
+
+struct ServerRestartDriver<'a> {
+    service: &'a CoreServerService,
+}
+
+#[async_trait]
+impl InstanceRestartDriver for ServerRestartDriver<'_> {
+    type Error = ServerServiceError;
+
+    async fn state(&self, instance: &Instance) -> Result<InstanceLifecycleState, Self::Error> {
+        let snapshot = self.service.status(&instance.id).await?;
+        Ok(match snapshot.state {
+            ServerState::Starting => InstanceLifecycleState::Starting,
+            ServerState::Running => InstanceLifecycleState::Running,
+            ServerState::Stopping => InstanceLifecycleState::Stopping,
+            ServerState::Stopped => InstanceLifecycleState::Stopped,
+        })
+    }
+
+    async fn request_stop(&self, instance: &Instance) -> Result<(), Self::Error> {
+        self.service.stop(&instance.id).await
+    }
+
+    async fn await_terminal(
+        &self,
+        instance: &Instance,
+        _: Duration,
+    ) -> Result<InstanceLifecycleState, Self::Error> {
+        self.state(instance).await
+    }
+
+    async fn start(&self, instance: &Instance) -> Result<(), Self::Error> {
+        self.service.start(&instance.id).await
+    }
 }
 
 /// 基于 `core` 进程原语的服务器进程管理服务实现。
@@ -90,6 +128,11 @@ impl CoreServerService {
         // 组装 JVM 参数（Xmx/Xms/编码 + 实例自定义参数）。
         // 默认 JVM 参数（全局配置）当前为空，待配置功能恢复后接入。
         let jvm_arguments = build_jvm_arguments(instance, "");
+        let custom_arguments = launch
+            .custom_arguments
+            .iter()
+            .map(OsString::from)
+            .collect::<Vec<_>>();
         // 从 Java 可执行文件推导 JAVA_HOME / bin（供脚本与自定义模式注入环境）。
         let java_environment = launch
             .java_executable
@@ -107,7 +150,7 @@ impl CoreServerService {
             entry_path: launch.startup_target.as_deref(),
             custom_command: launch.custom_command.as_deref(),
             custom_executable: launch.custom_executable.as_deref(),
-            custom_arguments: &[],
+            custom_arguments: &custom_arguments,
             installer_url: None,
             windows_console_encoding: WindowsConsoleEncoding::Utf8,
         };
@@ -277,6 +320,23 @@ impl ServerService for CoreServerService {
         // 进程已成功拉起并注册，退出 Starting 状态（Starting 仅覆盖 spawn 竞态窗口）。
         self.clear_starting(&id_str);
 
+        Ok(())
+    }
+
+    async fn restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let instance = self.find_instance(id).await?;
+        let driver = ServerRestartDriver { service: self };
+        restart_instance(&driver, &instance, RestartPolicy { stop_timeout: STOP_GRACEFUL_TIMEOUT })
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    target: "sealantern.application.server",
+                    instance_id = id.as_str(),
+                    error = %error,
+                    "failed to restart server process"
+                );
+                ServerServiceError::OperationFailed
+            })?;
         Ok(())
     }
 

--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -61,15 +61,25 @@ impl InstanceRestartDriver for ServerRestartDriver<'_> {
     }
 
     async fn request_stop(&self, instance: &Instance) -> Result<(), Self::Error> {
-        self.service.stop(&instance.id).await
+        self.service.request_stop_for_restart(&instance.id).await
     }
 
     async fn await_terminal(
         &self,
         instance: &Instance,
-        _: Duration,
+        timeout: Duration,
     ) -> Result<InstanceLifecycleState, Self::Error> {
-        self.state(instance).await
+        let deadline = Instant::now() + timeout;
+        loop {
+            let state = self.state(instance).await?;
+            if !state.is_active() || Instant::now() >= deadline {
+                return Ok(state);
+            }
+            tokio::time::sleep(
+                POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())),
+            )
+            .await;
+        }
     }
 
     async fn start(&self, instance: &Instance) -> Result<(), Self::Error> {
@@ -403,6 +413,13 @@ impl ServerService for CoreServerService {
 }
 
 impl CoreServerService {
+    /// 为重启流程请求优雅停止，不等待退出或执行超时强杀。
+    async fn request_stop_for_restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        self.send_command_inner(id, "stop").await?;
+        self.mark_stopping(id.as_str());
+        Ok(())
+    }
+
     /// 向服务器控制台发送命令（内部实现）。
     async fn send_command_inner(
         &self,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,11 +8,15 @@ license = "GPL-3.0-only"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = "0.1.91"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tracing = "0.1"
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+tokio = { version = "1.53.1", features = ["macros", "rt"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci_skip_validation)'] }

--- a/crates/core/src/instance/lifecycle.rs
+++ b/crates/core/src/instance/lifecycle.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::time::Duration;
 
+use async_trait::async_trait;
+
 use super::Instance;
 use crate::observability;
 
@@ -108,24 +110,25 @@ impl Default for RestartPolicy {
 /// 运行时驱动完成重启所需的最小能力。
 ///
 /// 具体轮询、进程控制、Docker 调用和异步实现均由上层运行时提供。
-pub trait InstanceRestartDriver {
+#[async_trait]
+pub trait InstanceRestartDriver: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
-    fn state(&self, instance: &Instance) -> Result<InstanceLifecycleState, Self::Error>;
+    async fn state(&self, instance: &Instance) -> Result<InstanceLifecycleState, Self::Error>;
 
-    fn request_stop(&self, instance: &Instance) -> Result<(), Self::Error>;
+    async fn request_stop(&self, instance: &Instance) -> Result<(), Self::Error>;
 
     /// 等待停止请求完成。
     ///
     /// 只有返回 [`InstanceLifecycleState::Stopped`] 才表示运行时已确认旧实例退出；
     /// 其他状态会被重启流程作为失败处理，绝不会继续启动新实例。
-    fn await_terminal(
+    async fn await_terminal(
         &self,
         instance: &Instance,
         timeout: Duration,
     ) -> Result<InstanceLifecycleState, Self::Error>;
 
-    fn start(&self, instance: &Instance) -> Result<(), Self::Error>;
+    async fn start(&self, instance: &Instance) -> Result<(), Self::Error>;
 }
 
 /// 重启完成后的领域结果。
@@ -177,7 +180,7 @@ impl<E: std::error::Error + 'static> std::error::Error for RestartError<E> {
 }
 
 /// 执行一次由运行时驱动提供具体能力的重启。
-pub fn restart_instance<D: InstanceRestartDriver>(
+pub async fn restart_instance<D: InstanceRestartDriver>(
     driver: &D,
     instance: &Instance,
     policy: RestartPolicy,
@@ -186,7 +189,7 @@ pub fn restart_instance<D: InstanceRestartDriver>(
         instance.id.as_str(),
         observability::INSTANCE_PREVIOUS_STATE_UNAVAILABLE,
     );
-    let previous_state = match driver.state(instance) {
+    let previous_state = match driver.state(instance).await {
         Ok(state) => state,
         Err(error) => {
             let error = RestartError::State(error);
@@ -203,7 +206,7 @@ pub fn restart_instance<D: InstanceRestartDriver>(
 
     let stop_requested = previous_state.requires_stop_before_restart();
     if stop_requested {
-        if let Err(error) = driver.request_stop(instance) {
+        if let Err(error) = driver.request_stop(instance).await {
             let error = RestartError::Stop(error);
             observability::instance_restart_failed(
                 instance.id.as_str(),
@@ -215,7 +218,7 @@ pub fn restart_instance<D: InstanceRestartDriver>(
             return Err(error);
         }
 
-        let terminal_state = match driver.await_terminal(instance, policy.stop_timeout) {
+        let terminal_state = match driver.await_terminal(instance, policy.stop_timeout).await {
             Ok(state) => state,
             Err(error) => {
                 let error = RestartError::AwaitTerminal(error);
@@ -242,7 +245,7 @@ pub fn restart_instance<D: InstanceRestartDriver>(
         }
     }
 
-    if let Err(error) = driver.start(instance) {
+    if let Err(error) = driver.start(instance).await {
         let error = RestartError::Start(error);
         observability::instance_restart_failed(
             instance.id.as_str(),
@@ -260,21 +263,22 @@ pub fn restart_instance<D: InstanceRestartDriver>(
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
     use std::io;
     use std::path::PathBuf;
+    use std::sync::Mutex;
 
     use super::{
         restart_instance, transition, InstanceLifecycleAction, InstanceLifecycleState,
         InstanceRestartDriver, RestartPolicy,
     };
     use crate::instance::{Instance, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+    use async_trait::async_trait;
 
     struct Driver {
         state: InstanceLifecycleState,
         terminal: InstanceLifecycleState,
         fail_at: Option<DriverFailure>,
-        calls: RefCell<Vec<&'static str>>,
+        calls: Mutex<Vec<&'static str>>,
     }
 
     #[derive(Clone, Copy)]
@@ -285,39 +289,40 @@ mod tests {
         Start,
     }
 
+    #[async_trait]
     impl InstanceRestartDriver for Driver {
         type Error = io::Error;
 
-        fn state(&self, _: &Instance) -> Result<InstanceLifecycleState, Self::Error> {
-            self.calls.borrow_mut().push("state");
+        async fn state(&self, _: &Instance) -> Result<InstanceLifecycleState, Self::Error> {
+            self.calls.lock().expect("lock").push("state");
             if matches!(self.fail_at, Some(DriverFailure::State)) {
                 return Err(io::Error::other("state unavailable"));
             }
             Ok(self.state)
         }
 
-        fn request_stop(&self, _: &Instance) -> Result<(), Self::Error> {
-            self.calls.borrow_mut().push("stop");
+        async fn request_stop(&self, _: &Instance) -> Result<(), Self::Error> {
+            self.calls.lock().expect("lock").push("stop");
             if matches!(self.fail_at, Some(DriverFailure::Stop)) {
                 return Err(io::Error::other("stop unavailable"));
             }
             Ok(())
         }
 
-        fn await_terminal(
+        async fn await_terminal(
             &self,
             _: &Instance,
             _: std::time::Duration,
         ) -> Result<InstanceLifecycleState, Self::Error> {
-            self.calls.borrow_mut().push("wait");
+            self.calls.lock().expect("lock").push("wait");
             if matches!(self.fail_at, Some(DriverFailure::AwaitTerminal)) {
                 return Err(io::Error::other("wait unavailable"));
             }
             Ok(self.terminal)
         }
 
-        fn start(&self, _: &Instance) -> Result<(), Self::Error> {
-            self.calls.borrow_mut().push("start");
+        async fn start(&self, _: &Instance) -> Result<(), Self::Error> {
+            self.calls.lock().expect("lock").push("start");
             if matches!(self.fail_at, Some(DriverFailure::Start)) {
                 return Err(io::Error::other("start unavailable"));
             }
@@ -353,100 +358,107 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn restart_stops_waits_and_starts_an_active_instance() {
+    #[tokio::test]
+    async fn restart_stops_waits_and_starts_an_active_instance() {
         let driver = Driver {
             state: InstanceLifecycleState::Running,
             terminal: InstanceLifecycleState::Stopped,
             fail_at: None,
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
 
-        let result = restart_instance(&driver, &instance(), RestartPolicy::default()).unwrap();
+        let result = restart_instance(&driver, &instance(), RestartPolicy::default())
+            .await
+            .unwrap();
 
         assert!(result.stop_requested);
-        assert_eq!(*driver.calls.borrow(), ["state", "stop", "wait", "start"]);
+        assert_eq!(*driver.calls.lock().expect("lock"), ["state", "stop", "wait", "start"]);
     }
 
-    #[test]
-    fn restart_starts_a_stopped_instance_without_a_stop_request() {
+    #[tokio::test]
+    async fn restart_starts_a_stopped_instance_without_a_stop_request() {
         let driver = Driver {
             state: InstanceLifecycleState::Stopped,
             terminal: InstanceLifecycleState::Stopped,
             fail_at: None,
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
 
-        let result = restart_instance(&driver, &instance(), RestartPolicy::default()).unwrap();
+        let result = restart_instance(&driver, &instance(), RestartPolicy::default())
+            .await
+            .unwrap();
 
         assert!(!result.stop_requested);
-        assert_eq!(*driver.calls.borrow(), ["state", "start"]);
+        assert_eq!(*driver.calls.lock().expect("lock"), ["state", "start"]);
     }
 
-    #[test]
-    fn restart_does_not_start_when_stop_ends_in_error() {
+    #[tokio::test]
+    async fn restart_does_not_start_when_stop_ends_in_error() {
         let driver = Driver {
             state: InstanceLifecycleState::Running,
             terminal: InstanceLifecycleState::Error,
             fail_at: None,
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
 
-        let result = restart_instance(&driver, &instance(), RestartPolicy::default());
+        let result = restart_instance(&driver, &instance(), RestartPolicy::default()).await;
 
         assert!(matches!(
             result,
             Err(super::RestartError::TerminalState { state: InstanceLifecycleState::Error })
         ));
-        assert_eq!(*driver.calls.borrow(), ["state", "stop", "wait"]);
+        assert_eq!(*driver.calls.lock().expect("lock"), ["state", "stop", "wait"]);
     }
 
-    #[test]
-    fn restart_returns_a_state_read_failure_without_calling_the_driver_again() {
+    #[tokio::test]
+    async fn restart_returns_a_state_read_failure_without_calling_the_driver_again() {
         let driver = Driver {
             state: InstanceLifecycleState::Stopped,
             terminal: InstanceLifecycleState::Stopped,
             fail_at: Some(DriverFailure::State),
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
 
-        let result = restart_instance(&driver, &instance(), RestartPolicy::default());
+        let result = restart_instance(&driver, &instance(), RestartPolicy::default()).await;
 
         assert!(matches!(result, Err(super::RestartError::State(_))));
-        assert_eq!(*driver.calls.borrow(), ["state"]);
+        assert_eq!(*driver.calls.lock().expect("lock"), ["state"]);
     }
 
-    #[test]
-    fn restart_propagates_each_runtime_failure_without_continuing() {
+    #[tokio::test]
+    async fn restart_propagates_each_runtime_failure_without_continuing() {
         let stop_driver = Driver {
             state: InstanceLifecycleState::Running,
             terminal: InstanceLifecycleState::Stopped,
             fail_at: Some(DriverFailure::Stop),
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
-        let stop_result = restart_instance(&stop_driver, &instance(), RestartPolicy::default());
+        let stop_result =
+            restart_instance(&stop_driver, &instance(), RestartPolicy::default()).await;
         assert!(matches!(stop_result, Err(super::RestartError::Stop(_))));
-        assert_eq!(*stop_driver.calls.borrow(), ["state", "stop"]);
+        assert_eq!(*stop_driver.calls.lock().expect("lock"), ["state", "stop"]);
 
         let wait_driver = Driver {
             state: InstanceLifecycleState::Running,
             terminal: InstanceLifecycleState::Stopped,
             fail_at: Some(DriverFailure::AwaitTerminal),
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
-        let wait_result = restart_instance(&wait_driver, &instance(), RestartPolicy::default());
+        let wait_result =
+            restart_instance(&wait_driver, &instance(), RestartPolicy::default()).await;
         assert!(matches!(wait_result, Err(super::RestartError::AwaitTerminal(_))));
-        assert_eq!(*wait_driver.calls.borrow(), ["state", "stop", "wait"]);
+        assert_eq!(*wait_driver.calls.lock().expect("lock"), ["state", "stop", "wait"]);
 
         let start_driver = Driver {
             state: InstanceLifecycleState::Stopped,
             terminal: InstanceLifecycleState::Stopped,
             fail_at: Some(DriverFailure::Start),
-            calls: RefCell::new(Vec::new()),
+            calls: Mutex::new(Vec::new()),
         };
-        let start_result = restart_instance(&start_driver, &instance(), RestartPolicy::default());
+        let start_result =
+            restart_instance(&start_driver, &instance(), RestartPolicy::default()).await;
         assert!(matches!(start_result, Err(super::RestartError::Start(_))));
-        assert_eq!(*start_driver.calls.borrow(), ["state", "start"]);
+        assert_eq!(*start_driver.calls.lock().expect("lock"), ["state", "start"]);
     }
 
     #[test]

--- a/crates/interface/src/server/service.rs
+++ b/crates/interface/src/server/service.rs
@@ -23,6 +23,11 @@ pub trait ServerService: Send + Sync {
     /// 启动实例对应的服务器进程。
     async fn start(&self, id: &InstanceId) -> Result<(), ServerServiceError>;
 
+    /// 按实例当前生命周期状态完成一次重启。
+    ///
+    /// 已停止实例直接启动；活动实例必须先确认停止后才能再次启动。
+    async fn restart(&self, id: &InstanceId) -> Result<(), ServerServiceError>;
+
     /// 优雅停止服务器进程（向控制台发送 stop 并等待退出，超时后强制终止）。
     async fn stop(&self, id: &InstanceId) -> Result<(), ServerServiceError>;
 


### PR DESCRIPTION
完善服务器重启生命周期契约，并修复自定义启动参数透传。

## Summary by Sourcery

优化服务器实例重启的生命周期，使用异步重启驱动并将其集成到应用服务器服务中，同时相应提升测试覆盖率和构建依赖。

New Features:
- 在服务器服务中新增服务器重启操作，可根据实例当前的生命周期状态进行重启。

Bug Fixes:
- 修复在构建服务器启动命令时自定义启动参数的传递问题。

Enhancements:
- 使用异步 traits 使实例重启驱动和重启工作流完全异步且线程安全。
- 实现一个具体的服务器重启驱动，将服务器状态映射到实例生命周期状态，并将停止/启动操作委托给核心服务器服务。

Build:
- 为异步生命周期和测试添加 `async-trait` 作为核心依赖，并将 `tokio` 作为开发依赖。

Tests:
- 将实例重启测试转换为异步 `tokio` 测试，并适配新的异步重启驱动 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the server instance restart lifecycle to use an async restart driver and integrate it into the application server service, while improving test coverage and build dependencies accordingly.

New Features:
- Add a server restart operation to the server service that restarts instances based on their current lifecycle state.

Bug Fixes:
- Fix propagation of custom launch arguments when building server start commands.

Enhancements:
- Make the instance restart driver and restart workflow fully asynchronous and thread-safe using async traits.
- Implement a concrete server restart driver that maps server states onto instance lifecycle states and delegates stop/start operations to the core server service.

Build:
- Add async-trait as a core dependency and tokio as a dev dependency for async lifecycle and tests.

Tests:
- Convert instance restart tests to async tokio tests and adapt them to the new async restart driver API.

</details>