### PR TITLE
fix(settings): 避免部分更新覆盖持久化新值

### DIFF
--- a/crates/extra/src/config/sealantern/manager.rs
+++ b/crates/extra/src/config/sealantern/manager.rs
@@ -177,33 +177,40 @@ impl SettingsManager {
         }
     }
 
-    /// 部分更新（只传需要改的字段）
-    /// 持久化失败时回滚内存状态
+    /// 部分更新（只传需要改的字段）。
+    ///
+    /// 在单个持久化锁内重新加载磁盘最新值、合并请求并按需写回，避免多个
+    /// 管理器基于过期内存快照覆盖彼此修改。成功后同步内存快照；失败时内存
+    /// 保持调用前状态。
     pub async fn update_partial(
         &mut self,
         partial: PartialAppSettings,
     ) -> Result<UpdateResult, sealantern_infra::fs::FsError> {
-        let old = self.inner.get().clone();
-        self.inner.update(|s| partial.merge_into(s));
-        let changed_groups = old.changed_groups(self.inner.get());
-        if changed_groups.is_empty() {
-            return Ok(UpdateResult {
-                settings: self.inner.get().clone(),
-                changed_groups,
-            });
-        }
-        match self.inner.save(false).await {
-            Ok(()) => {
-                observability::config_settings_partial_updated(&self.path, &changed_groups);
-                Ok(UpdateResult {
-                    settings: self.inner.get().clone(),
-                    changed_groups,
-                })
+        let mut changed_groups = Vec::new();
+        let updated = ConfigFile::update_persisted_if_changed(
+            &self.path,
+            AppSettings::default(),
+            false,
+            |settings| {
+                let previous = settings.clone();
+                partial.merge_into(settings);
+                changed_groups = previous.changed_groups(settings);
+                !changed_groups.is_empty()
+            },
+        )
+        .await;
+
+        match updated {
+            Ok(settings) => {
+                self.inner.set(settings.clone());
+                if !changed_groups.is_empty() {
+                    observability::config_settings_partial_updated(&self.path, &changed_groups);
+                }
+                Ok(UpdateResult { settings, changed_groups })
             }
-            Err(e) => {
-                self.inner.set(old);
-                observability::config_settings_persist_failed(&self.path, "update_partial", &e);
-                Err(e)
+            Err(error) => {
+                observability::config_settings_persist_failed(&self.path, "update_partial", &error);
+                Err(error)
             }
         }
     }
@@ -456,6 +463,7 @@ fn upgrade_settings(settings: &mut AppSettings, from_version: u32) {
 mod tests {
     use super::{default_settings_path, SettingsManager, SETTINGS_FILE_NAME};
     use crate::config::{AppSettings, JavaInfo, PartialAppSettings};
+    use sealantern_infra::fs::{FileLock, FsError};
 
     #[test]
     fn default_path_uses_owned_settings_file_name() {
@@ -516,5 +524,106 @@ mod tests {
             .await
             .expect("persisted settings should reload");
         assert_eq!(reloaded.get().cached_java_list[0].confidence, 87);
+    }
+
+    #[tokio::test]
+    async fn partial_updates_merge_with_the_latest_persisted_settings() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut first = SettingsManager::load(&path)
+            .await
+            .expect("first settings manager should load");
+        let mut second = SettingsManager::load(&path)
+            .await
+            .expect("second settings manager should load");
+
+        first
+            .update_partial(PartialAppSettings {
+                theme: Some("dark".to_string()),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("first partial update should persist");
+
+        let second_result = second
+            .update_partial(PartialAppSettings {
+                default_port: Some(25566),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("second partial update should merge with persisted state");
+
+        assert_eq!(second_result.settings.theme, "dark");
+        assert_eq!(second_result.settings.default_port, 25566);
+        assert_eq!(second.get().theme, "dark");
+        assert_eq!(second.get().default_port, 25566);
+
+        let reloaded = SettingsManager::load(&path)
+            .await
+            .expect("merged settings should reload");
+        assert_eq!(reloaded.get().theme, "dark");
+        assert_eq!(reloaded.get().default_port, 25566);
+    }
+
+    #[tokio::test]
+    async fn partial_updates_keep_last_writer_semantics_for_the_same_field() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut first = SettingsManager::load(&path)
+            .await
+            .expect("first settings manager should load");
+        let mut second = SettingsManager::load(&path)
+            .await
+            .expect("second settings manager should load");
+
+        first
+            .update_partial(PartialAppSettings {
+                theme: Some("dark".to_string()),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("first theme update should persist");
+        second
+            .update_partial(PartialAppSettings {
+                theme: Some("light".to_string()),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("second theme update should persist");
+
+        let reloaded = SettingsManager::load(&path)
+            .await
+            .expect("latest settings should reload");
+        assert_eq!(reloaded.get().theme, "light");
+    }
+
+    #[tokio::test]
+    async fn failed_partial_update_keeps_memory_and_disk_unchanged() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut manager = SettingsManager::load(&path)
+            .await
+            .expect("settings manager should load");
+        let before = tokio::fs::read_to_string(&path)
+            .await
+            .expect("settings fixture should be readable");
+        let file_lock = FileLock::try_acquire(&path).expect("test should acquire settings lock");
+
+        let result = manager
+            .update_partial(PartialAppSettings {
+                theme: Some("dark".to_string()),
+                ..PartialAppSettings::default()
+            })
+            .await;
+
+        assert!(matches!(result, Err(FsError::AlreadyLocked(_))));
+        assert_eq!(manager.get().theme, "auto");
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("settings should remain readable"),
+            before
+        );
+        drop(file_lock);
     }
 }

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -210,19 +210,37 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         auto_backup: bool,
         update: impl FnOnce(&mut T),
     ) -> Result<T, FsError> {
+        Self::update_persisted_if_changed(path, default, auto_backup, |data| {
+            update(data);
+            true
+        })
+        .await
+    }
+
+    /// 在单个文件锁内加载并按需持久化配置。
+    ///
+    /// `update` 在磁盘最新值上执行，并通过返回值声明是否需要写回。即使无需
+    /// 写回，本方法仍返回锁内加载的最新配置，供调用方同步内存快照。
+    pub async fn update_persisted_if_changed(
+        path: impl Into<PathBuf>,
+        default: T,
+        auto_backup: bool,
+        update: impl FnOnce(&mut T) -> bool,
+    ) -> Result<T, FsError> {
         let path = path.into();
         let format = ConfigFormat::from_extension(&path)?;
         let _guard = lock_config(&path).await?;
         let mut data = load_data_or_default(&path, format, default).await?;
 
-        update(&mut data);
-        if auto_backup && path.exists() {
-            backup_path(&path).await?;
+        if update(&mut data) {
+            if auto_backup && path.exists() {
+                backup_path(&path).await?;
+            }
+            let content = format.serialize(&data).map_err(|error| {
+                FsError::serialization("config", "encode", &path, error.to_string())
+            })?;
+            write_atomic(&path, content.as_bytes()).await?;
         }
-        let content = format.serialize(&data).map_err(|error| {
-            FsError::serialization("config", "encode", &path, error.to_string())
-        })?;
-        write_atomic(&path, content.as_bytes()).await?;
         Ok(data)
     }
 
@@ -535,6 +553,28 @@ mod tests {
         let saved = ConfigFile::<TestConfig>::load(&path).await.unwrap();
         assert_eq!(saved.get().port, 30000);
         assert!(!saved.get().enabled);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn conditional_update_returns_latest_data_without_rewriting() {
+        let dir = test_dir("conditional_update");
+        let path = dir.join("settings.json");
+        let original = r#"{"name":"latest","port":30000,"enabled":false}"#;
+        tokio::fs::write(&path, original).await.unwrap();
+
+        let loaded = ConfigFile::<TestConfig>::update_persisted_if_changed(
+            &path,
+            TestConfig::default(),
+            false,
+            |_| false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(loaded.port, 30000);
+        assert!(!loaded.enabled);
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), original);
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -221,6 +221,13 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
     ///
     /// `update` 在磁盘最新值上执行，并通过返回值声明是否需要写回。即使无需
     /// 写回，本方法仍返回锁内加载的最新配置，供调用方同步内存快照。
+    ///
+    /// # 使用约定
+    ///
+    /// `update` 会在进程内写锁和跨进程文件锁均被持有时执行，因此只应完成
+    /// 配置值的内存内变更及是否写回的判断。不得在回调中执行文件或网络 IO、
+    /// 长时间计算等耗时操作；与持久化无关的处理应放在本方法返回后执行。
+    /// 推荐使用体积较小的内联闭包，并避免捕获不必要的大量外部状态。
     pub async fn update_persisted_if_changed(
         path: impl Into<PathBuf>,
         default: T,


### PR DESCRIPTION
- 增加锁内按需更新配置的持久化
- 部分更新基于磁盘最新设置合并并同步内存快照
- 覆盖不同字段合并、同字段后写及失败回滚场景

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

确保部分配置更新在最新持久化设置上进行，并且仅在持久化成功后才更新内存状态，防止各个管理器互相覆盖对方的更改。

Bug Fixes（错误修复）:
- 防止在多个管理器基于过期的内存快照操作时，部分设置更新覆盖更新的持久化配置值。

Enhancements（增强）:
- 优化部分设置更新流程：重新加载最新的磁盘状态，合并请求的更改，并仅在实际有有效修改时进行条件性持久化。
- 引入一个条件性的配置文件更新辅助工具，在单一文件锁下执行更新，并在不需要变更时避免重写文件。

Tests（测试）:
- 添加针对部分设置更新的集成测试，涵盖跨管理器合并行为、同一字段的“最后写入者”语义以及在失败场景下同时保护内存与磁盘状态。
- 添加持久化测试，验证在无须变更时，条件更新会返回最新数据且不会重写底层配置文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure partial configuration updates operate on the latest persisted settings and only update in-memory state on successful persistence, preventing managers from overwriting each other’s changes.

Bug Fixes:
- Prevent partial settings updates from overwriting newer persisted values when multiple managers operate on stale in-memory snapshots.

Enhancements:
- Refine partial settings update to reload the latest disk state, merge requested changes, and conditionally persist only when there are effective modifications.
- Introduce a conditional config file update helper that executes updates under a single file lock and avoids rewriting when no changes are required.

Tests:
- Add integration tests for partial settings updates covering cross-manager merge behavior, last-writer semantics for the same field, and failure scenarios preserving memory and disk.
- Add a persistence test verifying that conditional updates return the latest data without rewriting the underlying config file when no changes are needed.

</details>