### PR TITLE
feat: 接通应用更新检查服务

### DIFF
--- a/application/src/error/mod.rs
+++ b/application/src/error/mod.rs
@@ -20,6 +20,8 @@ pub mod server;
 pub mod settings;
 /// 系统资源信息领域错误。
 pub mod system;
+/// 应用更新检查领域错误。
+pub mod update;
 
 pub use config::ConfigError;
 pub use cron::CronTaskError;
@@ -29,3 +31,4 @@ pub use plugin::PluginError;
 pub use server::ServerError;
 pub use settings::SettingsError;
 pub use system::SystemError;
+pub use update::UpdateCheckError;

--- a/application/src/error/update.rs
+++ b/application/src/error/update.rs
@@ -1,0 +1,55 @@
+//! 应用更新检查领域的主错误。
+
+use std::fmt;
+
+use sealantern_extra::update::UpdateCheckError as ExtraUpdateCheckError;
+use sealantern_interface::UpdateCheckServiceError;
+
+/// 应用更新检查失败的内部错误。
+#[derive(Debug)]
+pub enum UpdateCheckError {
+    /// 更新源客户端初始化或远程检查失败。
+    CheckFailed { source: ExtraUpdateCheckError },
+    /// 更新源返回了应用层无法识别的数据。
+    InvalidResponse { detail: String },
+    /// 当前宿主不支持更新检查。
+    Unsupported,
+}
+
+impl fmt::Display for UpdateCheckError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CheckFailed { source } => write!(formatter, "update check failed: {source}"),
+            Self::InvalidResponse { detail } => {
+                write!(formatter, "invalid update response: {detail}")
+            }
+            Self::Unsupported => formatter.write_str("update check not supported"),
+        }
+    }
+}
+
+impl std::error::Error for UpdateCheckError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::CheckFailed { source } => Some(source),
+            Self::InvalidResponse { .. } | Self::Unsupported => None,
+        }
+    }
+}
+
+impl From<ExtraUpdateCheckError> for UpdateCheckError {
+    fn from(source: ExtraUpdateCheckError) -> Self {
+        Self::CheckFailed { source }
+    }
+}
+
+impl From<UpdateCheckError> for UpdateCheckServiceError {
+    fn from(error: UpdateCheckError) -> Self {
+        match error {
+            UpdateCheckError::CheckFailed { .. } | UpdateCheckError::InvalidResponse { .. } => {
+                Self::CheckFailed
+            }
+            UpdateCheckError::Unsupported => Self::Unsupported,
+        }
+    }
+}

--- a/application/src/error/update.rs
+++ b/application/src/error/update.rs
@@ -1,6 +1,7 @@
 //! 应用更新检查领域的主错误。
 
 use std::fmt;
+use std::time::Duration;
 
 use sealantern_extra::update::UpdateCheckError as ExtraUpdateCheckError;
 use sealantern_interface::UpdateCheckServiceError;
@@ -12,6 +13,8 @@ pub enum UpdateCheckError {
     CheckFailed { source: ExtraUpdateCheckError },
     /// 更新源返回了应用层无法识别的数据。
     InvalidResponse { detail: String },
+    /// 更新检查超过应用层允许的总时长。
+    TimedOut { timeout: Duration },
     /// 当前宿主不支持更新检查。
     Unsupported,
 }
@@ -23,6 +26,9 @@ impl fmt::Display for UpdateCheckError {
             Self::InvalidResponse { detail } => {
                 write!(formatter, "invalid update response: {detail}")
             }
+            Self::TimedOut { timeout } => {
+                write!(formatter, "update check timed out after {timeout:?}")
+            }
             Self::Unsupported => formatter.write_str("update check not supported"),
         }
     }
@@ -32,7 +38,7 @@ impl std::error::Error for UpdateCheckError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::CheckFailed { source } => Some(source),
-            Self::InvalidResponse { .. } | Self::Unsupported => None,
+            Self::InvalidResponse { .. } | Self::TimedOut { .. } | Self::Unsupported => None,
         }
     }
 }
