### PR TITLE
refactor(config): 收拢应用设置默认加载入口

### DIFF
--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -15,7 +15,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use sealantern_extra::config::SettingsManager;
-use sealantern_infra::platform::get_app_data_dir;
 
 use crate::error::InstanceError;
 use crate::service::{
@@ -88,9 +87,8 @@ impl AppServices {
     ) -> Result<Self, InstanceError> {
         let instance = Arc::new(instance);
 
-        // 加载设置管理器
-        let settings_path = get_app_data_dir().join("sea_lantern_settings.json");
-        let settings_manager = SettingsManager::load(&settings_path)
+        // 由 extra 配置模块统一解析默认路径并加载设置。
+        let settings_manager = SettingsManager::load_default()
             .await
             .map_err(|e| InstanceError::Internal(e.to_string()))?;
 

--- a/crates/extra/src/config/sealantern/manager.rs
+++ b/crates/extra/src/config/sealantern/manager.rs
@@ -15,6 +15,7 @@ use std::path::{Path, PathBuf};
 use sealantern_infra::fs::{read_string_limited, write_atomic, DataLimit, FileLock, FsError};
 use sealantern_infra::persistence::config::ConfigFile;
 use sealantern_infra::persistence::process_lock_registry;
+use sealantern_infra::platform::get_app_data_dir;
 use serde::Deserialize;
 use tokio::sync::OwnedRwLockWriteGuard;
 
@@ -25,6 +26,14 @@ use crate::observability;
 
 /// 配置文件读取上限：最大 10 MiB。
 const CONFIG_READ_LIMIT: DataLimit = DataLimit::new(10 * 1024 * 1024);
+
+/// SeaLantern 应用设置文件名。
+const SETTINGS_FILE_NAME: &str = "sea_lantern_settings.json";
+
+/// 解析 SeaLantern 应用设置文件的默认路径。
+fn default_settings_path() -> PathBuf {
+    get_app_data_dir().join(SETTINGS_FILE_NAME)
+}
 
 /// 旧版嵌套配置格式（v1：`{ version, preferences: {...} }`）。
 ///
@@ -61,6 +70,14 @@ pub struct SettingsManager {
 }
 
 impl SettingsManager {
+    /// 从 SeaLantern 默认配置位置加载或创建设置文件。
+    ///
+    /// 默认路径、文件名和持久化策略均由配置模块统一管理；调用方无需了解
+    /// 配置文件在不同运行环境中的具体位置。
+    pub async fn load_default() -> Result<Self, FsError> {
+        Self::load(default_settings_path()).await
+    }
+
     /// 加载或创建设置文件，检测版本号并执行迁移。
     ///
     /// 处理顺序：
@@ -437,8 +454,18 @@ fn upgrade_settings(settings: &mut AppSettings, from_version: u32) {
 
 #[cfg(test)]
 mod tests {
-    use super::SettingsManager;
+    use super::{default_settings_path, SettingsManager, SETTINGS_FILE_NAME};
     use crate::config::{AppSettings, JavaInfo, PartialAppSettings};
+
+    #[test]
+    fn default_path_uses_owned_settings_file_name() {
+        assert_eq!(
+            default_settings_path()
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some(SETTINGS_FILE_NAME)
+        );
+    }
 
     #[tokio::test]
     async fn empty_partial_update_does_not_rewrite_settings() {


### PR DESCRIPTION
- 由 extra 统一持有设置文件名与默认路径解析
- 为 SettingsManager 增加默认位置加载入口
- application 装配层不再感知配置文件位置

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

在 `config` 模块中集中处理 SeaLantern 设置的默认路径，并简化应用的设置加载流程。

新功能：
- 添加 `SettingsManager::load_default()` 入口点，用于从应用的默认配置位置加载设置。

改进：
- 在 `config/extra` crate 中定义单一的自有设置文件名常量和默认路径解析器，使调用方与文件系统细节解耦。

测试：
- 添加单元测试，以验证默认设置路径是否使用集中定义的设置文件名常量。

杂项：
- 更新应用服务的初始化逻辑，改为依赖 `config` 模块的默认设置加载器，而不是直接构造设置路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize SeaLantern settings default path handling in the config module and simplify the application’s settings loading.

New Features:
- Add a SettingsManager::load_default() entry point that loads settings from the app’s default configuration location.

Enhancements:
- Define a single owned settings file name constant and default path resolver within the config/extra crate, decoupling callers from filesystem details.

Tests:
- Add a unit test to verify the default settings path uses the centralized settings file name constant.

Chores:
- Update application service initialization to rely on the config module’s default settings loader instead of constructing the settings path directly.

</details>