### PR TITLE
feat(interface): 扩展设置管理服务契约

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5297,6 +5297,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "sealantern-core",
+ "sealantern-extra",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/interface/Cargo.toml
+++ b/crates/interface/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1.53.1", features = ["rt", "macros"] }
 serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 sealantern-core = { path = "../core" }
+sealantern-extra = { path = "../extra" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -115,7 +115,13 @@ impl std::error::Error for ServerServiceError {}
 pub enum SettingsServiceError {
     /// 设置分组或设置项不存在。
     NotFound,
-    /// 底层配置加载/保存操作失败。
+    /// 客户端提供的设置或导入内容不合法。
+    InvalidInput,
+    /// 底层配置加载、锁定或持久化失败。
+    StorageFailed,
+    /// 设置服务暂时不可用或尚未完成装配。
+    Unavailable,
+    /// 未分类的设置操作失败。
     OperationFailed,
     /// 该能力尚未实现（占位）。
     Unsupported,
@@ -141,6 +147,9 @@ impl std::fmt::Display for SettingsServiceError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let message = match self {
             Self::NotFound => "settings not found",
+            Self::InvalidInput => "invalid settings input",
+            Self::StorageFailed => "settings storage failed",
+            Self::Unavailable => "settings service unavailable",
             Self::OperationFailed => "settings operation failed",
             Self::Unsupported => "operation not supported",
         };

--- a/crates/interface/src/settings/service.rs
+++ b/crates/interface/src/settings/service.rs
@@ -1,16 +1,102 @@
 //! 设置信息服务端口。
 
 use async_trait::async_trait;
+use sealantern_extra::models::{AppSettings, PartialAppSettings, UpdateResult};
 
 use crate::error::SettingsServiceError;
 
 use super::models::SettingsOverview;
 
-/// 设置信息宿主能力端口。
+/// 设置管理宿主能力端口。
 ///
-/// 提供设置分组、设置项列表等查询能力，不涉及具体配置读写。
+/// 配置模型及持久化语义由 `extra` 提供；本端口统一暴露设置概览、读取、更新、
+/// 重置与导入导出能力，供不同宿主复用。
 #[async_trait]
 pub trait SettingsService: Send + Sync {
     /// 获取设置概览（所有分组及其设置项列表）。
     async fn settings_overview(&self) -> Result<SettingsOverview, SettingsServiceError>;
+
+    /// 获取当前完整设置。
+    ///
+    /// 默认返回 [`SettingsServiceError::Unsupported`]，允许宿主分阶段接入新契约。
+    async fn get(&self) -> Result<AppSettings, SettingsServiceError> {
+        Err(SettingsServiceError::Unsupported)
+    }
+
+    /// 全量替换并持久化当前设置。
+    ///
+    /// 默认返回 [`SettingsServiceError::Unsupported`]，允许宿主分阶段接入新契约。
+    async fn update(&self, _settings: AppSettings) -> Result<UpdateResult, SettingsServiceError> {
+        Err(SettingsServiceError::Unsupported)
+    }
+
+    /// 部分更新并持久化当前设置。
+    ///
+    /// 默认返回 [`SettingsServiceError::Unsupported`]，允许宿主分阶段接入新契约。
+    async fn update_partial(
+        &self,
+        _partial: PartialAppSettings,
+    ) -> Result<UpdateResult, SettingsServiceError> {
+        Err(SettingsServiceError::Unsupported)
+    }
+
+    /// 将当前设置恢复为默认值。
+    ///
+    /// 默认返回 [`SettingsServiceError::Unsupported`]，允许宿主分阶段接入新契约。
+    async fn reset(&self) -> Result<AppSettings, SettingsServiceError> {
+        Err(SettingsServiceError::Unsupported)
+    }
+
+    /// 将当前设置导出为 JSON 字符串。
+    ///
+    /// 默认返回 [`SettingsServiceError::Unsupported`]，允许宿主分阶段接入新契约。
+    async fn export_json(&self) -> Result<String, SettingsServiceError> {
+        Err(SettingsServiceError::Unsupported)
+    }
+
+    /// 从 JSON 字符串导入并持久化设置。
+    ///
+    /// 默认返回 [`SettingsServiceError::Unsupported`]，允许宿主分阶段接入新契约。
+    async fn import_json(&self, _json: &str) -> Result<UpdateResult, SettingsServiceError> {
+        Err(SettingsServiceError::Unsupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct OverviewOnlySettingsService;
+
+    #[async_trait]
+    impl SettingsService for OverviewOnlySettingsService {
+        async fn settings_overview(&self) -> Result<SettingsOverview, SettingsServiceError> {
+            Ok(SettingsOverview {
+                groups: Vec::new(),
+                total_entries: 0,
+                configured_entries: 0,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn unimplemented_settings_operations_are_explicitly_unsupported() {
+        let service = OverviewOnlySettingsService;
+
+        assert!(matches!(service.get().await, Err(SettingsServiceError::Unsupported)));
+        assert!(matches!(
+            service.update(AppSettings::default()).await,
+            Err(SettingsServiceError::Unsupported)
+        ));
+        assert!(matches!(
+            service.update_partial(PartialAppSettings::default()).await,
+            Err(SettingsServiceError::Unsupported)
+        ));
+        assert!(matches!(service.reset().await, Err(SettingsServiceError::Unsupported)));
+        assert_eq!(service.export_json().await, Err(SettingsServiceError::Unsupported));
+        assert!(matches!(
+            service.import_json("{}").await,
+            Err(SettingsServiceError::Unsupported)
+        ));
+    }
 }

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -162,6 +162,21 @@ impl HttpError {
                 code: "settings_not_found",
                 message: error.to_string(),
             },
+            SettingsServiceError::InvalidInput => Self {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_settings",
+                message: error.to_string(),
+            },
+            SettingsServiceError::StorageFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "settings_storage_failed",
+                message: error.to_string(),
+            },
+            SettingsServiceError::Unavailable => Self {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "settings_unavailable",
+                message: error.to_string(),
+            },
             SettingsServiceError::OperationFailed => Self {
                 status: StatusCode::INTERNAL_SERVER_ERROR,
                 code: "settings_operation_failed",
@@ -281,5 +296,20 @@ mod tests {
 
         assert_eq!(error.status, StatusCode::NOT_IMPLEMENTED);
         assert_eq!(error.code, "operation_unsupported");
+    }
+
+    #[test]
+    fn settings_errors_have_stable_http_classification() {
+        let invalid = HttpError::from(SettingsServiceError::InvalidInput);
+        assert_eq!(invalid.status, StatusCode::BAD_REQUEST);
+        assert_eq!(invalid.code, "invalid_settings");
+
+        let storage = HttpError::from(SettingsServiceError::StorageFailed);
+        assert_eq!(storage.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(storage.code, "settings_storage_failed");
+
+        let unavailable = HttpError::from(SettingsServiceError::Unavailable);
+        assert_eq!(unavailable.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(unavailable.code, "settings_unavailable");
     }
 }


### PR DESCRIPTION
- 直接复用 extra 的配置模型定义完整设置操作端口
- 为分阶段接入提供显式 Unsupported 默认实现
- 扩展设置错误类别并补充 HTTP 分类映射

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

扩展设置管理服务契约，以公开完整的配置操作，并使错误处理与 HTTP 响应保持一致。

新功能：
- 为设置服务接口添加类似 CRUD 的操作以及 JSON 导入/导出功能，并由来自 `extra` crate 的共享配置模型提供支持。

改进：
- 为新的设置操作引入显式的 `Unsupported` 默认值，以便不同宿主可以逐步采用这些功能。
- 扩展设置错误类别，并确保与设置相关的故障在 HTTP 状态/代码映射上保持稳定。

构建：
- 将 `sealantern-extra` 添加为接口 crate 依赖，以复用共享配置模型。

测试：
- 添加单元测试，验证扩展后的设置服务中默认的 `Unsupported` 行为，以及新设置错误的 HTTP 分类。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the settings management service contract to expose full configuration operations and align error handling with HTTP responses.

New Features:
- Add CRUD-style operations and JSON import/export capabilities to the settings service interface, backed by shared configuration models from the extra crate.

Enhancements:
- Introduce explicit Unsupported defaults for new settings operations to allow gradual adoption by different hosts.
- Expand settings error categories and ensure stable HTTP status/code mappings for settings-related failures.

Build:
- Add sealantern-extra as an interface crate dependency to reuse shared configuration models.

Tests:
- Add unit tests verifying default Unsupported behavior in the extended settings service and the HTTP classification of new settings errors.

</details>