### PR TITLE
feat: 接通定时任务应用链路

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,10 +5218,12 @@ name = "sealantern-application"
 version = "1.2.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "sealantern-core",
  "sealantern-extra",
  "sealantern-infra",
  "sealantern-interface",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",
@@ -5292,6 +5294,7 @@ name = "sealantern-interface"
 version = "1.2.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "sealantern-core",
  "serde",
  "serde_json",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -12,7 +12,11 @@ async-trait = "0.1.91"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "sync", "fs", "time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
+chrono = "0.4"
 sealantern-core = { path = "../crates/core" }
 sealantern-interface = { path = "../crates/interface" }
 sealantern-extra = { path = "../crates/extra" }
 sealantern-infra = { path = "../crates/infra" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/application/src/error/cron.rs
+++ b/application/src/error/cron.rs
@@ -1,0 +1,74 @@
+//! 服务器定时任务领域的主错误。
+
+use std::fmt;
+
+use sealantern_extra::server::cron_task::CronTaskError as ExtraCronTaskError;
+use sealantern_interface::CronTaskServiceError;
+
+/// 服务器定时任务操作失败的应用层主错误。
+#[derive(Debug)]
+pub enum CronTaskError {
+    /// 指定任务不存在。
+    TaskNotFound { source: ExtraCronTaskError },
+    /// 任务输入或 Cron 表达式不合法。
+    InvalidInput { source: ExtraCronTaskError },
+    /// JSON 持久化失败。
+    StorageFailed { source: ExtraCronTaskError },
+    /// 服务器动作执行失败。
+    ExecutionFailed { source: ExtraCronTaskError },
+    /// 该能力尚未实现。
+    Unsupported,
+}
+
+impl fmt::Display for CronTaskError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TaskNotFound { source } => write!(formatter, "cron task not found: {source}"),
+            Self::InvalidInput { source } => write!(formatter, "invalid cron task: {source}"),
+            Self::StorageFailed { source } => {
+                write!(formatter, "cron task storage failed: {source}")
+            }
+            Self::ExecutionFailed { source } => {
+                write!(formatter, "cron task execution failed: {source}")
+            }
+            Self::Unsupported => write!(formatter, "operation not supported"),
+        }
+    }
+}
+
+impl std::error::Error for CronTaskError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TaskNotFound { source }
+            | Self::InvalidInput { source }
+            | Self::StorageFailed { source }
+            | Self::ExecutionFailed { source } => Some(source),
+            Self::Unsupported => None,
+        }
+    }
+}
+
+impl From<ExtraCronTaskError> for CronTaskError {
+    fn from(source: ExtraCronTaskError) -> Self {
+        match source {
+            ExtraCronTaskError::TaskNotFound(_) => Self::TaskNotFound { source },
+            ExtraCronTaskError::InvalidTask(_) | ExtraCronTaskError::InvalidCron { .. } => {
+                Self::InvalidInput { source }
+            }
+            ExtraCronTaskError::Storage(_) => Self::StorageFailed { source },
+            ExtraCronTaskError::Execution { .. } => Self::ExecutionFailed { source },
+        }
+    }
+}
+
+impl From<CronTaskError> for CronTaskServiceError {
+    fn from(error: CronTaskError) -> Self {
+        match error {
+            CronTaskError::TaskNotFound { .. } => Self::TaskNotFound,
+            CronTaskError::InvalidInput { .. } => Self::InvalidInput,
+            CronTaskError::StorageFailed { .. } => Self::StorageFailed,
+            CronTaskError::ExecutionFailed { .. } => Self::ExecutionFailed,
+            CronTaskError::Unsupported => Self::Unsupported,
+        }
+    }
+}

--- a/application/src/error/cron.rs
+++ b/application/src/error/cron.rs
@@ -16,6 +16,8 @@ pub enum CronTaskError {
     StorageFailed { source: ExtraCronTaskError },
     /// 服务器动作执行失败。
     ExecutionFailed { source: ExtraCronTaskError },
+    /// 上游新增且尚未显式分类的错误。
+    Unexpected { source: ExtraCronTaskError },
     /// 该能力尚未实现。
     Unsupported,
 }
@@ -31,6 +33,9 @@ impl fmt::Display for CronTaskError {
             Self::ExecutionFailed { source } => {
                 write!(formatter, "cron task execution failed: {source}")
             }
+            Self::Unexpected { source } => {
+                write!(formatter, "cron task operation failed: {source}")
+            }
             Self::Unsupported => write!(formatter, "operation not supported"),
         }
     }
