### PR TITLE
feat: 暴露定时任务宿主接口

### DIFF
--- a/crates/extra/src/server/cron_task/model.rs
+++ b/crates/extra/src/server/cron_task/model.rs
@@ -20,6 +20,7 @@ impl CronTaskAction {
 
 /// 创建或更新定时任务时可修改的字段。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CronTaskDraft {
     pub name: String,
     pub server_id: String,
@@ -30,6 +31,7 @@ pub struct CronTaskDraft {
 
 /// 已持久化的服务器定时任务。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CronTask {
     pub id: String,
     pub name: String,
@@ -44,6 +46,7 @@ pub struct CronTask {
 
 /// 定时任务持久化文件的根对象。
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CronTaskList {
     pub tasks: Vec<CronTask>,
 }

--- a/crates/interface/src/cron/models.rs
+++ b/crates/interface/src/cron/models.rs
@@ -13,6 +13,7 @@ pub enum CronTaskAction {
 
 /// 创建或更新定时任务时可修改的字段。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CronTaskDraft {
     pub name: String,
     pub server_id: String,
@@ -23,6 +24,7 @@ pub struct CronTaskDraft {
 
 /// 宿主可见的定时任务快照。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CronTask {
     pub id: String,
     pub name: String,
@@ -37,10 +39,45 @@ pub struct CronTask {
 
 /// 一次定时任务执行结果。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct CronTaskRun {
     pub task_id: String,
     pub server_id: String,
     pub action: CronTaskAction,
     pub succeeded: bool,
     pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CronTaskServiceError;
+
+    use super::{CronTaskAction, CronTaskDraft};
+
+    #[test]
+    fn cron_task_contract_uses_snake_case_fields() {
+        let draft = CronTaskDraft {
+            name: "Nightly restart".to_owned(),
+            server_id: "server-a".to_owned(),
+            cron_expression: "0 0 4 * * *".to_owned(),
+            action: CronTaskAction::Restart,
+            enabled: true,
+        };
+
+        let value = serde_json::to_value(draft).expect("serialize cron task draft");
+
+        assert_eq!(value["server_id"], "server-a");
+        assert_eq!(value["cron_expression"], "0 0 4 * * *");
+        assert_eq!(value["action"]["kind"], "restart");
+        assert!(value.get("serverId").is_none());
+        assert!(value.get("cronExpression").is_none());
+    }
+
+    #[test]
+    fn cron_task_errors_use_snake_case_variants() {
+        let value = serde_json::to_value(CronTaskServiceError::TaskNotFound)
+            .expect("serialize cron task error");
+
+        assert_eq!(value, "task_not_found");
+    }
 }

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -6,6 +6,7 @@
 
 /// 服务器定时任务操作失败的契约错误类别。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CronTaskServiceError {
     /// 指定的任务不存在。
     TaskNotFound,

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -9,7 +9,9 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::Serialize;
 
-use sealantern_interface::{InstanceServiceError, ServerServiceError, SystemServiceError};
+use sealantern_interface::{
+    CronTaskServiceError, InstanceServiceError, ServerServiceError, SystemServiceError,
+};
 
 /// 展平的 HTTP 错误响应体。
 #[derive(Debug, Serialize)]
@@ -32,6 +34,42 @@ pub struct HttpError {
 }
 
 impl HttpError {
+    /// 由定时任务契约错误构建 HTTP 错误。
+    pub fn from_cron_error(error: CronTaskServiceError) -> Self {
+        match error {
+            CronTaskServiceError::TaskNotFound => Self {
+                status: StatusCode::NOT_FOUND,
+                code: "cron_task_not_found",
+                message: error.to_string(),
+            },
+            CronTaskServiceError::InvalidInput => Self {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_cron_task",
+                message: error.to_string(),
+            },
+            CronTaskServiceError::StorageFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "cron_task_storage_failed",
+                message: error.to_string(),
+            },
+            CronTaskServiceError::ExecutionFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "cron_task_execution_failed",
+                message: error.to_string(),
+            },
+            CronTaskServiceError::OperationFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "cron_task_operation_failed",
+                message: error.to_string(),
+            },
+            CronTaskServiceError::Unsupported => Self {
+                status: StatusCode::NOT_IMPLEMENTED,
+                code: "operation_unsupported",
+                message: error.to_string(),
+            },
+        }
+    }
+
     /// 由接口契约错误构建 HTTP 错误。
     pub fn from_instance_error(error: InstanceServiceError) -> Self {
         match error {
@@ -142,6 +180,12 @@ impl HttpError {
 impl From<InstanceServiceError> for HttpError {
     fn from(error: InstanceServiceError) -> Self {
         Self::from_instance_error(error)
+    }
+}
+
+impl From<CronTaskServiceError> for HttpError {
+    fn from(error: CronTaskServiceError) -> Self {
+        Self::from_cron_error(error)
     }
 }
 

--- a/server/src/adapter/http/handlers/cron.rs
+++ b/server/src/adapter/http/handlers/cron.rs
@@ -1,0 +1,83 @@
+//! 服务器定时任务 REST handler。
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+
+use sealantern_interface::cron::{CronTask, CronTaskDraft, CronTaskRun};
+use sealantern_interface::CronTaskService;
+
+use super::super::error::HttpError;
+use super::super::state::AppState;
+
+/// 启停定时任务请求体。
+#[derive(Debug, serde::Deserialize)]
+pub struct SetEnabledRequest {
+    pub enabled: bool,
+}
+
+/// `GET /api/cron-tasks` — 列出全部定时任务。
+pub async fn list_cron_tasks(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<CronTask>>, HttpError> {
+    state.cron().list().await.map(Json).map_err(HttpError::from)
+}
+
+/// `POST /api/cron-tasks` — 创建定时任务。
+pub async fn create_cron_task(
+    State(state): State<AppState>,
+    Json(draft): Json<CronTaskDraft>,
+) -> Result<(StatusCode, Json<CronTask>), HttpError> {
+    let task = state.cron().create(draft).await?;
+    Ok((StatusCode::CREATED, Json(task)))
+}
+
+/// `PUT /api/cron-tasks/{id}` — 更新定时任务。
+pub async fn update_cron_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(draft): Json<CronTaskDraft>,
+) -> Result<Json<CronTask>, HttpError> {
+    state
+        .cron()
+        .update(&id, draft)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `DELETE /api/cron-tasks/{id}` — 删除定时任务。
+pub async fn delete_cron_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, HttpError> {
+    state.cron().delete(&id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `PUT /api/cron-tasks/{id}/enabled` — 启用或禁用定时任务。
+pub async fn set_cron_task_enabled(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(request): Json<SetEnabledRequest>,
+) -> Result<Json<CronTask>, HttpError> {
+    state
+        .cron()
+        .set_enabled(&id, request.enabled)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `POST /api/cron-tasks/{id}/run` — 立即执行一次定时任务。
+pub async fn run_cron_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<CronTaskRun>, HttpError> {
+    state
+        .cron()
+        .run_now(&id)
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}

--- a/server/src/adapter/http/handlers/cron.rs
+++ b/server/src/adapter/http/handlers/cron.rs
@@ -12,6 +12,7 @@ use super::super::state::AppState;
 
 /// 启停定时任务请求体。
 #[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct SetEnabledRequest {
     pub enabled: bool,
 }

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -2,10 +2,15 @@
 //!
 //! handler 只做传输层薄转发：解析请求 → 调用应用层服务 → 收敛错误。
 
+pub mod cron;
 pub mod instance;
 pub mod server;
 pub mod system;
 
+pub use cron::{
+    create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
+    update_cron_task,
+};
 pub use instance::{
     create_instance, delete_instance, get_instance, list_instances, rename_instance,
     update_instance_path,

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -56,9 +56,18 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
         .route("/system/process/{pid}", get(handlers::process_usage))
         .route("/system/directory/{*path}", get(handlers::directory_usage));
 
+    let cron_routes = Router::new()
+        .route("/cron-tasks", get(handlers::list_cron_tasks))
+        .route("/cron-tasks", post(handlers::create_cron_task))
+        .route("/cron-tasks/{id}", put(handlers::update_cron_task))
+        .route("/cron-tasks/{id}", delete(handlers::delete_cron_task))
+        .route("/cron-tasks/{id}/enabled", put(handlers::set_cron_task_enabled))
+        .route("/cron-tasks/{id}/run", post(handlers::run_cron_task));
+
     Router::new()
         .nest(API_PREFIX, instance_routes)
         .nest(API_PREFIX, system_routes)
+        .nest(API_PREFIX, cron_routes)
         .merge(spa_router(config))
         .with_state(state)
 }

--- a/server/src/adapter/http/state.rs
+++ b/server/src/adapter/http/state.rs
@@ -9,7 +9,9 @@
 
 use std::sync::Arc;
 
-use sealantern_application::service::{CoreInstanceService, CoreServerService, CoreSystemService};
+use sealantern_application::service::{
+    CoreCronTaskService, CoreInstanceService, CoreServerService, CoreSystemService,
+};
 use sealantern_application::services::AppServices;
 
 /// HTTP 层的共享应用状态。
@@ -34,6 +36,11 @@ impl AppState {
     /// 访问服务器进程管理服务（`Arc` 共享句柄，clone 廉价）。
     pub fn server(&self) -> Arc<CoreServerService> {
         self.services.server().clone()
+    }
+
+    /// 访问服务器定时任务服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn cron(&self) -> Arc<CoreCronTaskService> {
+        self.services.cron().clone()
     }
 
     /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。

--- a/src-tauri/src/adapter/tauri/commands/cron.rs
+++ b/src-tauri/src/adapter/tauri/commands/cron.rs
@@ -1,0 +1,57 @@
+//! 服务器定时任务 Tauri 命令。
+
+use std::sync::Arc;
+
+use sealantern_application::service::CoreCronTaskService;
+use sealantern_application::services::AppServices;
+use sealantern_interface::cron::{CronTask, CronTaskDraft, CronTaskRun};
+use sealantern_interface::{CronTaskService, CronTaskServiceError};
+
+async fn cron_service() -> Result<Arc<CoreCronTaskService>, CronTaskServiceError> {
+    let services = AppServices::get()
+        .await
+        .map_err(|_| CronTaskServiceError::OperationFailed)?;
+    Ok(services.cron().clone())
+}
+
+/// 列出全部定时任务。
+#[tauri::command]
+pub async fn list_cron_tasks() -> Result<Vec<CronTask>, CronTaskServiceError> {
+    cron_service().await?.list().await
+}
+
+/// 创建定时任务。
+#[tauri::command]
+pub async fn create_cron_task(draft: CronTaskDraft) -> Result<CronTask, CronTaskServiceError> {
+    cron_service().await?.create(draft).await
+}
+
+/// 更新定时任务。
+#[tauri::command]
+pub async fn update_cron_task(
+    id: String,
+    draft: CronTaskDraft,
+) -> Result<CronTask, CronTaskServiceError> {
+    cron_service().await?.update(&id, draft).await
+}
+
+/// 删除定时任务。
+#[tauri::command]
+pub async fn delete_cron_task(id: String) -> Result<(), CronTaskServiceError> {
+    cron_service().await?.delete(&id).await
+}
+
+/// 启用或禁用定时任务。
+#[tauri::command]
+pub async fn set_cron_task_enabled(
+    id: String,
+    enabled: bool,
+) -> Result<CronTask, CronTaskServiceError> {
+    cron_service().await?.set_enabled(&id, enabled).await
+}
+
+/// 立即执行一次定时任务。
+#[tauri::command]
+pub async fn run_cron_task(id: String) -> Result<CronTaskRun, CronTaskServiceError> {
+    cron_service().await?.run_now(&id).await
+}

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod compat;
+pub mod cron;
 pub mod download;
 pub mod instance;
 pub mod server;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,10 @@ use tauri::Manager;
 use adapter::tauri::commands::compat::download_compat::{
     cancel_download_task, download_file, poll_task,
 };
+use adapter::tauri::commands::cron::{
+    create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
+    update_cron_task,
+};
 use adapter::tauri::commands::compat::instance_compat::{
     add_existing_server, collect_copy_conflicts, copy_directory_contents, create_server,
     delete_server, force_stop_server, get_server_list, get_server_logs, get_server_status,
@@ -49,6 +53,13 @@ pub fn run() {
             desktop_pick_save_file,
             desktop_pick_server_executable,
             desktop_pick_startup_file,
+            //服务器定时任务契约命令
+            create_cron_task,
+            delete_cron_task,
+            list_cron_tasks,
+            run_cron_task,
+            set_cron_task_enabled,
+            update_cron_task,
             //兼容层（前端旧命令名 → 新服务，由adapter/tauri/commands/compat提供）
             add_existing_server,
             cancel_download_task,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,10 +9,6 @@ use tauri::Manager;
 use adapter::tauri::commands::compat::download_compat::{
     cancel_download_task, download_file, poll_task,
 };
-use adapter::tauri::commands::cron::{
-    create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
-    update_cron_task,
-};
 use adapter::tauri::commands::compat::instance_compat::{
     add_existing_server, collect_copy_conflicts, copy_directory_contents, create_server,
     delete_server, force_stop_server, get_server_list, get_server_logs, get_server_status,
@@ -23,6 +19,10 @@ use adapter::tauri::commands::compat::instance_compat::{
 use adapter::tauri::commands::compat::system_compat::{
     get_default_run_path, get_safe_mode_status, get_server_resource_usage, get_system_info,
     open_file, open_folder, remove_file, test_ipv6_connectivity,
+};
+use adapter::tauri::commands::cron::{
+    create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
+    update_cron_task,
 };
 use desktop::{
     desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,


### PR DESCRIPTION
依赖 #903 和 #904。为 HTTP 与 Tauri 暴露 Cron 任务列表、创建、更新、删除、启停及手动执行能力，统一消费 interface 契约并补齐 HTTP 错误映射。

## Summary by Sourcery

在应用层和接口层之间暴露统一的 cron 任务托管服务，并将其接入 HTTP 和 Tauri，使客户端可以管理和执行服务器端的定时任务。

New Features:
- 引入 `CronTaskService` 接口和相关模型，用于描述服务器端定时任务、其动作以及执行结果。
- 添加 Tauri 命令和 HTTP REST 接口，用于列出、创建、更新、删除、启用/禁用以及运行 cron 任务。
- 提供应用层的 `CoreCronTaskService`，用于将 cron 任务持久化到 JSON，校验输入，执行服务器动作，并运行后台调度器。

Bug Fixes:
- 对齐额外 cron 任务服务中的任务动作记录和执行方式，从存储静态字符串改为存储完整的动作枚举。

Enhancements:
- 扩展全局 `AppServices` 容器以及 HTTP/Tauri 状态，将 cron 任务服务纳入其中，并管理其后台调度器的生命周期，包括在服务被替换时的干净停用。
- 添加专门的 `CronTaskServiceError` 到 HTTP 错误响应映射，使 cron 相关失败返回合适的状态码和错误码。
- 将额外的 `CronTaskError` 标记为 `non_exhaustive`，并调整模型以在运行记录中使用类型化的 `CronTaskAction`。

Build:
- 在 application 和 interface crate 中添加 `chrono` 依赖，用于支持带时间戳的 cron 任务模型和调度逻辑，并将 `tempfile` 作为应用测试的开发依赖。

Tests:
- 为 `CoreCronTaskService` 添加应用层测试，用于验证持久化、服务器动作派发、输入校验以及调度器行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a unified cron task hosting service across the application and interface layers, and wire it into HTTP and Tauri so clients can manage and execute scheduled server actions.

New Features:
- Introduce a CronTaskService interface and models to describe server-side scheduled tasks, their actions, and execution results.
- Add Tauri commands and HTTP REST endpoints to list, create, update, delete, enable/disable, and run cron tasks.
- Provide an application-level CoreCronTaskService that persists cron tasks to JSON, validates input, executes server actions, and runs a background scheduler.

Bug Fixes:
- Align cron task action recording and execution in the extra cron task service to store the full action enum instead of a static string.

Enhancements:
- Extend the global AppServices container and HTTP/Tauri state to include the cron task service and manage lifecycle of its background scheduler, including clean deactivation on service replacement.
- Add dedicated CronTaskServiceError mapping to HTTP error responses so cron-related failures return appropriate status codes and error codes.
- Refine extra CronTaskError as non_exhaustive and adjust models to use the typed CronTaskAction for run records.

Build:
- Add chrono as a dependency in application and interface crates to support timestamped cron task models and scheduling logic, and tempfile as a dev-dependency for application tests.

Tests:
- Add application-level tests for CoreCronTaskService to verify persistence, server action dispatch, input validation, and scheduler behavior.

</details>