### PR TITLE
feat: 暴露应用更新检查接口

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,6 +5314,7 @@ dependencies = [
  "sealantern-interface",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tracing",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,6 +28,7 @@ include_dir = "0.7"
 winres = "0.1.12"
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }
 

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -262,11 +262,24 @@ impl IntoResponse for HttpError {
 mod tests {
     use super::*;
 
-    #[test]
-    fn update_check_failure_maps_to_bad_gateway() {
-        let error = HttpError::from(UpdateCheckServiceError::CheckFailed);
+    #[tokio::test]
+    async fn update_check_failure_has_stable_http_response() {
+        let response = HttpError::from(UpdateCheckServiceError::CheckFailed).into_response();
 
-        assert_eq!(error.status, StatusCode::BAD_GATEWAY);
-        assert_eq!(error.code, "update_check_failed");
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("read error response");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("parse error response");
+        assert_eq!(value["code"], "update_check_failed");
+        assert_eq!(value["message"], "update check failed");
+    }
+
+    #[test]
+    fn unsupported_update_check_maps_to_not_implemented() {
+        let error = HttpError::from(UpdateCheckServiceError::Unsupported);
+
+        assert_eq!(error.status, StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(error.code, "operation_unsupported");
     }
 }

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 use sealantern_interface::{
     CronTaskServiceError, InstanceServiceError, ServerServiceError, SettingsServiceError,
-    SystemServiceError,
+    SystemServiceError, UpdateCheckServiceError,
 };
 
 /// 展平的 HTTP 错误响应体。
@@ -35,6 +35,22 @@ pub struct HttpError {
 }
 
 impl HttpError {
+    /// 由应用更新检查契约错误构建 HTTP 错误。
+    pub fn from_update_error(error: UpdateCheckServiceError) -> Self {
+        match error {
+            UpdateCheckServiceError::CheckFailed => Self {
+                status: StatusCode::BAD_GATEWAY,
+                code: "update_check_failed",
+                message: error.to_string(),
+            },
+            UpdateCheckServiceError::Unsupported => Self {
+                status: StatusCode::NOT_IMPLEMENTED,
+                code: "operation_unsupported",
+                message: error.to_string(),
+            },
+        }
+    }
+
     /// 由定时任务契约错误构建 HTTP 错误。
     pub fn from_cron_error(error: CronTaskServiceError) -> Self {
         match error {
@@ -229,9 +245,28 @@ impl From<SystemServiceError> for HttpError {
     }
 }
 
+impl From<UpdateCheckServiceError> for HttpError {
+    fn from(error: UpdateCheckServiceError) -> Self {
+        Self::from_update_error(error)
+    }
+}
+
 impl IntoResponse for HttpError {
     fn into_response(self) -> Response {
         let body = HttpErrorBody { code: self.code, message: self.message };
         (self.status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_check_failure_maps_to_bad_gateway() {
+        let error = HttpError::from(UpdateCheckServiceError::CheckFailed);
+
+        assert_eq!(error.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(error.code, "update_check_failed");
     }
 }

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -7,6 +7,7 @@ pub mod instance;
 pub mod server;
 pub mod settings;
 pub mod system;
+pub mod update;
 
 pub use cron::{
     create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
@@ -22,3 +23,4 @@ pub use server::{
 };
 pub use settings::settings_overview;
 pub use system::{directory_usage, process_usage, system_snapshot};
+pub use update::check_update;

--- a/server/src/adapter/http/handlers/update.rs
+++ b/server/src/adapter/http/handlers/update.rs
@@ -1,0 +1,20 @@
+//! 应用更新检查 REST handler。
+
+use axum::extract::State;
+use axum::Json;
+
+use sealantern_interface::update::UpdateInfo;
+use sealantern_interface::UpdateCheckService;
+
+use super::super::error::HttpError;
+use super::super::state::AppState;
+
+/// `GET /api/update` — 检查当前平台是否存在应用更新。
+pub async fn check_update(State(state): State<AppState>) -> Result<Json<UpdateInfo>, HttpError> {
+    state
+        .update()
+        .check()
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -77,3 +77,49 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
         .merge(spa_router(config))
         .with_state(state)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use sealantern_application::service::CoreInstanceService;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn update_route_returns_snake_case_contract() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let path = std::env::temp_dir()
+            .join(format!("sealantern-update-route-{}-{unique}.json", std::process::id()));
+        let instance = CoreInstanceService::with_path(path)
+            .await
+            .expect("create instance service");
+        let router = build_router(AppServices::from_inner(instance), ViteConfig::default());
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/update")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("call update route");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .expect("read update response");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse update response");
+        assert!(value.get("has_update").is_some());
+        assert!(value.get("latest_version").is_some());
+        assert!(value.get("hasUpdate").is_none());
+    }
+}

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -80,24 +80,18 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use sealantern_application::service::CoreInstanceService;
+    use tempfile::tempdir;
     use tower::ServiceExt;
 
     use super::*;
 
     #[tokio::test]
     async fn update_route_returns_snake_case_contract() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        let path = std::env::temp_dir()
-            .join(format!("sealantern-update-route-{}-{unique}.json", std::process::id()));
-        let instance = CoreInstanceService::with_path(path)
+        let directory = tempdir().expect("create temporary directory");
+        let instance = CoreInstanceService::with_path(directory.path().join("instances.json"))
             .await
             .expect("create instance service");
         let router = build_router(AppServices::from_inner(instance), ViteConfig::default());

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -66,11 +66,14 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
         .route("/cron-tasks/{id}/enabled", put(handlers::set_cron_task_enabled))
         .route("/cron-tasks/{id}/run", post(handlers::run_cron_task));
 
+    let update_routes = Router::new().route("/update", get(handlers::check_update));
+
     Router::new()
         .nest(API_PREFIX, instance_routes)
         .nest(API_PREFIX, settings_routes)
         .nest(API_PREFIX, system_routes)
         .nest(API_PREFIX, cron_routes)
+        .nest(API_PREFIX, update_routes)
         .merge(spa_router(config))
         .with_state(state)
 }

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -83,18 +83,26 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use sealantern_application::service::CoreInstanceService;
-    use tempfile::tempdir;
+    use tempfile::{tempdir, TempDir};
     use tower::ServiceExt;
 
     use super::*;
 
-    #[tokio::test]
-    async fn update_route_returns_snake_case_contract() {
+    async fn test_router() -> (Router, TempDir) {
         let directory = tempdir().expect("create temporary directory");
         let instance = CoreInstanceService::with_path(directory.path().join("instances.json"))
             .await
             .expect("create instance service");
-        let router = build_router(AppServices::from_inner(instance), ViteConfig::default());
+        (
+            build_router(AppServices::from_inner(instance), ViteConfig::default()),
+            directory,
+        )
+    }
+
+    #[cfg(debug_assertions)]
+    #[tokio::test]
+    async fn update_route_returns_snake_case_contract() {
+        let (router, _directory) = test_router().await;
 
         let response = router
             .oneshot(
@@ -115,5 +123,21 @@ mod tests {
         assert!(value.get("has_update").is_some());
         assert!(value.get("latest_version").is_some());
         assert!(value.get("hasUpdate").is_none());
+    }
+
+    #[tokio::test]
+    async fn update_route_rejects_post_requests() {
+        let (router, _directory) = test_router().await;
+
+        let response = router
+            .oneshot(
+                Request::post("/api/update")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("call update route");
+
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 }

--- a/server/src/adapter/http/state.rs
+++ b/server/src/adapter/http/state.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use sealantern_application::service::{
     CoreCronTaskService, CoreInstanceService, CoreServerService, CoreSettingsService,
-    CoreSystemService,
+    CoreSystemService, CoreUpdateCheckService,
 };
 use sealantern_application::services::AppServices;
 
@@ -52,5 +52,10 @@ impl AppState {
     /// 访问系统资源信息服务（`Arc` 共享句柄，clone 廉价）。
     pub fn system(&self) -> Arc<CoreSystemService> {
         self.services.system().clone()
+    }
+
+    /// 访问应用更新检查服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn update(&self) -> Arc<CoreUpdateCheckService> {
+        self.services.update().clone()
     }
 }

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod instance;
 pub mod server;
 pub mod settings;
 pub mod system;
+pub mod update;

--- a/src-tauri/src/adapter/tauri/commands/update.rs
+++ b/src-tauri/src/adapter/tauri/commands/update.rs
@@ -1,0 +1,26 @@
+//! 应用更新检查 Tauri 命令。
+
+use std::sync::Arc;
+
+use sealantern_application::service::CoreUpdateCheckService;
+use sealantern_application::services::AppServices;
+use sealantern_interface::update::UpdateInfo;
+use sealantern_interface::{UpdateCheckService, UpdateCheckServiceError};
+
+async fn update_service() -> Result<Arc<CoreUpdateCheckService>, UpdateCheckServiceError> {
+    let services = AppServices::get().await.map_err(|error| {
+        tracing::error!(
+            target: "sealantern.tauri.update",
+            error = %error,
+            "failed to initialize application services for update check"
+        );
+        UpdateCheckServiceError::CheckFailed
+    })?;
+    Ok(services.update().clone())
+}
+
+/// 检查当前平台是否存在应用更新。
+#[tauri::command]
+pub async fn check_update() -> Result<UpdateInfo, UpdateCheckServiceError> {
+    update_service().await?.check().await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ use adapter::tauri::commands::settings::get_settings_overview;
 use adapter::tauri::commands::system::{
     get_directory_usage, get_process_usage, get_system_snapshot,
 };
+use adapter::tauri::commands::update::check_update;
 use desktop::{
     desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
     desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
@@ -74,6 +75,8 @@ pub fn run() {
             get_directory_usage,
             get_process_usage,
             get_system_snapshot,
+            //应用更新检查契约命令
+            check_update,
             //兼容层（前端旧命令名 → 新服务，由adapter/tauri/commands/compat提供）
             add_existing_server,
             cancel_download_task,


### PR DESCRIPTION
通过 Tauri 的 check_update 命令与 GET /api/update 暴露应用更新检查。

统一 HTTP 错误分类，并用宿主契约测试固定 snake_case 响应。

## Summary by Sourcery

通过 Tauri 命令和 HTTP `/api/update` 端点对外提供统一的应用更新检查能力，该能力由新的多源更新检查服务以及稳定的 snake_case 合同（contract）提供支持。

New Features:
- 在接口层新增跨平台的应用更新检查服务和 trait，并使用 snake_case 的 JSON 模型。
- 通过 Tauri `check_update` 命令以及 `GET /api/update` HTTP 路由对外暴露应用更新检查功能，保证响应结构稳定。

Bug Fixes:
- 通过解析发行页面以及结构化的 Next.js 数据，确保 CNB.cool 的更新检查在没有匿名 OpenAPI 访问权限的情况下也能正常工作。
- 改进资产选择逻辑，避免选择错误 CPU 架构的二进制文件。

Enhancements:
- 引入多源 `ReleaseUpdateChecker`，用于编排 GitHub、CNB 和 Arch AUR 提供方，并提供超时控制、缓存以及一致的错误处理。
- 统一更新相关的 HTTP 客户端配置，包括显式超时和 User-Agent 设置，同时共享 AUR 客户端。
- 将更新检查领域错误映射为稳定的、snake_case 的 HTTP 错误响应，并通过测试来保证该合同的稳定性。
- 优化 Linux 更新提供方选择逻辑，在合适的情况下优先使用 GitHub，并清晰呈现多个提供方组合失败的情况。

Tests:
- 新增单元测试和集成测试，用于验证更新路由合同、HTTP 错误映射、CNB 解析、资产选择以及更新检查器行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a unified application update check capability over both Tauri commands and an HTTP /api/update endpoint, backed by a new multi-source update checking service and stable snake_case contracts.

New Features:
- Add a cross-platform application update check service and trait in the interface layer with snake_case JSON models.
- Expose application update checking via a Tauri check_update command and a GET /api/update HTTP route with stable response shape.

Bug Fixes:
- Ensure CNB.cool update checking works without anonymous OpenAPI access by parsing release pages and structured Next.js data.
- Improve asset selection to avoid choosing binaries for the wrong CPU architecture.

Enhancements:
- Introduce a multi-source ReleaseUpdateChecker that orchestrates GitHub, CNB, and Arch AUR providers with timeouts, caching and consistent error handling.
- Unify update-related HTTP client configuration with explicit timeouts and user agents, and share AUR clients.
- Map update check domain errors into stable, snake_case HTTP error responses with tests to enforce the contract.
- Refine Linux update provider selection logic to prefer GitHub when appropriate and surface combined provider failures clearly.

Tests:
- Add unit and integration tests to validate update route contract, HTTP error mappings, CNB parsing, asset selection, and update checker behavior.

</details>