@@ -42,7 +47,8 @@ impl std::error::Error for CronTaskError {
             Self::TaskNotFound { source }
             | Self::InvalidInput { source }
             | Self::StorageFailed { source }
-            | Self::ExecutionFailed { source } => Some(source),
+            | Self::ExecutionFailed { source }
+            | Self::Unexpected { source } => Some(source),
             Self::Unsupported => None,
         }
     }
@@ -57,6 +63,10 @@ impl From<ExtraCronTaskError> for CronTaskError {
             }
             ExtraCronTaskError::Storage(_) => Self::StorageFailed { source },
             ExtraCronTaskError::Execution { .. } => Self::ExecutionFailed { source },
+            other => {
+                debug_assert!(false, "unmapped extra cron task error: {other}");
+                Self::Unexpected { source: other }
+            }
         }
     }
 }
@@ -68,6 +78,7 @@ impl From<CronTaskError> for CronTaskServiceError {
             CronTaskError::InvalidInput { .. } => Self::InvalidInput,
             CronTaskError::StorageFailed { .. } => Self::StorageFailed,
             CronTaskError::ExecutionFailed { .. } => Self::ExecutionFailed,
+            CronTaskError::Unexpected { .. } => Self::OperationFailed,
             CronTaskError::Unsupported => Self::Unsupported,
         }
     }

--- a/application/src/error/mod.rs
+++ b/application/src/error/mod.rs
@@ -6,6 +6,8 @@
 
 /// 配置管理领域错误。
 pub mod config;
+/// 服务器定时任务领域错误。
+pub mod cron;
 /// 下载任务管理领域错误。
 pub mod download;
 /// 实例管理领域错误。
@@ -18,6 +20,7 @@ pub mod server;
 pub mod system;
 
 pub use config::ConfigError;
+pub use cron::CronTaskError;
 pub use download::DownloadError;
 pub use instance::InstanceError;
 pub use plugin::PluginError;

