### PR TITLE
feat: 启动定时任务后台调度

### DIFF
--- a/application/src/error/cron.rs
+++ b/application/src/error/cron.rs
@@ -64,7 +64,7 @@ impl From<ExtraCronTaskError> for CronTaskError {
             ExtraCronTaskError::Storage(_) => Self::StorageFailed { source },
             ExtraCronTaskError::Execution { .. } => Self::ExecutionFailed { source },
             other => {
-                debug_assert!(false, "unmapped extra cron task error: {other}");
+                debug_assert!(false, "unmapped extra cron task error: {:?}", other);
                 Self::Unexpected { source: other }
             }
         }

--- a/application/src/service/cron.rs
+++ b/application/src/service/cron.rs
@@ -4,7 +4,9 @@
 //! [`ServerService`] 执行重启和控制台命令。宿主仅依赖 `interface` 契约。
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -27,6 +29,15 @@ use super::CoreServerService;
 
 /// 定时任务 JSON 文件名，置于应用数据根目录。
 const CRON_TASKS_FILE: &str = "cron_tasks.json";
+/// 自动调度检查间隔；Cron 表达式支持秒级粒度。
+const SCHEDULER_TICK_INTERVAL: Duration = Duration::from_secs(1);
+/// 存储等系统错误发生后的退避时间，避免持续刷日志和磁盘。
+const SCHEDULER_ERROR_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+struct CronSchedulerHandle {
+    shutdown: tokio::sync::watch::Sender<bool>,
+    task: tokio::task::JoinHandle<()>,
+}
 
 struct ServerCronTaskExecutor<S> {
     server: Arc<S>,
@@ -66,6 +77,8 @@ where
     path: PathBuf,
     executor: ServerCronTaskExecutor<S>,
     inner: tokio::sync::OnceCell<tokio::sync::Mutex<InnerCronTaskService<S>>>,
+    scheduler: tokio::sync::Mutex<Option<CronSchedulerHandle>>,
+    scheduler_active: AtomicBool,
 }
 
 impl CoreCronTaskService<CoreServerService> {
@@ -85,7 +98,87 @@ where
             path: path.into(),
             executor: ServerCronTaskExecutor { server },
             inner: tokio::sync::OnceCell::new(),
+            scheduler: tokio::sync::Mutex::new(None),
+            scheduler_active: AtomicBool::new(true),
         }
+    }
+
+    /// 启动此服务的唯一后台调度器；已运行时返回 `false`。
+    pub async fn start_scheduler(self: &Arc<Self>) -> bool {
+        self.start_scheduler_with_intervals(SCHEDULER_TICK_INTERVAL, SCHEDULER_ERROR_RETRY_INTERVAL)
+            .await
+    }
+
+    /// 停止后台调度器并等待任务退出；未运行时返回 `false`。
+    pub async fn stop_scheduler(&self) -> bool {
+        let handle = self.scheduler.lock().await.take();
+        let Some(handle) = handle else {
+            return false;
+        };
+
+        let _ = handle.shutdown.send(true);
+        if let Err(error) = handle.task.await {
+            tracing::error!(
+                target: "sealantern.application.cron_task",
+                error = %error,
+                "cron scheduler task failed while stopping"
+            );
+        }
+        true
+    }
+
+    /// 永久停用此服务的后台调度器，供应用服务容器替换旧实例时调用。
+    pub(crate) async fn deactivate_scheduler(&self) {
+        self.scheduler_active.store(false, Ordering::Release);
+        self.stop_scheduler().await;
+    }
+
+    async fn start_scheduler_with_intervals(
+        self: &Arc<Self>,
+        tick_interval: Duration,
+        error_retry_interval: Duration,
+    ) -> bool {
+        if !self.scheduler_active.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut scheduler = self.scheduler.lock().await;
+        if !self.scheduler_active.load(Ordering::Acquire) {
+            return false;
+        }
+        if scheduler
+            .as_ref()
+            .is_some_and(|handle| !handle.task.is_finished())
+        {
+            return false;
+        }
+
+        let (shutdown, mut shutdown_rx) = tokio::sync::watch::channel(false);
+        let service = Arc::downgrade(self);
+        let task = tokio::spawn(async move {
+            let mut delay = tick_interval;
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    result = shutdown_rx.changed() => {
+                        if result.is_err() || *shutdown_rx.borrow() {
+                            break;
+                        }
+                        continue;
+                    }
+                }
+
+                let Some(service) = service.upgrade() else {
+                    break;
+                };
+                delay = match service.run_due().await {
+                    Ok(_) => tick_interval,
+                    Err(_) => error_retry_interval,
+                };
+            }
+        });
+
+        *scheduler = Some(CronSchedulerHandle { shutdown, task });
+        true
     }
 
     /// 执行当前所有到期任务，供后续后台调度器周期调用。
