### PR TITLE
feat: 定义应用更新检查契约

### DIFF
--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -193,3 +193,25 @@ impl std::fmt::Display for SystemServiceError {
 }
 
 impl std::error::Error for SystemServiceError {}
+
+/// 应用更新检查失败的契约错误类别。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateCheckServiceError {
+    /// 更新源检查或响应处理失败。
+    CheckFailed,
+    /// 当前宿主不支持更新检查。
+    Unsupported,
+}
+
+impl std::fmt::Display for UpdateCheckServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::CheckFailed => "update check failed",
+            Self::Unsupported => "update check not supported",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for UpdateCheckServiceError {}

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -19,6 +19,8 @@ pub mod server;
 pub mod settings;
 /// 系统资源信息相关模型与服务端口。
 pub mod system;
+/// 应用更新检查相关模型与服务端口。
+pub mod update;
 
 /// 服务器定时任务服务端口。
 pub use cron::CronTaskService;
@@ -36,6 +38,8 @@ pub use error::ServerServiceError;
 pub use error::SettingsServiceError;
 /// 系统资源信息服务错误枚举。
 pub use error::SystemServiceError;
+/// 应用更新检查错误枚举。
+pub use error::UpdateCheckServiceError;
 /// 服务器实例记录管理服务端口。
 pub use instance::InstanceService;
 /// 服务器进程管理服务端口。
@@ -44,3 +48,5 @@ pub use server::ServerService;
 pub use settings::SettingsService;
 /// 系统资源信息服务端口。
 pub use system::SystemService;
+/// 应用更新检查服务端口。
+pub use update::UpdateCheckService;

--- a/crates/interface/src/update/mod.rs
+++ b/crates/interface/src/update/mod.rs
@@ -1,0 +1,7 @@
+//! 应用更新检查契约。
+
+pub mod models;
+pub mod service;
+
+pub use models::{UpdateInfo, UpdateSource};
+pub use service::UpdateCheckService;

--- a/crates/interface/src/update/mod.rs
+++ b/crates/interface/src/update/mod.rs
@@ -1,7 +1,7 @@
 //! 应用更新检查契约。
 
-pub mod models;
-pub mod service;
+mod models;
+mod service;
 
 pub use models::{UpdateInfo, UpdateSource};
 pub use service::UpdateCheckService;

--- a/crates/interface/src/update/models.rs
+++ b/crates/interface/src/update/models.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+/// 提供更新信息的发布源。
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UpdateSource {
+    /// GitHub Releases。
+    Github,
+    /// CNB.cool 发布页。
+    Cnb,
+    /// Arch User Repository。
+    ArchAur,
+}
+
+/// 当前平台的应用更新检查结果。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateInfo {
+    /// 是否存在适合当前平台的新版本资源。
+    pub has_update: bool,
+    /// 最新发布版本。
+    pub latest_version: String,
+    /// 当前应用版本。
+    pub current_version: String,
+    /// 当前平台资源的下载地址。
+    pub download_url: Option<String>,
+    /// 发布说明。
+    pub release_notes: Option<String>,
+    /// 发布时间。
+    pub published_at: Option<String>,
+    /// 最终采用的发布源。
+    pub source: Option<UpdateSource>,
+    /// 发布资源的 SHA-256；发布源未提供时为空。
+    pub sha256: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::UpdateCheckServiceError;
+
+    use super::{UpdateInfo, UpdateSource};
+
+    #[test]
+    fn update_contract_uses_stable_snake_case_names() {
+        let info = UpdateInfo {
+            has_update: true,
+            latest_version: "2.0.0".to_owned(),
+            current_version: "1.0.0".to_owned(),
+            download_url: Some("https://example.com/update".to_owned()),
+            release_notes: None,
+            published_at: None,
+            source: Some(UpdateSource::ArchAur),
+            sha256: None,
+        };
+
+        let value = serde_json::to_value(info).expect("serialize update info");
+
+        assert_eq!(value["has_update"], true);
+        assert_eq!(value["latest_version"], "2.0.0");
+        assert_eq!(value["source"], "arch-aur");
+        assert!(value.get("hasUpdate").is_none());
+        assert!(value.get("latestVersion").is_none());
+    }
+
+    #[test]
+    fn update_errors_use_snake_case_variants() {
+        let value = serde_json::to_value(UpdateCheckServiceError::CheckFailed)
+            .expect("serialize update check error");
+
+        assert_eq!(value, "check_failed");
+    }
+}

--- a/crates/interface/src/update/models.rs
+++ b/crates/interface/src/update/models.rs
@@ -1,8 +1,8 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// 提供更新信息的发布源。
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateSource {
     /// GitHub Releases。
@@ -14,7 +14,7 @@ pub enum UpdateSource {
 }
 
 /// 当前平台的应用更新检查结果。
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct UpdateInfo {
     /// 是否存在适合当前平台的新版本资源。

--- a/crates/interface/src/update/service.rs
+++ b/crates/interface/src/update/service.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+use crate::error::UpdateCheckServiceError;
+
+use super::models::UpdateInfo;
+
+/// 应用更新检查宿主能力端口。
+///
+/// 当前版本由实现方从应用构建信息获取，宿主不得覆盖；下载与安装属于独立能力，
+/// 后续通过单独的 trait 扩展。
+#[async_trait]
+pub trait UpdateCheckService: Send + Sync {
+    /// 检查当前平台是否存在新版本。
+    async fn check(&self) -> Result<UpdateInfo, UpdateCheckServiceError>;
+}


### PR DESCRIPTION
新增宿主无关的应用更新检查契约。

固定更新结果与错误的 snake_case 序列化边界。

## Summary by Sourcery

定义一个与宿主无关的应用程序更新检查约定，并将其集成到接口和额外的更新模块中。

New Features:
- 引入 `UpdateCheckService` trait 以及相关的 `UpdateInfo`/`UpdateSource` 模型，用于与平台无关的应用程序更新检查。
- 添加 `UpdateChecker` 抽象以及 `ReleaseUpdateChecker` 实现，用于在多个发行版提供方之间编排更新检查。
- 定义 `UpdateCheckServiceError` 和 `UpdateCheckError` 错误类型，用于分别表示约定层面和编排层面的更新检查失败，并支持稳定的 `snake_case` 序列化。

Tests:
- 添加测试，用于验证更新信息和错误的稳定 `snake_case` 序列化，以及验证在更新检查器中 Linux 提供方选择逻辑和调试模式行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define a host-agnostic application update checking contract and integrate it into the interface and extra update modules.

New Features:
- Introduce an UpdateCheckService trait and associated UpdateInfo/UpdateSource models for platform-agnostic application update checking.
- Add an UpdateChecker abstraction and ReleaseUpdateChecker implementation that orchestrate update checks across multiple release providers.
- Define UpdateCheckServiceError and UpdateCheckError error types for contract-level and orchestration-level update check failures with stable snake_case serialization.

Tests:
- Add tests to validate stable snake_case serialization for update info and errors, and to verify Linux provider selection logic and debug-mode behavior in the update checker.

</details>