--- a/application/src/service/cron.rs
+++ b/application/src/service/cron.rs
@@ -1,0 +1,381 @@
+//! 服务器定时任务服务实现。
+//!
+//! 使用 `extra` 的 Cron 调度与 JSON 持久化能力，并通过注入的
+//! [`ServerService`] 执行重启和控制台命令。宿主仅依赖 `interface` 契约。
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use sealantern_core::instance::InstanceId;
+use sealantern_extra::server::cron_task::{
+    CronTask as ExtraCronTask, CronTaskAction as ExtraCronTaskAction,
+    CronTaskDraft as ExtraCronTaskDraft, CronTaskError as ExtraCronTaskError,
+    CronTaskExecutor as ExtraCronTaskExecutor, CronTaskRun as ExtraCronTaskRun,
+    CronTaskService as ExtraCronTaskService,
+};
+use sealantern_infra::platform::get_app_data_dir;
+use sealantern_interface::cron::{CronTask, CronTaskAction, CronTaskDraft, CronTaskRun};
+use sealantern_interface::{
+    CronTaskService, CronTaskServiceError, ServerService, ServerServiceError,
+};
+
+use crate::error::CronTaskError;
+
+use super::CoreServerService;
+
+/// 定时任务 JSON 文件名，置于应用数据根目录。
+const CRON_TASKS_FILE: &str = "cron_tasks.json";
+
+struct ServerCronTaskExecutor<S> {
+    server: Arc<S>,
+}
+
+impl<S> Clone for ServerCronTaskExecutor<S> {
+    fn clone(&self) -> Self {
+        Self { server: self.server.clone() }
+    }
+}
+
+#[async_trait]
+impl<S> ExtraCronTaskExecutor for ServerCronTaskExecutor<S>
+where
+    S: ServerService + 'static,
+{
+    type Error = ServerServiceError;
+
+    async fn restart_server(&self, server_id: &str) -> Result<(), Self::Error> {
+        let id = parse_instance_id(server_id)?;
+        self.server.restart(&id).await
+    }
+
+    async fn send_server_command(&self, server_id: &str, command: &str) -> Result<(), Self::Error> {
+        let id = parse_instance_id(server_id)?;
+        self.server.send_command(&id, command).await
+    }
+}
+
+type InnerCronTaskService<S> = ExtraCronTaskService<ServerCronTaskExecutor<S>>;
+
+/// 基于 `extra` 调度实现与服务器进程契约的定时任务服务。
+pub struct CoreCronTaskService<S = CoreServerService>
+where
+    S: ServerService + 'static,
+{
+    path: PathBuf,
+    executor: ServerCronTaskExecutor<S>,
+    inner: tokio::sync::Mutex<Option<InnerCronTaskService<S>>>,
+}
+
+impl CoreCronTaskService<CoreServerService> {
+    /// 使用应用数据目录中的默认 JSON 文件构造服务。
+    pub fn new(server: Arc<CoreServerService>) -> Self {
+        Self::with_path(get_app_data_dir().join(CRON_TASKS_FILE), server)
+    }
+}
+
+impl<S> CoreCronTaskService<S>
+where
+    S: ServerService + 'static,
+{
+    /// 使用指定 JSON 路径构造服务，实际加载延迟到首次调用。
+    pub fn with_path(path: impl Into<PathBuf>, server: Arc<S>) -> Self {
+        Self {
+            path: path.into(),
+            executor: ServerCronTaskExecutor { server },
+            inner: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    /// 执行当前所有到期任务，供后续后台调度器周期调用。
+    pub async fn run_due(&self) -> Result<Vec<CronTaskRun>, CronTaskServiceError> {
+        let mut service = self.service().await?;
+        service
+            .as_mut()
+            .expect("cron task service initialized")
+            .run_due(Utc::now())
+            .await
+            .map(|runs| runs.into_iter().map(run_to_contract).collect())
+            .map_err(contract_error)
+    }
+
+    async fn service(
+        &self,
+    ) -> Result<tokio::sync::MutexGuard<'_, Option<InnerCronTaskService<S>>>, CronTaskServiceError>
+    {
+        let mut service = self.inner.lock().await;
+        if service.is_none() {
+            let loaded = ExtraCronTaskService::load(self.path.clone(), self.executor.clone())
+                .await
+                .map_err(contract_error)?;
+            *service = Some(loaded);
+        }
+        Ok(service)
+    }
+}
+
+#[async_trait]
+impl<S> CronTaskService for CoreCronTaskService<S>
+where
+    S: ServerService + 'static,
+{
+    async fn list(&self) -> Result<Vec<CronTask>, CronTaskServiceError> {
+        let service = self.service().await?;
+        Ok(service
+            .as_ref()
+            .expect("cron task service initialized")
+            .tasks()
+            .iter()
+            .cloned()
+            .map(task_to_contract)
+            .collect())
+    }
+
+    async fn create(&self, draft: CronTaskDraft) -> Result<CronTask, CronTaskServiceError> {
+        let mut service = self.service().await?;
+        service
+            .as_mut()
+            .expect("cron task service initialized")
+            .create(draft_to_extra(draft))
+            .await
+            .map(task_to_contract)
+            .map_err(contract_error)
+    }
+
+    async fn update(
+        &self,
+        id: &str,
+        draft: CronTaskDraft,
+    ) -> Result<CronTask, CronTaskServiceError> {
+        let mut service = self.service().await?;
+        service
+            .as_mut()
+            .expect("cron task service initialized")
+            .update(id, draft_to_extra(draft))
+            .await
+            .map(task_to_contract)
+            .map_err(contract_error)
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), CronTaskServiceError> {
+        let mut service = self.service().await?;
+        service
+            .as_mut()
+            .expect("cron task service initialized")
+            .delete(id)
+            .await
+            .map_err(contract_error)
+    }
+
+    async fn set_enabled(&self, id: &str, enabled: bool) -> Result<CronTask, CronTaskServiceError> {
+        let mut service = self.service().await?;
+        service
+            .as_mut()
+            .expect("cron task service initialized")
+            .set_enabled(id, enabled)
+            .await
+            .map(task_to_contract)
+            .map_err(contract_error)
+    }
+
+    async fn run_now(&self, id: &str) -> Result<CronTaskRun, CronTaskServiceError> {
+        let mut service = self.service().await?;
+        service
+            .as_mut()
+            .expect("cron task service initialized")
+            .run_now(id, Utc::now())
+            .await
+            .map(run_to_contract)
+            .map_err(contract_error)
+    }
+}
+
+fn parse_instance_id(raw: &str) -> Result<InstanceId, ServerServiceError> {
+    InstanceId::new(raw.to_owned()).map_err(|_| ServerServiceError::InvalidInput)
+}
+
+fn contract_error(error: ExtraCronTaskError) -> CronTaskServiceError {
+    let error = CronTaskError::from(error);
+    tracing::error!(
+        target: "sealantern.application.cron_task",
+        error = %error,
+        "cron task operation failed"
+    );
+    error.into()
+}
+
+fn action_to_extra(action: CronTaskAction) -> ExtraCronTaskAction {
+    match action {
+        CronTaskAction::Restart => ExtraCronTaskAction::Restart,
+        CronTaskAction::Command { command } => ExtraCronTaskAction::Command { command },
+    }
+}
+
+fn action_to_contract(action: ExtraCronTaskAction) -> CronTaskAction {
+    match action {
+        ExtraCronTaskAction::Restart => CronTaskAction::Restart,
+        ExtraCronTaskAction::Command { command } => CronTaskAction::Command { command },
+    }
+}
+
+fn draft_to_extra(draft: CronTaskDraft) -> ExtraCronTaskDraft {
+    ExtraCronTaskDraft {
+        name: draft.name,
+        server_id: draft.server_id,
+        cron_expression: draft.cron_expression,
+        action: action_to_extra(draft.action),
+        enabled: draft.enabled,
+    }
+}
+
+fn task_to_contract(task: ExtraCronTask) -> CronTask {
+    CronTask {
+        id: task.id,
+        name: task.name,
+        server_id: task.server_id,
+        cron_expression: task.cron_expression,
+        action: action_to_contract(task.action),
+        enabled: task.enabled,
+        last_run_at: task.last_run_at,
+        next_run_at: task.next_run_at,
+        last_error: task.last_error,
+    }
+}
+
+fn run_to_contract(run: ExtraCronTaskRun) -> CronTaskRun {
+    CronTaskRun {
+        task_id: run.task_id,
+        server_id: run.server_id,
+        action: action_to_contract(run.action),
+        succeeded: run.succeeded,
+        error: run.error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use sealantern_interface::server::{ServerSnapshot, ServerState};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeServerService {
+        calls: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ServerService for FakeServerService {
+        async fn status(&self, id: &InstanceId) -> Result<ServerSnapshot, ServerServiceError> {
+            Ok(ServerSnapshot {
+                instance_id: id.as_str().to_owned(),
+                state: ServerState::Stopped,
+                pid: None,
+                uptime_secs: None,
+                error_message: None,
+            })
+        }
+
+        async fn start(&self, _id: &InstanceId) -> Result<(), ServerServiceError> {
+            Ok(())
+        }
+
+        async fn restart(&self, id: &InstanceId) -> Result<(), ServerServiceError> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(format!("restart:{}", id.as_str()));
+            Ok(())
+        }
+
+        async fn stop(&self, _id: &InstanceId) -> Result<(), ServerServiceError> {
+            Ok(())
+        }
+
+        async fn force_stop(&self, _id: &InstanceId) -> Result<(), ServerServiceError> {
+            Ok(())
+        }
+
+        async fn send_command(
+            &self,
+            id: &InstanceId,
+            command: &str,
+        ) -> Result<(), ServerServiceError> {
+            self.calls
+                .lock()
+                .expect("calls lock")
+                .push(format!("command:{}:{command}", id.as_str()));
+            Ok(())
+        }
+    }
+
+    fn draft(action: CronTaskAction) -> CronTaskDraft {
+        CronTaskDraft {
+            name: "测试任务".to_owned(),
+            server_id: "server-a".to_owned(),
+            cron_expression: "* * * * *".to_owned(),
+            action,
+            enabled: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn persists_tasks_and_executes_through_server_contract() {
+        let directory = tempdir().expect("temp directory");
+        let path = directory.path().join("cron_tasks.json");
+        let server = Arc::new(FakeServerService::default());
+        let service = CoreCronTaskService::with_path(&path, server.clone());
+
+        let restart = service
+            .create(draft(CronTaskAction::Restart))
+            .await
+            .expect("create restart task");
+        let command = service
+            .create(draft(CronTaskAction::Command { command: "say scheduled".to_owned() }))
+            .await
+            .expect("create command task");
+
+        service
+            .run_now(&restart.id)
+            .await
+            .expect("run restart task");
+        service
+            .run_now(&command.id)
+            .await
+            .expect("run command task");
+
+        assert_eq!(
+            *server.calls.lock().expect("calls lock"),
+            ["restart:server-a", "command:server-a:say scheduled"]
+        );
+        assert!(tokio::fs::read_to_string(&path)
+            .await
+            .expect("read persisted tasks")
+            .contains("say scheduled"));
+
+        let reloaded = CoreCronTaskService::with_path(path, server);
+        assert_eq!(reloaded.list().await.expect("reload tasks").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_server_id_before_calling_server_contract() {
+        let directory = tempdir().expect("temp directory");
+        let server = Arc::new(FakeServerService::default());
+        let service = CoreCronTaskService::with_path(
+            directory.path().join("cron_tasks.json"),
+            server.clone(),
+        );
+        let task = service
+            .create(CronTaskDraft {
+                server_id: "   ".to_owned(),
+                ..draft(CronTaskAction::Restart)
+            })
+            .await;
+
+        assert_eq!(task, Err(CronTaskServiceError::InvalidInput));
+        assert!(server.calls.lock().expect("calls lock").is_empty());
+    }
+}

--- a/application/src/service/cron.rs
+++ b/application/src/service/cron.rs
@@ -65,7 +65,7 @@ where
 {
     path: PathBuf,
     executor: ServerCronTaskExecutor<S>,
-    inner: tokio::sync::Mutex<Option<InnerCronTaskService<S>>>,
+    inner: tokio::sync::OnceCell<tokio::sync::Mutex<InnerCronTaskService<S>>>,
 }
 
 impl CoreCronTaskService<CoreServerService> {
@@ -84,7 +84,7 @@ where
         Self {
             path: path.into(),
             executor: ServerCronTaskExecutor { server },
-            inner: tokio::sync::Mutex::new(None),
+            inner: tokio::sync::OnceCell::new(),
         }
     }
 
@@ -92,8 +92,6 @@ where
     pub async fn run_due(&self) -> Result<Vec<CronTaskRun>, CronTaskServiceError> {
         let mut service = self.service().await?;
         service
-            .as_mut()
-            .expect("cron task service initialized")
             .run_due(Utc::now())
             .await
             .map(|runs| runs.into_iter().map(run_to_contract).collect())
@@ -102,16 +100,17 @@ where
 
     async fn service(
         &self,
-    ) -> Result<tokio::sync::MutexGuard<'_, Option<InnerCronTaskService<S>>>, CronTaskServiceError>
-    {
-        let mut service = self.inner.lock().await;
-        if service.is_none() {
-            let loaded = ExtraCronTaskService::load(self.path.clone(), self.executor.clone())
-                .await
-                .map_err(contract_error)?;
-            *service = Some(loaded);
-        }
-        Ok(service)
+    ) -> Result<tokio::sync::MutexGuard<'_, InnerCronTaskService<S>>, CronTaskServiceError> {
+        let service = self
+            .inner
+            .get_or_try_init(|| async {
+                ExtraCronTaskService::load(self.path.clone(), self.executor.clone())
+                    .await
+                    .map(tokio::sync::Mutex::new)
+                    .map_err(contract_error)
+            })
+            .await?;
+        Ok(service.lock().await)
     }
 }
 
@@ -123,8 +122,6 @@ where
     async fn list(&self) -> Result<Vec<CronTask>, CronTaskServiceError> {
         let service = self.service().await?;
         Ok(service
-            .as_ref()
-            .expect("cron task service initialized")
             .tasks()
             .iter()
             .cloned()
@@ -135,8 +132,6 @@ where
     async fn create(&self, draft: CronTaskDraft) -> Result<CronTask, CronTaskServiceError> {
         let mut service = self.service().await?;
         service
-            .as_mut()
-            .expect("cron task service initialized")
             .create(draft_to_extra(draft))
             .await
             .map(task_to_contract)
@@ -150,8 +145,6 @@ where
     ) -> Result<CronTask, CronTaskServiceError> {
         let mut service = self.service().await?;
         service
-            .as_mut()
-            .expect("cron task service initialized")
             .update(id, draft_to_extra(draft))
             .await
             .map(task_to_contract)
@@ -160,19 +153,12 @@ where
 
     async fn delete(&self, id: &str) -> Result<(), CronTaskServiceError> {
         let mut service = self.service().await?;
-        service
-            .as_mut()
-            .expect("cron task service initialized")
-            .delete(id)
-            .await
-            .map_err(contract_error)
+        service.delete(id).await.map_err(contract_error)
     }
 
     async fn set_enabled(&self, id: &str, enabled: bool) -> Result<CronTask, CronTaskServiceError> {
         let mut service = self.service().await?;
         service
-            .as_mut()
-            .expect("cron task service initialized")
             .set_enabled(id, enabled)
             .await
             .map(task_to_contract)
@@ -182,8 +168,6 @@ where
     async fn run_now(&self, id: &str) -> Result<CronTaskRun, CronTaskServiceError> {
         let mut service = self.service().await?;
         service
-            .as_mut()
-            .expect("cron task service initialized")
             .run_now(id, Utc::now())
             .await
             .map(run_to_contract)

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -1,14 +1,16 @@
 //! 应用层服务实现模块。
 //!
 //! 存放各类宿主能力的默认实现（如 [`CoreInstanceService`]、[`CoreSystemService`]、
-//! [`CoreServerService`]、[`CoreDownloadService`]），实现 `interface` 的能力端口，
-//! 由 `services` 装配层组装进全局容器。
+//! [`CoreServerService`]、[`CoreDownloadService`]、[`CoreCronTaskService`]），实现
+//! `interface` 的能力端口，由 `services` 装配层组装进全局容器。
 
+mod cron;
 mod download;
 mod instance;
 mod server;
 mod system;
 
+pub use cron::CoreCronTaskService;
 pub use download::CoreDownloadService;
 pub use instance::CoreInstanceService;
 pub use server::CoreServerService;

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -15,7 +15,8 @@ use std::sync::Arc;
 
 use crate::error::InstanceError;
 use crate::service::{
-    CoreDownloadService, CoreInstanceService, CoreServerService, CoreSystemService,
+    CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreServerService,
+    CoreSystemService,
 };
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
@@ -36,6 +37,8 @@ pub struct AppServicesInner {
     pub instance: Arc<CoreInstanceService>,
     /// 服务器进程管理服务。
     pub server: Arc<CoreServerService>,
+    /// 服务器定时任务服务。
+    pub cron: Arc<CoreCronTaskService>,
     /// 系统资源信息服务。
     pub system: Arc<CoreSystemService>,
 }
@@ -50,12 +53,14 @@ impl AppServices {
     /// 服务器进程服务共享同一实例服务句柄；下载/系统资源服务自动构造。
     pub fn from_inner(instance: CoreInstanceService) -> Self {
         let instance = Arc::new(instance);
+        let server = Arc::new(CoreServerService::new(instance.clone()));
         Self {
             inner: Arc::new(AppServicesInner {
                 download: Arc::new(
                     CoreDownloadService::new().expect("failed to init download service"),
                 ),
-                server: Arc::new(CoreServerService::new(instance.clone())),
+                cron: Arc::new(CoreCronTaskService::new(server.clone())),
+                server,
                 instance,
                 system: Arc::new(CoreSystemService),
             }),
@@ -132,6 +137,16 @@ impl AppServices {
     /// 便捷访问入口：一步拿到服务器进程管理服务的共享句柄（惰性初始化 + 可替换）。
     pub async fn server_service() -> Result<Arc<CoreServerService>, InstanceError> {
         Ok(Self::get().await?.server().clone())
+    }
+
+    /// 访问服务器定时任务服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn cron(&self) -> &Arc<CoreCronTaskService> {
+        &self.inner.cron
+    }
+
+    /// 便捷访问入口：一步拿到定时任务服务的共享句柄（惰性初始化 + 可替换）。
+    pub async fn cron_service() -> Result<Arc<CoreCronTaskService>, InstanceError> {
+        Ok(Self::get().await?.cron().clone())
     }
 
     /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。

--- a/crates/extra/src/server/cron_task/service.rs
+++ b/crates/extra/src/server/cron_task/service.rs
@@ -212,7 +212,7 @@ impl<E: CronTaskExecutor> CronTaskService<E> {
             let failed_run = CronTaskRun {
                 task_id: task.id.clone(),
                 server_id: task.server_id.clone(),
-                action: task.action.as_str(),
+                action: task.action.clone(),
                 succeeded: false,
                 error: None,
             };
@@ -253,7 +253,7 @@ impl<E: CronTaskExecutor> CronTaskService<E> {
         let run = CronTaskRun {
             task_id: task.id.clone(),
             server_id: task.server_id.clone(),
-            action,
+            action: task.action.clone(),
             succeeded: execution_error.is_none(),
             error: execution_error.clone(),
         };

--- a/crates/extra/src/server/cron_task/service.rs
+++ b/crates/extra/src/server/cron_task/service.rs
@@ -25,6 +25,7 @@ pub trait CronTaskExecutor: Send + Sync {
 
 /// Cron 任务服务错误。
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CronTaskError {
     Storage(FsError),
     TaskNotFound(String),

--- a/crates/interface/Cargo.toml
+++ b/crates/interface/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 async-trait = "0.1.91"
 tokio = { version = "1.53.1", features = ["rt", "macros"] }
 serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
 sealantern-core = { path = "../core" }
 
 [dev-dependencies]

--- a/crates/interface/src/cron/mod.rs
+++ b/crates/interface/src/cron/mod.rs
@@ -1,0 +1,7 @@
+//! 服务器定时任务契约。
+
+mod models;
+mod service;
+
+pub use models::{CronTask, CronTaskAction, CronTaskDraft, CronTaskRun};
+pub use service::CronTaskService;

--- a/crates/interface/src/cron/models.rs
+++ b/crates/interface/src/cron/models.rs
@@ -1,21 +1,14 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// 定时任务的实际服务器动作。
+/// 定时任务执行的服务器动作。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CronTaskAction {
+    /// 重启指定服务器。
     Restart,
+    /// 向指定服务器控制台发送命令。
     Command { command: String },
-}
-
-impl CronTaskAction {
-    pub(crate) const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Restart => "restart",
-            Self::Command { .. } => "command",
-        }
-    }
 }
 
 /// 创建或更新定时任务时可修改的字段。
@@ -28,7 +21,7 @@ pub struct CronTaskDraft {
     pub enabled: bool,
 }
 
-/// 已持久化的服务器定时任务。
+/// 宿主可见的定时任务快照。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CronTask {
     pub id: String,
@@ -42,14 +35,8 @@ pub struct CronTask {
     pub last_error: Option<String>,
 }
 
-/// 定时任务持久化文件的根对象。
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CronTaskList {
-    pub tasks: Vec<CronTask>,
-}
-
-/// 一次定时任务执行的结果。
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// 一次定时任务执行结果。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CronTaskRun {
     pub task_id: String,
     pub server_id: String,

--- a/crates/interface/src/cron/service.rs
+++ b/crates/interface/src/cron/service.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+
+use crate::error::CronTaskServiceError;
+
+use super::models::{CronTask, CronTaskDraft, CronTaskRun};
+
+/// 服务器定时任务宿主能力端口。
+///
+/// 实现方负责 JSON 持久化、Cron 表达式校验和服务器动作执行；传输层只消费
+/// 本契约，不直接依赖具体调度或存储实现。
+#[async_trait]
+pub trait CronTaskService: Send + Sync {
+    /// 列出全部定时任务。
+    async fn list(&self) -> Result<Vec<CronTask>, CronTaskServiceError>;
+
+    /// 创建并持久化定时任务。
+    async fn create(&self, draft: CronTaskDraft) -> Result<CronTask, CronTaskServiceError>;
+
+    /// 更新并持久化定时任务。
+    async fn update(
+        &self,
+        id: &str,
+        draft: CronTaskDraft,
+    ) -> Result<CronTask, CronTaskServiceError>;
+
+    /// 删除定时任务。
+    async fn delete(&self, id: &str) -> Result<(), CronTaskServiceError>;
+
+    /// 启用或禁用定时任务。
+    async fn set_enabled(&self, id: &str, enabled: bool) -> Result<CronTask, CronTaskServiceError>;
+
+    /// 立即执行一次指定任务，并更新运行记录和下次执行时间。
+    async fn run_now(&self, id: &str) -> Result<CronTaskRun, CronTaskServiceError>;
+}

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -15,6 +15,8 @@ pub enum CronTaskServiceError {
     StorageFailed,
     /// 任务对应的服务器动作执行失败。
     ExecutionFailed,
+    /// 未分类的内部操作失败。
+    OperationFailed,
     /// 该能力尚未实现。
     Unsupported,
 }
@@ -26,6 +28,7 @@ impl std::fmt::Display for CronTaskServiceError {
             Self::InvalidInput => "invalid cron task input",
             Self::StorageFailed => "cron task storage failed",
             Self::ExecutionFailed => "cron task execution failed",
+            Self::OperationFailed => "cron task operation failed",
             Self::Unsupported => "operation not supported",
         };
         formatter.write_str(message)

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -4,6 +4,36 @@
 //! 由 `application` 层的主错误（`application::error`）转换而来。
 //! 底层失败详情由应用层记录到受控日志，不跨传输面泄漏。
 
+/// 服务器定时任务操作失败的契约错误类别。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum CronTaskServiceError {
+    /// 指定的任务不存在。
+    TaskNotFound,
+    /// 任务配置或标识不合法。
+    InvalidInput,
+    /// JSON 持久化读写失败。
+    StorageFailed,
+    /// 任务对应的服务器动作执行失败。
+    ExecutionFailed,
+    /// 该能力尚未实现。
+    Unsupported,
+}
+
+impl std::fmt::Display for CronTaskServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::TaskNotFound => "cron task not found",
+            Self::InvalidInput => "invalid cron task input",
+            Self::StorageFailed => "cron task storage failed",
+            Self::ExecutionFailed => "cron task execution failed",
+            Self::Unsupported => "operation not supported",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for CronTaskServiceError {}
+
 /// 实例管理操作失败的契约错误类别。
 ///
 /// 分类风格与 `server` 侧 `ConsoleCommandServiceError` 保持一致：

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -20,10 +20,10 @@ pub mod system;
 
 /// 服务器定时任务服务端口。
 pub use cron::CronTaskService;
-/// 服务器定时任务错误枚举。
-pub use error::CronTaskServiceError;
 /// 下载任务管理服务端口。
 pub use download::DownloadService;
+/// 服务器定时任务错误枚举。
+pub use error::CronTaskServiceError;
 /// 下载任务管理错误枚举。
 pub use error::DownloadServiceError;
 /// 服务器实例管理错误枚举。

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -5,6 +5,8 @@
 
 #![forbid(unsafe_code)]
 
+/// 服务器定时任务相关模型与服务端口。
+pub mod cron;
 /// 下载任务管理相关模型与服务端口。
 pub mod download;
 /// 接口契约错误类型。
@@ -16,6 +18,10 @@ pub mod server;
 /// 系统资源信息相关模型与服务端口。
 pub mod system;
 
+/// 服务器定时任务服务端口。
+pub use cron::CronTaskService;
+/// 服务器定时任务错误枚举。
+pub use error::CronTaskServiceError;
 /// 下载任务管理服务端口。
 pub use download::DownloadService;
 /// 下载任务管理错误枚举。


### PR DESCRIPTION
新增 Cron 定时任务的 interface 契约与 application 默认实现，使用应用数据目录下的 JSON 文件持久化。application executor 将任务动作统一转发到 ServerService 的 restart/send_command，并装配进 AppServices。

## Summary by Sourcery

引入服务器定时任务（cron task）能力，并将其接入应用服务体系，使用基于 JSON 的持久化存储，并通过现有的 server service 路由执行。

新功能：
- 添加接口层级的 cron 任务模型、服务 trait，以及用于服务器定时任务的错误类型。
- 提供一个应用侧的 `CoreCronTaskService` 实现，通过 JSON 加载和持久化任务，并触发服务器重启或执行命令。
- 通过全局 `AppServices` 容器暴露 cron 任务服务和错误，以便于访问。

增强：
- 通过使用结构化的 `CronTaskAction` 替代静态字符串，使额外的 cron 任务模型和运行行为与新的约定保持一致。

构建：
- 在 interface 和 application crate 中添加 `chrono` 作为依赖，并添加 `tempfile` 作为 cron 任务测试的开发依赖。

测试：
- 为 `CoreCronTaskService` 添加类集成测试，覆盖持久化、通过 server 合同执行任务，以及对 server ID 的校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a server cron task capability wired into the application services, with JSON-backed persistence and execution routed through the existing server service.

New Features:
- Add interface-level cron task models, service trait, and error type for server scheduled tasks.
- Provide an application CoreCronTaskService implementation that loads and persists tasks via JSON and triggers server restarts or commands.
- Expose cron task services and errors through the global AppServices container for convenient access.

Enhancements:
- Align extra cron task models and runs with the new contract by using structured CronTaskAction instead of static strings.

Build:
- Add chrono as a dependency in interface and application crates and tempfile as a dev-dependency for cron task tests.

Tests:
- Add integration-style tests for CoreCronTaskService covering persistence, execution via server contract, and validation of server IDs.

</details>