@@ -361,5 +454,63 @@ mod tests {
 
         assert_eq!(task, Err(CronTaskServiceError::InvalidInput));
         assert!(server.calls.lock().expect("calls lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn scheduler_runs_due_tasks_once_and_stops_cleanly() {
+        let directory = tempdir().expect("temp directory");
+        let server = Arc::new(FakeServerService::default());
+        let service = Arc::new(CoreCronTaskService::with_path(
+            directory.path().join("cron_tasks.json"),
+            server.clone(),
+        ));
+        service
+            .create(CronTaskDraft {
+                cron_expression: "* * * * * *".to_owned(),
+                ..draft(CronTaskAction::Restart)
+            })
+            .await
+            .expect("create scheduled task");
+
+        assert!(
+            service
+                .start_scheduler_with_intervals(
+                    Duration::from_millis(10),
+                    Duration::from_millis(20),
+                )
+                .await
+        );
+        assert!(
+            !service
+                .start_scheduler_with_intervals(
+                    Duration::from_millis(10),
+                    Duration::from_millis(20),
+                )
+                .await
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !server.calls.lock().expect("calls lock").is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("scheduler executes due task");
+
+        assert!(service.stop_scheduler().await);
+        assert!(!service.stop_scheduler().await);
+        service.deactivate_scheduler().await;
+        assert!(
+            !service
+                .start_scheduler_with_intervals(
+                    Duration::from_millis(10),
+                    Duration::from_millis(20),
+                )
+                .await
+        );
+        assert_eq!(*server.calls.lock().expect("calls lock"), ["restart:server-a"]);
     }
 }

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -73,8 +73,10 @@ impl AppServices {
     /// 并发首次调用也只初始化一次，其余等待并复用首个注册的结果。
     pub async fn get() -> Result<Self, InstanceError> {
         // 快速路径：已初始化直接返回（读锁，无 IO）。
-        if let Some(existing) = SERVICES.read().await.as_ref() {
-            return Ok(Self { inner: existing.clone() });
+        if let Some(existing) = SERVICES.read().await.clone() {
+            let services = Self { inner: existing };
+            services.start_background_services().await;
+            return Ok(services);
         }
 
         // 惰性构造：释放读锁后异步加载，避免持锁阻塞。
@@ -82,23 +84,31 @@ impl AppServices {
 
         // 注册：加写锁；若并发期间已有人注册，则复用其结果，丢弃本次构造。
         let mut guard = SERVICES.write().await;
-        Ok(Self {
-            inner: match guard.as_ref() {
-                Some(existing) => existing.clone(),
-                None => {
-                    guard.replace(built.inner.clone());
-                    built.inner.clone()
-                }
-            },
-        })
+        let inner = match guard.as_ref() {
+            Some(existing) => existing.clone(),
+            None => {
+                guard.replace(built.inner.clone());
+                built.inner.clone()
+            }
+        };
+        drop(guard);
+
+        let services = Self { inner };
+        services.start_background_services().await;
+        Ok(services)
     }
 
     /// 显式注册给定服务（启动预热 / 测试注入 / 重载用），覆盖既有实例。
     pub async fn register(instance: CoreInstanceService) -> Result<Self, InstanceError> {
         let services = Self::from_inner(instance);
         let inner = services.inner.clone();
-        *SERVICES.write().await = Some(inner.clone());
-        Ok(Self { inner })
+        let previous = SERVICES.write().await.replace(inner.clone());
+        if let Some(previous) = previous {
+            previous.cron.deactivate_scheduler().await;
+        }
+        let services = Self { inner };
+        services.start_background_services().await;
+        Ok(services)
     }
 
     /// 非阻塞尝试取全局服务；未初始化时返回 `None`（供无需初始化的路径判断）。
@@ -147,6 +157,15 @@ impl AppServices {
     /// 便捷访问入口：一步拿到定时任务服务的共享句柄（惰性初始化 + 可替换）。
     pub async fn cron_service() -> Result<Arc<CoreCronTaskService>, InstanceError> {
         Ok(Self::get().await?.cron().clone())
+    }
+
+    async fn start_background_services(&self) {
+        if self.inner.cron.start_scheduler().await {
+            tracing::info!(
+                target: "sealantern.application.cron_task",
+                "cron scheduler started"
+            );
+        }
     }
 
     /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -11,6 +11,7 @@
 //!
 //! `AppServices` 是内部 `Arc` 的轻量句柄（clone 廉价 → 可跨 async 边界随处持有）。
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::error::InstanceError;
@@ -31,6 +32,7 @@ pub struct AppServices {
 /// 后续新增服务只需在此加一个 `Arc<XxxService>` 字段，在 [`AppServices`]
 /// 下补一条 `pub async fn xxx_service()` 便捷函数即可，无需改动调用方。
 pub struct AppServicesInner {
+    background_started: AtomicBool,
     /// 下载任务管理服务。
     pub download: Arc<CoreDownloadService>,
     /// 服务器实例记录管理服务。
@@ -56,6 +58,7 @@ impl AppServices {
         let server = Arc::new(CoreServerService::new(instance.clone()));
         Self {
             inner: Arc::new(AppServicesInner {
+                background_started: AtomicBool::new(false),
                 download: Arc::new(
                     CoreDownloadService::new().expect("failed to init download service"),
                 ),
@@ -160,6 +163,14 @@ impl AppServices {
     }
 
     async fn start_background_services(&self) {
+        if self
+            .inner
+            .background_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
         if self.inner.cron.start_scheduler().await {
             tracing::info!(
                 target: "sealantern.application.cron_task",


### PR DESCRIPTION
依赖 #903。为 CoreCronTaskService 增加单实例后台 worker，由 AppServices 自动启动；worker 支持停止、错误退避和旧服务替换停用，并按秒检查到期任务。

## Summary by Sourcery

引入一个基于 cron 的服务器任务调度服务，使用单个后台 worker，由应用服务容器自动管理。

新特性：
- 添加 `CoreCronTaskService` 实现，用于持久化 cron 任务、执行服务器重启和命令，并通过 interface crate 暴露契约。
- 暴露 `CronTaskService` 接口、模型和错误类型，用于跨各层管理服务器 cron 任务，包括列表、CRUD、启用/禁用以及临时（ad‑hoc）执行。
- 将 cron 任务服务接入全局 `AppServices` 容器，采用惰性初始化，并自动启动后台调度循环。

缺陷修复：
- 确保 cron 任务运行记录在额外的 cron 任务模型中存储具体的动作类型，而不是静态字符串切片。

改进优化：
- 为 cron 任务操作添加应用层错误映射，将 extra 层错误转换为稳定的 interface 错误枚举。
- 将 `ExtraCronTaskError` 标记为 `non_exhaustive`，以便未来向后兼容地扩展错误类型。
- 为应用层和接口层依赖添加 `chrono` 和仅用于测试的工具，以支持基于时间的 cron 调度和持久化测试。

测试：
- 添加类似集成测试的用例，用于验证 cron 任务持久化、服务器契约执行、输入校验以及调度器生命周期行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a cron-based server task scheduling service with a single background worker that is automatically managed by the application service container.

New Features:
- Add a CoreCronTaskService implementation that persists cron tasks, executes server restarts and commands, and exposes a contract via the interface crate.
- Expose a CronTaskService interface, models, and error types for managing server cron tasks across layers, including listing, CRUD, enable/disable, and ad-hoc execution.
- Wire the cron task service into the global AppServices container with lazy initialization and automatic startup of a background scheduler loop.

Bug Fixes:
- Ensure cron task run records store the concrete action type instead of static string slices in the extra cron task models.

Enhancements:
- Add application-level error mapping for cron task operations from extra-layer errors into stable interface error enums.
- Mark the Extra CronTaskError as non_exhaustive to allow forward-compatible error expansion.
- Extend application and interface dependencies with chrono and test-only utilities to support time-based cron scheduling and persistence tests.

Tests:
- Add integration-style tests for cron task persistence, server contract execution, input validation, and scheduler lifecycle behaviour.

</details>