### PR TITLE
fix(frontend): 移除前端页面变化通知

### DIFF
--- a/src/api/plugin.ts
+++ b/src/api/plugin.ts
@@ -171,10 +171,6 @@ export async function onLocaleChanged(locale: string): Promise<void> {
   return tauriInvoke("on_locale_changed", { locale });
 }
 
-export async function onPageChanged(path: string): Promise<void> {
-  return tauriInvoke("on_page_changed", { path });
-}
-
 export async function componentMirrorClear(): Promise<void> {
   return tauriInvoke("component_mirror_clear");
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,4 @@
 import { createRouter, createWebHistory } from "vue-router";
-import { onPageChanged } from "@api/plugin";
 
 const routes = [
   {
@@ -108,20 +107,6 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
-});
-
-// 路由切换后通知插件页面变化;原实现注册 250ms/900ms 两个定时器冗余触发,改为单次延时
-let pageChangedTimer: number | null = null;
-
-router.afterEach((to) => {
-  if (pageChangedTimer !== null) {
-    clearTimeout(pageChangedTimer);
-  }
-  // 300ms 等待页面渲染稳定后再通知,避免插件在过渡动画期间收到事件
-  pageChangedTimer = window.setTimeout(() => {
-    pageChangedTimer = null;
-    onPageChanged(to.path).catch(() => {});
-  }, 300);
 });
 
 export default router;

--- a/src/stores/pluginStore.ts
+++ b/src/stores/pluginStore.ts
@@ -308,8 +308,6 @@ export const usePluginStore = defineStore("plugin", () => {
         );
         await loadNavItems();
 
-        const currentPath = window.location.hash.replace(/^#/, "") || "/";
-        await pluginApi.onPageChanged(currentPath);
         await replayUiSnapshot();
         setTimeout(() => replayUiSnapshot(), 300);
 


### PR DESCRIPTION
- 删除路由切换后触发 on_page_changed 的延时通知逻辑
- 删除插件启用后主动触发页面变化通知的调用
- 移除前端 onPageChanged API，避免继续调用已废弃的后端命令

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

移除前端页面变更通知与插件系统的集成，包括路由钩子以及对应的插件 API。

改进内容：
- 通过在启用插件时不再触发页面变更通知，简化插件初始化流程。
- 通过移除已弃用的前端端点 `onPageChanged`，精简插件 API 的接口范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove frontend page change notification integration with the plugin system, including the router hook and corresponding plugin API.

Enhancements:
- Simplify plugin initialization by no longer triggering a page change notification when enabling a plugin.
- Clean up the plugin API surface by removing the deprecated onPageChanged frontend endpoint.

</details>