### PR TITLE
fix: 串行化服务器生命周期操作

### DIFF
--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -45,6 +45,7 @@ struct ManagedProcess {
 
 struct ServerRestartDriver<'a> {
     service: &'a CoreServerService,
+    _lifecycle_guard: &'a OwnedMutexGuard<()>,
 }
 
 #[async_trait]
@@ -53,12 +54,16 @@ impl InstanceRestartDriver for ServerRestartDriver<'_> {
 
     async fn state(&self, instance: &Instance) -> Result<InstanceLifecycleState, Self::Error> {
         let snapshot = self.service.status_for_instance(instance)?;
-        Ok(match snapshot.state {
+        let state = match snapshot.state {
             ServerState::Starting => InstanceLifecycleState::Starting,
             ServerState::Running => InstanceLifecycleState::Running,
             ServerState::Stopping => InstanceLifecycleState::Stopping,
             ServerState::Stopped => InstanceLifecycleState::Stopped,
-        })
+        };
+        if !state.is_active() {
+            self.service.clear_lifecycle_flags(instance.id.as_str());
+        }
+        Ok(state)
     }
 
     async fn request_stop(&self, instance: &Instance) -> Result<(), Self::Error> {
@@ -122,7 +127,7 @@ impl CoreServerService {
                 .map_err(|_| ServerError::Internal {
                     source: Box::new(std::io::Error::other("lifecycle locks poisoned")),
                 })?;
-            locks.retain(|_, lock| lock.strong_count() > 0);
+            // 失效弱引用只在对应实例再次访问时覆盖，避免每次获取都扫描整张表。
             if let Some(lock) = locks.get(id.as_str()).and_then(Weak::upgrade) {
                 lock
             } else {
@@ -238,6 +243,11 @@ impl CoreServerService {
         }
     }
 
+    fn clear_lifecycle_flags(&self, id: &str) {
+        self.clear_starting(id);
+        self.clear_stopping(id);
+    }
+
     fn status_for_instance(
         &self,
         instance: &Instance,
@@ -253,9 +263,6 @@ impl CoreServerService {
                 .unwrap_or(false);
             if !is_running {
                 processes.remove(&id_str);
-                drop(processes);
-                self.clear_starting(&id_str);
-                self.clear_stopping(&id_str);
                 return Ok(ServerSnapshot {
                     instance_id: id_str,
                     state: ServerState::Stopped,
@@ -303,9 +310,12 @@ impl ServerService for CoreServerService {
     }
 
     async fn restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
-        let _guard = self.lock_lifecycle(id).await?;
+        let lifecycle_guard = self.lock_lifecycle(id).await?;
         let instance = self.find_instance(id).await?;
-        let driver = ServerRestartDriver { service: self };
+        let driver = ServerRestartDriver {
+            service: self,
+            _lifecycle_guard: &lifecycle_guard,
+        };
         restart_instance(&driver, &instance, RestartPolicy { stop_timeout: STOP_GRACEFUL_TIMEOUT })
             .await
             .map_err(|error| {
@@ -455,12 +465,11 @@ impl CoreServerService {
 
         // 超时：强制终止进程树。
         let mut processes = self.processes_lock()?;
-        if let Some(managed) = processes.get_mut(&id_str) {
-            managed
-                .daemon
-                .terminate_tree()
-                .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
-            processes.remove(&id_str);
+        if let Some(mut managed) = processes.remove(&id_str) {
+            if let Err(error) = managed.daemon.terminate_tree() {
+                processes.insert(id_str.clone(), managed);
+                return Err(ServerError::OperationFailed { source: Box::new(error) }.into());
+            }
         }
         self.clear_stopping(&id_str);
         Ok(())
@@ -470,15 +479,13 @@ impl CoreServerService {
         let id_str = id.as_str().to_string();
 
         let mut processes = self.processes_lock()?;
-        if let Some(managed) = processes.get_mut(&id_str) {
-            managed
-                .daemon
-                .terminate_tree()
-                .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
-            processes.remove(&id_str);
+        if let Some(mut managed) = processes.remove(&id_str) {
+            if let Err(error) = managed.daemon.terminate_tree() {
+                processes.insert(id_str.clone(), managed);
+                return Err(ServerError::OperationFailed { source: Box::new(error) }.into());
+            }
         }
-        self.clear_starting(&id_str);
-        self.clear_stopping(&id_str);
+        self.clear_lifecycle_flags(&id_str);
         Ok(())
     }
 
@@ -624,11 +631,22 @@ mod tests {
                 .expect("second lock");
 
         drop(first_guard);
-        tokio::time::timeout(Duration::from_millis(20), service.lock_lifecycle(&first))
-            .await
-            .expect("same instance must continue after release")
-            .expect("reacquired lock");
         drop(second_guard);
+        let reacquired =
+            tokio::time::timeout(Duration::from_millis(20), service.lock_lifecycle(&first))
+                .await
+                .expect("same instance must continue after release")
+                .expect("reacquired lock");
+
+        let locks = service.lifecycle_locks.lock().expect("lifecycle locks");
+        assert_eq!(locks.len(), 2);
+        assert!(locks
+            .get(second.as_str())
+            .expect("second lock slot")
+            .upgrade()
+            .is_none());
+        drop(locks);
+        drop(reacquired);
 
         let _ = std::fs::remove_dir_all(path.parent().expect("parent"));
     }

--- a/application/src/service/server.rs
+++ b/application/src/service/server.rs
@@ -12,7 +12,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
@@ -26,6 +26,7 @@ use sealantern_core::process::{
 };
 use sealantern_interface::server::{ServerSnapshot, ServerState};
 use sealantern_interface::{InstanceService, ServerService, ServerServiceError};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
 use crate::error::ServerError;
 
@@ -51,7 +52,7 @@ impl InstanceRestartDriver for ServerRestartDriver<'_> {
     type Error = ServerServiceError;
 
     async fn state(&self, instance: &Instance) -> Result<InstanceLifecycleState, Self::Error> {
-        let snapshot = self.service.status(&instance.id).await?;
+        let snapshot = self.service.status_for_instance(instance)?;
         Ok(match snapshot.state {
             ServerState::Starting => InstanceLifecycleState::Starting,
             ServerState::Running => InstanceLifecycleState::Running,
@@ -83,7 +84,7 @@ impl InstanceRestartDriver for ServerRestartDriver<'_> {
     }
 
     async fn start(&self, instance: &Instance) -> Result<(), Self::Error> {
-        self.service.start(&instance.id).await
+        self.service.start_unlocked(&instance.id, instance).await
     }
 }
 
@@ -97,6 +98,8 @@ pub struct CoreServerService {
     starting: Mutex<HashSet<String>>,
     /// 停止中的实例集合。
     stopping: Mutex<HashSet<String>>,
+    /// 每个实例独立的生命周期操作锁。
+    lifecycle_locks: Mutex<HashMap<String, Weak<AsyncMutex<()>>>>,
 }
 
 impl CoreServerService {
@@ -107,7 +110,28 @@ impl CoreServerService {
             processes: Mutex::new(HashMap::new()),
             starting: Mutex::new(HashSet::new()),
             stopping: Mutex::new(HashSet::new()),
+            lifecycle_locks: Mutex::new(HashMap::new()),
         }
+    }
+
+    async fn lock_lifecycle(&self, id: &InstanceId) -> Result<OwnedMutexGuard<()>, ServerError> {
+        let lock = {
+            let mut locks = self
+                .lifecycle_locks
+                .lock()
+                .map_err(|_| ServerError::Internal {
+                    source: Box::new(std::io::Error::other("lifecycle locks poisoned")),
+                })?;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            if let Some(lock) = locks.get(id.as_str()).and_then(Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(AsyncMutex::new(()));
+                locks.insert(id.as_str().to_owned(), Arc::downgrade(&lock));
+                lock
+            }
+        };
+        Ok(lock.lock_owned().await)
     }
 
     /// 按实例 ID 查找实例记录。
@@ -213,16 +237,13 @@ impl CoreServerService {
             s.remove(id);
         }
     }
-}
 
-#[async_trait]
-impl ServerService for CoreServerService {
-    async fn status(&self, id: &InstanceId) -> Result<ServerSnapshot, ServerServiceError> {
-        // 确认实例存在，并复用实例信息避免重复查询与状态不一致。
-        let instance = self.find_instance(id).await?;
-        let id_str = id.as_str().to_string();
+    fn status_for_instance(
+        &self,
+        instance: &Instance,
+    ) -> Result<ServerSnapshot, ServerServiceError> {
+        let id_str = instance.id.as_str().to_owned();
         let started_at = instance.last_started_at_unix_secs;
-
         let mut processes = self.processes_lock()?;
         if let Some(managed) = processes.get_mut(&id_str) {
             let is_running = managed
@@ -230,30 +251,34 @@ impl ServerService for CoreServerService {
                 .poll()
                 .map(|status| status.is_none())
                 .unwrap_or(false);
-
+            if !is_running {
+                processes.remove(&id_str);
+                drop(processes);
+                self.clear_starting(&id_str);
+                self.clear_stopping(&id_str);
+                return Ok(ServerSnapshot {
+                    instance_id: id_str,
+                    state: ServerState::Stopped,
+                    pid: None,
+                    uptime_secs: None,
+                    error_message: None,
+                });
+            }
             let state = if self.is_stopping(&id_str) {
                 ServerState::Stopping
-            } else if is_running && self.is_starting(&id_str) {
+            } else if self.is_starting(&id_str) {
                 ServerState::Starting
-            } else if is_running {
-                ServerState::Running
             } else {
-                ServerState::Stopped
+                ServerState::Running
             };
-
             return Ok(ServerSnapshot {
                 instance_id: id_str,
                 state,
-                pid: if is_running {
-                    Some(managed.daemon.id())
-                } else {
-                    None
-                },
-                uptime_secs: started_at.and_then(|t| current_timestamp_secs().checked_sub(t)),
+                pid: Some(managed.daemon.id()),
+                uptime_secs: started_at.and_then(|time| current_timestamp_secs().checked_sub(time)),
                 error_message: None,
             });
         }
-
         Ok(ServerSnapshot {
             instance_id: id_str,
             state: ServerState::Stopped,
@@ -262,9 +287,62 @@ impl ServerService for CoreServerService {
             error_message: None,
         })
     }
+}
+
+#[async_trait]
+impl ServerService for CoreServerService {
+    async fn status(&self, id: &InstanceId) -> Result<ServerSnapshot, ServerServiceError> {
+        let instance = self.find_instance(id).await?;
+        self.status_for_instance(&instance)
+    }
 
     async fn start(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let _guard = self.lock_lifecycle(id).await?;
         let instance = self.find_instance(id).await?;
+        self.start_unlocked(id, &instance).await
+    }
+
+    async fn restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let _guard = self.lock_lifecycle(id).await?;
+        let instance = self.find_instance(id).await?;
+        let driver = ServerRestartDriver { service: self };
+        restart_instance(&driver, &instance, RestartPolicy { stop_timeout: STOP_GRACEFUL_TIMEOUT })
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    target: "sealantern.application.server",
+                    instance_id = id.as_str(),
+                    error = %error,
+                    "failed to restart server process"
+                );
+                ServerServiceError::OperationFailed
+            })?;
+        Ok(())
+    }
+
+    async fn stop(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let _guard = self.lock_lifecycle(id).await?;
+        self.find_instance(id).await?;
+        self.stop_unlocked(id).await
+    }
+
+    async fn force_stop(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+        let _guard = self.lock_lifecycle(id).await?;
+        self.find_instance(id).await?;
+        self.force_stop_unlocked(id)
+    }
+
+    async fn send_command(&self, id: &InstanceId, command: &str) -> Result<(), ServerServiceError> {
+        self.send_command_inner(id, command).await
+    }
+}
+
+impl CoreServerService {
+    async fn start_unlocked(
+        &self,
+        id: &InstanceId,
+        instance: &Instance,
+    ) -> Result<(), ServerServiceError> {
         let id_str = id.as_str().to_string();
 
         {
@@ -277,7 +355,7 @@ impl ServerService for CoreServerService {
             }
         }
 
-        let mut command = match self.build_process_command(&instance) {
+        let mut command = match self.build_process_command(instance) {
             Ok(command) => command,
             Err(error) => {
                 tracing::error!(
@@ -311,14 +389,28 @@ impl ServerService for CoreServerService {
         self.processes_lock()?
             .insert(id_str.clone(), ManagedProcess { daemon, terminal });
 
-        // 更新实例的最后启动时间。
-        let _ = self
-            .instance_service
-            .update_last_started(id)
-            .await
-            .map_err(|_| ServerError::OperationFailed {
+        // 启动元数据持久化失败时回滚进程，保证返回失败即没有运行中的新进程。
+        if let Err(error) = self.instance_service.update_last_started(id).await {
+            tracing::error!(
+                target: "sealantern.application.server",
+                instance_id = %id_str,
+                error = %error,
+                "failed to persist server start metadata"
+            );
+            if let Err(rollback_error) = self.force_stop_unlocked(id) {
+                tracing::error!(
+                    target: "sealantern.application.server",
+                    instance_id = %id_str,
+                    error = %rollback_error,
+                    "failed to roll back server process after metadata persistence failure"
+                );
+            }
+            self.clear_starting(&id_str);
+            return Err(ServerError::OperationFailed {
                 source: Box::new(std::io::Error::other("failed to update last started")),
-            })?;
+            }
+            .into());
+        }
 
         // 后台读取进程输出，避免管道阻塞（当前先消费，后续接入日志管线）。
         if let Some(managed) = self.processes_lock()?.get_mut(&id_str) {
@@ -333,29 +425,11 @@ impl ServerService for CoreServerService {
         Ok(())
     }
 
-    async fn restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
-        let instance = self.find_instance(id).await?;
-        let driver = ServerRestartDriver { service: self };
-        restart_instance(&driver, &instance, RestartPolicy { stop_timeout: STOP_GRACEFUL_TIMEOUT })
-            .await
-            .map_err(|error| {
-                tracing::error!(
-                    target: "sealantern.application.server",
-                    instance_id = id.as_str(),
-                    error = %error,
-                    "failed to restart server process"
-                );
-                ServerServiceError::OperationFailed
-            })?;
-        Ok(())
-    }
-
-    async fn stop(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+    async fn stop_unlocked(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
         let id_str = id.as_str().to_string();
-        self.find_instance(id).await?;
 
         // 优雅停止：向控制台发送 stop，等待退出。
-        let _ = self.send_command_inner(id, "stop").await;
+        self.send_command_inner(id, "stop").await?;
         self.mark_stopping(&id_str);
 
         let deadline = Instant::now() + STOP_GRACEFUL_TIMEOUT;
@@ -381,38 +455,33 @@ impl ServerService for CoreServerService {
 
         // 超时：强制终止进程树。
         let mut processes = self.processes_lock()?;
-        if let Some(mut managed) = processes.remove(&id_str) {
+        if let Some(managed) = processes.get_mut(&id_str) {
             managed
                 .daemon
                 .terminate_tree()
                 .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+            processes.remove(&id_str);
         }
         self.clear_stopping(&id_str);
         Ok(())
     }
 
-    async fn force_stop(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+    fn force_stop_unlocked(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
         let id_str = id.as_str().to_string();
-        self.find_instance(id).await?;
 
         let mut processes = self.processes_lock()?;
-        if let Some(mut managed) = processes.remove(&id_str) {
+        if let Some(managed) = processes.get_mut(&id_str) {
             managed
                 .daemon
                 .terminate_tree()
                 .map_err(|e| ServerError::OperationFailed { source: Box::new(e) })?;
+            processes.remove(&id_str);
         }
         self.clear_starting(&id_str);
         self.clear_stopping(&id_str);
         Ok(())
     }
 
-    async fn send_command(&self, id: &InstanceId, command: &str) -> Result<(), ServerServiceError> {
-        self.send_command_inner(id, command).await
-    }
-}
-
-impl CoreServerService {
     /// 为重启流程请求优雅停止，不等待退出或执行超时强杀。
     async fn request_stop_for_restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
         self.send_command_inner(id, "stop").await?;
@@ -512,4 +581,55 @@ fn build_jvm_arguments(instance: &Instance, default_jvm_args: &str) -> Vec<OsStr
 
     args.extend(instance.launch.jvm_arguments.iter().map(OsString::from));
     args
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use sealantern_core::instance::InstanceId;
+
+    use super::{CoreInstanceService, CoreServerService};
+
+    fn registry_path() -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("sealantern-server-lock-{}-{nonce}", std::process::id()))
+            .join("instances.json")
+    }
+
+    #[tokio::test]
+    async fn lifecycle_operations_serialize_per_instance() {
+        let path = registry_path();
+        let instances = CoreInstanceService::with_path(&path)
+            .await
+            .expect("instance service");
+        let service = CoreServerService::new(Arc::new(instances));
+        let first = InstanceId::new("first").expect("first id");
+        let second = InstanceId::new("second").expect("second id");
+
+        let first_guard = service.lock_lifecycle(&first).await.expect("first lock");
+        assert!(tokio::time::timeout(Duration::from_millis(20), service.lock_lifecycle(&first))
+            .await
+            .is_err());
+        let second_guard =
+            tokio::time::timeout(Duration::from_millis(20), service.lock_lifecycle(&second))
+                .await
+                .expect("different instance must not wait")
+                .expect("second lock");
+
+        drop(first_guard);
+        tokio::time::timeout(Duration::from_millis(20), service.lock_lifecycle(&first))
+            .await
+            .expect("same instance must continue after release")
+            .expect("reacquired lock");
+        drop(second_guard);
+
+        let _ = std::fs::remove_dir_all(path.parent().expect("parent"));
+    }
 }


### PR DESCRIPTION
按实例串行执行服务器生命周期操作，并修复失败状态下的进程所有权处理。

## Summary by Sourcery

针对每个实例串行化服务器生命周期操作，并在失败时改进进程归属处理。

Bug Fixes（错误修复）:
- 确保服务器状态能够正确反映已停止的进程，并清理进程追踪和生命周期标记。
- 当持久化启动元数据失败时，回滚新启动的服务器进程，防止出现孤立运行的进程。
- 修复重启、停止和强制停止操作，以避免在进程缺失或生命周期标记过期时出现 panic 和状态不一致。

Enhancements（增强）:
- 引入基于实例的异步生命周期锁，防止在同一实例上并发执行生命周期操作。
- 将服务器生命周期方法重构为“加锁版”和“未加锁版”，以集中处理生命周期协调逻辑。
- 调整状态计算方式，使其依赖于实例级快照和一致的进程状态，从而简化生命周期状态转换。

Tests（测试）:
- 添加一项类似集成测试的用例，以验证生命周期操作在每个实例上是串行的，同时在不同实例之间仍然可以并发执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serialize server lifecycle operations per instance and improve process ownership handling on failures.

Bug Fixes:
- Ensure server status correctly reflects stopped processes and cleans up process tracking and lifecycle flags.
- Roll back newly started server processes when persisting start metadata fails, preventing orphaned running processes.
- Fix restart, stop, and force-stop operations to avoid panics and inconsistencies when processes are missing or lifecycle flags are stale.

Enhancements:
- Introduce per-instance asynchronous lifecycle locks to prevent concurrent lifecycle operations on the same instance.
- Refactor server lifecycle methods into locked and unlocked variants to centralize lifecycle coordination.
- Adjust status computation to rely on instance-level snapshots and consistent process state, simplifying lifecycle state transitions.

Tests:
- Add an integration-style test to verify that lifecycle operations are serialized per instance while remaining concurrent across instances.

</details>