### PR TITLE
feat: 暴露服务器重启接口

### DIFF
--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -11,6 +11,7 @@ pub use instance::{
     update_instance_path,
 };
 pub use server::{
-    force_stop_server, send_server_command, server_status, start_server, stop_server,
+    force_stop_server, restart_server, send_server_command, server_status, start_server,
+    stop_server,
 };
 pub use system::{directory_usage, process_usage, system_snapshot};

--- a/server/src/adapter/http/handlers/server.rs
+++ b/server/src/adapter/http/handlers/server.rs
@@ -1,6 +1,6 @@
 //! 服务器进程管理 REST handler。
 //!
-//! 提供服务器进程生命周期（状态/启动/停止/强制停止/控制台命令）接口，
+//! 提供服务器进程生命周期（状态/启动/重启/停止/强制停止/控制台命令）接口，
 //! 薄转发到 [`CoreServerService`](sealantern_application::service::CoreServerService)
 //! 并收敛错误为 [`HttpError`](super::super::error::HttpError)。
 
@@ -41,6 +41,21 @@ pub async fn start_server(
 ) -> Result<Json<ServerSnapshot>, HttpError> {
     let id = parse_id(&id)?;
     state.server().start(&id).await?;
+    state
+        .server()
+        .status(&id)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `POST /api/instances/{id}/restart` — 重启服务器进程。
+pub async fn restart_server(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ServerSnapshot>, HttpError> {
+    let id = parse_id(&id)?;
+    state.server().restart(&id).await?;
     state
         .server()
         .status(&id)

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -37,6 +37,7 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
         // ── 嵌套子资源（服务器进程生命周期） ──
         .route("/instances/{id}/status", get(handlers::server_status))
         .route("/instances/{id}/start", post(handlers::start_server))
+        .route("/instances/{id}/restart", post(handlers::restart_server))
         .route("/instances/{id}/stop", post(handlers::stop_server))
         .route(
             "/instances/{id}/force-stop",

--- a/src-tauri/src/adapter/tauri/commands/compat/instance_compat.rs
+++ b/src-tauri/src/adapter/tauri/commands/compat/instance_compat.rs
@@ -175,6 +175,14 @@ pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
     service.start(&id).await
 }
 
+/// 重启服务器（兼容 `restart_server`）。
+#[tauri::command]
+pub async fn restart_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_server(id)?;
+    service.restart(&id).await
+}
+
 /// 停止服务器（兼容 `stop_server`）。
 #[tauri::command]
 pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {

--- a/src-tauri/src/adapter/tauri/commands/server.rs
+++ b/src-tauri/src/adapter/tauri/commands/server.rs
@@ -42,6 +42,13 @@ pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
     service.start(&id).await
 }
 
+/// 重启服务器进程。
+pub async fn restart_server(id: String) -> Result<(), ServerServiceError> {
+    let service = server_service().await?;
+    let id = parse_id_for_tauri(id)?;
+    service.restart(&id).await
+}
+
 /// 优雅停止服务器进程。
 pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,8 +13,8 @@ use adapter::tauri::commands::compat::instance_compat::{
     add_existing_server, collect_copy_conflicts, copy_directory_contents, create_server,
     delete_server, force_stop_server, get_server_list, get_server_logs, get_server_status,
     import_modpack, import_server, parse_server_core_type, prepare_force_stop_server,
-    scan_startup_candidates, send_command, start_server, stop_server, update_server_name,
-    update_server_path, validate_server_path,
+    restart_server, scan_startup_candidates, send_command, start_server, stop_server,
+    update_server_name, update_server_path, validate_server_path,
 };
 use adapter::tauri::commands::compat::system_compat::{
     get_default_run_path, get_safe_mode_status, get_server_resource_usage, get_system_info,
@@ -73,6 +73,7 @@ pub fn run() {
             poll_task,
             prepare_force_stop_server,
             remove_file,
+            restart_server,
             scan_startup_candidates,
             send_command,
             start_server,


### PR DESCRIPTION
为 HTTP 与 Tauri 宿主暴露统一的服务器重启能力。POST /api/instances/{id}/restart 与 estart_server 均通过 ServerService::restart 调用 application 生命周期链路。

## Summary by Sourcery

通过 HTTP 和 Tauri 接口提供统一的服务器重启功能。

新功能：
- 添加 HTTP 端点 `POST /api/instances/{id}/restart`，用于重启服务器实例并返回其状态。
- 暴露用于重启服务器进程的 Tauri 命令，包括一个接入主命令集的兼容层命令。

改进：
- 更新服务器生命周期处理器和路由配置，将重启操作与现有的启动/停止/强制停止端点一起纳入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a unified server restart capability over both HTTP and Tauri interfaces.

New Features:
- Add HTTP endpoint POST /api/instances/{id}/restart to restart a server instance and return its status.
- Expose Tauri commands to restart server processes, including a compat-layer command wired into the main command set.

Enhancements:
- Update server lifecycle handler and router wiring to include restart operations alongside existing start/stop/force-stop endpoints.

</details>