@@ -46,9 +52,9 @@ impl From<ExtraUpdateCheckError> for UpdateCheckError {
 impl From<UpdateCheckError> for UpdateCheckServiceError {
     fn from(error: UpdateCheckError) -> Self {
         match error {
-            UpdateCheckError::CheckFailed { .. } | UpdateCheckError::InvalidResponse { .. } => {
-                Self::CheckFailed
-            }
+            UpdateCheckError::CheckFailed { .. }
+            | UpdateCheckError::InvalidResponse { .. }
+            | UpdateCheckError::TimedOut { .. } => Self::CheckFailed,
             UpdateCheckError::Unsupported => Self::Unsupported,
         }
     }

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -10,6 +10,7 @@ mod instance;
 mod server;
 mod settings;
 mod system;
+mod update;
 
 pub use cron::CoreCronTaskService;
 pub use download::CoreDownloadService;
@@ -17,3 +18,4 @@ pub use instance::CoreInstanceService;
 pub use server::CoreServerService;
 pub use settings::CoreSettingsService;
 pub use system::CoreSystemService;
+pub use update::CoreUpdateCheckService;

--- a/application/src/service/update.rs
+++ b/application/src/service/update.rs
@@ -1,5 +1,7 @@
 //! 应用更新检查服务实现。
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use sealantern_extra::update::{
     ReleaseUpdateChecker, UpdateChecker as ExtraUpdateChecker, UpdateInfo as ExtraUpdateInfo,
@@ -9,9 +11,34 @@ use sealantern_interface::{UpdateCheckService, UpdateCheckServiceError};
 
 use crate::error::UpdateCheckError;
 
+/// 单次更新检查在应用层允许占用的总时长。
+const UPDATE_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
+/// 成功检查结果的缓存时间。
+const UPDATE_CHECK_SUCCESS_TTL: Duration = Duration::from_secs(5 * 60);
+/// 失败检查结果的短暂退避时间。
+const UPDATE_CHECK_FAILURE_TTL: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+struct CachedUpdateCheck {
+    checked_at: tokio::time::Instant,
+    result: Result<UpdateInfo, UpdateCheckServiceError>,
+}
+
+impl CachedUpdateCheck {
+    fn is_fresh(&self) -> bool {
+        let ttl = if self.result.is_ok() {
+            UPDATE_CHECK_SUCCESS_TTL
+        } else {
+            UPDATE_CHECK_FAILURE_TTL
+        };
+        self.checked_at.elapsed() < ttl
+    }
+}
+
 /// 基于官方多来源检查器的应用更新服务。
 pub struct CoreUpdateCheckService {
     checker: tokio::sync::OnceCell<ReleaseUpdateChecker>,
+    cache: tokio::sync::Mutex<Option<CachedUpdateCheck>>,
 }
 
 impl CoreUpdateCheckService {
@@ -19,6 +46,7 @@ impl CoreUpdateCheckService {
     pub const fn new() -> Self {
         Self {
             checker: tokio::sync::OnceCell::const_new(),
+            cache: tokio::sync::Mutex::const_new(None),
         }
     }
 
@@ -38,8 +66,40 @@ impl Default for CoreUpdateCheckService {
 #[async_trait]
 impl UpdateCheckService for CoreUpdateCheckService {
     async fn check(&self) -> Result<UpdateInfo, UpdateCheckServiceError> {
-        check_with(self.checker().await?, env!("CARGO_PKG_VERSION")).await
+        cached_check_with(
+            &self.cache,
+            self.checker().await?,
+            env!("CARGO_PKG_VERSION"),
+            UPDATE_CHECK_TIMEOUT,
+        )
+        .await
     }
+}
+
+async fn cached_check_with<C>(
+    cache: &tokio::sync::Mutex<Option<CachedUpdateCheck>>,
+    checker: &C,
+    current_version: &str,
+    timeout: Duration,
+) -> Result<UpdateInfo, UpdateCheckServiceError>
+where
+    C: ExtraUpdateChecker + ?Sized,
+{
+    // 持锁覆盖远程检查，使并发调用共享同一次 provider 请求。
+    let mut cache = cache.lock().await;
+    if let Some(cached) = cache.as_ref().filter(|cached| cached.is_fresh()) {
+        return cached.result.clone();
+    }
+
+    let result = match tokio::time::timeout(timeout, check_with(checker, current_version)).await {
+        Ok(result) => result,
+        Err(_) => Err(contract_error(UpdateCheckError::TimedOut { timeout })),
+    };
+    *cache = Some(CachedUpdateCheck {
+        checked_at: tokio::time::Instant::now(),
+        result: result.clone(),
+    });
+    result
 }
 
 async fn check_with<C>(
@@ -92,12 +152,16 @@ fn contract_error(error: impl Into<UpdateCheckError>) -> UpdateCheckServiceError
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use sealantern_extra::update::UpdateCheckError as ExtraUpdateCheckError;
 
     use super::*;
 
     struct FakeChecker {
         info: Option<ExtraUpdateInfo>,
+        delay: Duration,
+        calls: AtomicUsize,
     }
 
     #[async_trait]
@@ -106,12 +170,32 @@ mod tests {
             &self,
             _current_version: &str,
         ) -> Result<ExtraUpdateInfo, ExtraUpdateCheckError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(self.delay).await;
             self.info
                 .clone()
                 .ok_or_else(|| ExtraUpdateCheckError::ProviderFailed {
                     provider: "github",
                     message: "offline".to_owned(),
                 })
+        }
+    }
+
+    impl FakeChecker {
+        fn with_info(info: ExtraUpdateInfo) -> Self {
+            Self {
+                info: Some(info),
+                delay: Duration::ZERO,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn failure() -> Self {
+            Self {
+                info: None,
+                delay: Duration::ZERO,
+                calls: AtomicUsize::new(0),
+            }
         }
     }
 
@@ -130,7 +214,7 @@ mod tests {
 
     #[tokio::test]
     async fn maps_known_update_source_to_contract() {
-        let checker = FakeChecker { info: Some(update(Some("arch-aur"))) };
+        let checker = FakeChecker::with_info(update(Some("arch-aur")));
 
         let info = check_with(&checker, "1.0.0").await.expect("check update");
 
@@ -140,7 +224,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_unknown_update_source() {
-        let checker = FakeChecker { info: Some(update(Some("mirror"))) };
+        let checker = FakeChecker::with_info(update(Some("mirror")));
 
         let error = check_with(&checker, "1.0.0")
             .await
@@ -151,12 +235,48 @@ mod tests {
 
     #[tokio::test]
     async fn maps_provider_failure_to_contract_error() {
-        let checker = FakeChecker { info: None };
+        let checker = FakeChecker::failure();
 
         let error = check_with(&checker, "1.0.0")
             .await
             .expect_err("provider failure must fail");
 
         assert_eq!(error, UpdateCheckServiceError::CheckFailed);
+    }
+
+    #[tokio::test]
+    async fn concurrent_checks_share_one_provider_request() {
+        let checker = FakeChecker {
+            info: Some(update(Some("github"))),
+            delay: Duration::from_millis(20),
+            calls: AtomicUsize::new(0),
+        };
+        let cache = tokio::sync::Mutex::new(None);
+
+        let (first, second) = tokio::join!(
+            cached_check_with(&cache, &checker, "1.0.0", Duration::from_secs(1)),
+            cached_check_with(&cache, &checker, "1.0.0", Duration::from_secs(1))
+        );
+
+        assert!(first.is_ok());
+        assert!(second.is_ok());
+        assert_eq!(checker.calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn total_timeout_is_reported_and_cached() {
+        let checker = FakeChecker {
+            info: Some(update(Some("github"))),
+            delay: Duration::from_millis(50),
+            calls: AtomicUsize::new(0),
+        };
+        let cache = tokio::sync::Mutex::new(None);
+
+        let first = cached_check_with(&cache, &checker, "1.0.0", Duration::from_millis(1)).await;
+        let second = cached_check_with(&cache, &checker, "1.0.0", Duration::from_millis(1)).await;
+
+        assert_eq!(first, Err(UpdateCheckServiceError::CheckFailed));
+        assert_eq!(second, Err(UpdateCheckServiceError::CheckFailed));
+        assert_eq!(checker.calls.load(Ordering::Relaxed), 1);
     }
 }

--- a/application/src/service/update.rs
+++ b/application/src/service/update.rs
@@ -1,0 +1,162 @@
+//! 应用更新检查服务实现。
+
+use async_trait::async_trait;
+use sealantern_extra::update::{
+    ReleaseUpdateChecker, UpdateChecker as ExtraUpdateChecker, UpdateInfo as ExtraUpdateInfo,
+};
+use sealantern_interface::update::{UpdateInfo, UpdateSource};
+use sealantern_interface::{UpdateCheckService, UpdateCheckServiceError};
+
+use crate::error::UpdateCheckError;
+
+/// 基于官方多来源检查器的应用更新服务。
+pub struct CoreUpdateCheckService {
+    checker: tokio::sync::OnceCell<ReleaseUpdateChecker>,
+}
+
+impl CoreUpdateCheckService {
+    /// 构造服务；网络客户端延迟到首次检查时初始化。
+    pub const fn new() -> Self {
+        Self {
+            checker: tokio::sync::OnceCell::const_new(),
+        }
+    }
+
+    async fn checker(&self) -> Result<&ReleaseUpdateChecker, UpdateCheckServiceError> {
+        self.checker
+            .get_or_try_init(|| async { ReleaseUpdateChecker::new().map_err(contract_error) })
+            .await
+    }
+}
+
+impl Default for CoreUpdateCheckService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl UpdateCheckService for CoreUpdateCheckService {
+    async fn check(&self) -> Result<UpdateInfo, UpdateCheckServiceError> {
+        check_with(self.checker().await?, env!("CARGO_PKG_VERSION")).await
+    }
+}
+
+async fn check_with<C>(
+    checker: &C,
+    current_version: &str,
+) -> Result<UpdateInfo, UpdateCheckServiceError>
+where
+    C: ExtraUpdateChecker + ?Sized,
+{
+    let info = checker
+        .check(current_version)
+        .await
+        .map_err(contract_error)?;
+    update_to_contract(info).map_err(contract_error)
+}
+
+fn update_to_contract(info: ExtraUpdateInfo) -> Result<UpdateInfo, UpdateCheckError> {
+    Ok(UpdateInfo {
+        has_update: info.has_update,
+        latest_version: info.latest_version,
+        current_version: info.current_version,
+        download_url: info.download_url,
+        release_notes: info.release_notes,
+        published_at: info.published_at,
+        source: info.source.map(parse_source).transpose()?,
+        sha256: info.sha256,
+    })
+}
+
+fn parse_source(source: String) -> Result<UpdateSource, UpdateCheckError> {
+    match source.as_str() {
+        "github" => Ok(UpdateSource::Github),
+        "cnb" => Ok(UpdateSource::Cnb),
+        "arch-aur" => Ok(UpdateSource::ArchAur),
+        _ => Err(UpdateCheckError::InvalidResponse {
+            detail: format!("unknown update source: {source}"),
+        }),
+    }
+}
+
+fn contract_error(error: impl Into<UpdateCheckError>) -> UpdateCheckServiceError {
+    let error = error.into();
+    tracing::error!(
+        target: "sealantern.application.update",
+        error = %error,
+        "update check failed"
+    );
+    error.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use sealantern_extra::update::UpdateCheckError as ExtraUpdateCheckError;
+
+    use super::*;
+
+    struct FakeChecker {
+        info: Option<ExtraUpdateInfo>,
+    }
+
+    #[async_trait]
+    impl ExtraUpdateChecker for FakeChecker {
+        async fn check(
+            &self,
+            _current_version: &str,
+        ) -> Result<ExtraUpdateInfo, ExtraUpdateCheckError> {
+            self.info
+                .clone()
+                .ok_or_else(|| ExtraUpdateCheckError::ProviderFailed {
+                    provider: "github",
+                    message: "offline".to_owned(),
+                })
+        }
+    }
+
+    fn update(source: Option<&str>) -> ExtraUpdateInfo {
+        ExtraUpdateInfo {
+            has_update: true,
+            latest_version: "2.0.0".to_owned(),
+            current_version: "1.0.0".to_owned(),
+            download_url: Some("https://example.com/update".to_owned()),
+            release_notes: None,
+            published_at: None,
+            source: source.map(str::to_owned),
+            sha256: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_known_update_source_to_contract() {
+        let checker = FakeChecker { info: Some(update(Some("arch-aur"))) };
+
+        let info = check_with(&checker, "1.0.0").await.expect("check update");
+
+        assert_eq!(info.source, Some(UpdateSource::ArchAur));
+        assert_eq!(info.latest_version, "2.0.0");
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_update_source() {
+        let checker = FakeChecker { info: Some(update(Some("mirror"))) };
+
+        let error = check_with(&checker, "1.0.0")
+            .await
+            .expect_err("unknown source must fail");
+
+        assert_eq!(error, UpdateCheckServiceError::CheckFailed);
+    }
+
+    #[tokio::test]
+    async fn maps_provider_failure_to_contract_error() {
+        let checker = FakeChecker { info: None };
+
+        let error = check_with(&checker, "1.0.0")
+            .await
+            .expect_err("provider failure must fail");
+
+        assert_eq!(error, UpdateCheckServiceError::CheckFailed);
+    }
+}

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -20,7 +20,7 @@ use sealantern_infra::platform::get_app_data_dir;
 use crate::error::InstanceError;
 use crate::service::{
     CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreServerService,
-    CoreSettingsService, CoreSystemService,
+    CoreSettingsService, CoreSystemService, CoreUpdateCheckService,
 };
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
@@ -50,6 +50,8 @@ pub struct AppServicesInner {
     pub system: Arc<CoreSystemService>,
     /// 设置管理器（持久化配置）。
     pub settings_manager: Option<tokio::sync::Mutex<SettingsManager>>,
+    /// 应用更新检查服务。
+    pub update: Arc<CoreUpdateCheckService>,
 }
 
 /// 进程级全局容器。惰性初始化，可替换。
@@ -75,6 +77,7 @@ impl AppServices {
                 settings: Arc::new(CoreSettingsService),
                 system: Arc::new(CoreSystemService),
                 settings_manager: None,
+                update: Arc::new(CoreUpdateCheckService::new()),
             }),
         }
     }
@@ -104,6 +107,7 @@ impl AppServices {
                 settings: Arc::new(CoreSettingsService),
                 system: Arc::new(CoreSystemService),
                 settings_manager: Some(tokio::sync::Mutex::new(settings_manager)),
+                update: Arc::new(CoreUpdateCheckService::new()),
             }),
         })
     }
@@ -243,5 +247,15 @@ impl AppServices {
             .settings_manager
             .as_ref()
             .ok_or(InstanceError::Internal("settings manager not initialized".to_string()))
+    }
+
+    /// 访问应用更新检查服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn update(&self) -> &Arc<CoreUpdateCheckService> {
+        &self.inner.update
+    }
+
+    /// 便捷访问入口：一步拿到更新检查服务的共享句柄（惰性初始化 + 可替换）。
+    pub async fn update_service() -> Result<Arc<CoreUpdateCheckService>, InstanceError> {
+        Ok(Self::get().await?.update().clone())
     }
 }


### PR DESCRIPTION
将应用更新检查契约接到 extra 的多来源检查器。

应用层负责当前版本、来源类型转换、错误归类与客户端惰性初始化。

## Summary by Sourcery

通过在应用层引入更新检查服务，将其接入多源检查器，并通过接口契约对外暴露。

新功能：
- 在接口中定义更新检查契约，包括 `UpdateInfo`、`UpdateSource` 和 `UpdateCheckService` trait。
- 在应用层新增 `CoreUpdateCheckService`，基于 extra crate 的多源检查器提供延迟初始化的更新检查。
- 在 extra crate 中实现多提供方的 `ReleaseUpdateChecker`，按需从 GitHub、CNB 和 Arch AUR 获取更新信息。

增强：
- 在 extra、application 和 interface 各层为更新检查引入结构化错误类型，并建立内部错误与契约错误之间的映射关系。
- 将更新检查服务注册到全局应用服务容器中，便于宿主进行访问和使用。

测试：
- 添加单元测试，以确保更新模型和错误枚举的 JSON 契约稳定性，验证正确的源映射、错误传播以及多提供方选择行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an application-level update checking service wired to the multi-source checker and exposed via the interface contract.

New Features:
- Define update checking contract in the interface, including UpdateInfo, UpdateSource, and UpdateCheckService trait.
- Add CoreUpdateCheckService in the application layer, providing lazy-initialized update checks based on the extra crate’s multi-source checker.
- Implement a multi-provider ReleaseUpdateChecker in the extra crate to resolve updates from GitHub, CNB, and Arch AUR as appropriate.

Enhancements:
- Introduce structured error types for update checking across extra, application, and interface layers, with mapping between internal and contract errors.
- Register the update check service in the global application services container for convenient access by the host.

Tests:
- Add unit tests to ensure stable JSON contract for update models and error enums, correct source mapping, error propagation, and multi-provider selection behavior.

</details>