### PR TITLE
feat(settings): 增加配置校验与精确错误分类

### DIFF
--- a/application/src/error/settings.rs
+++ b/application/src/error/settings.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use sealantern_infra::fs::FsError;
+use sealantern_extra::config::SettingsError as ExtraSettingsError;
 use sealantern_interface::error::SettingsServiceError;
 
 /// 设置服务主错误类型。
@@ -11,10 +11,15 @@ use sealantern_interface::error::SettingsServiceError;
 /// 转换时收敛为分类，不向宿主泄漏敏感信息。
 #[derive(Debug)]
 pub enum SettingsError {
+    /// 设置内容不符合业务约束或导入内容不合法。
+    InvalidInput {
+        /// extra 配置层提供的原始分类与诊断信息。
+        source: ExtraSettingsError,
+    },
     /// 配置加载、锁定、读取或持久化失败。
     StorageFailed {
-        /// 底层文件系统错误。
-        source: FsError,
+        /// extra 配置层提供的原始分类与诊断信息。
+        source: ExtraSettingsError,
     },
     /// 未分类的配置操作失败。
     OperationFailed {
@@ -26,6 +31,9 @@ pub enum SettingsError {
 impl fmt::Display for SettingsError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidInput { source } => {
+                write!(formatter, "invalid settings input: {source}")
+            }
             Self::StorageFailed { source } => {
                 write!(formatter, "settings storage failed: {source}")
             }
@@ -39,15 +47,19 @@ impl fmt::Display for SettingsError {
 impl std::error::Error for SettingsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::InvalidInput { source } => Some(source),
             Self::StorageFailed { source } => Some(source),
             Self::OperationFailed { source } => Some(source.as_ref()),
         }
     }
 }
 
-impl From<FsError> for SettingsError {
-    fn from(source: FsError) -> Self {
-        Self::StorageFailed { source }
+impl From<ExtraSettingsError> for SettingsError {
+    fn from(source: ExtraSettingsError) -> Self {
+        match source {
+            ExtraSettingsError::InvalidInput { .. } => Self::InvalidInput { source },
+            ExtraSettingsError::Storage { .. } => Self::StorageFailed { source },
+        }
     }
 }
 
@@ -57,8 +69,33 @@ impl From<FsError> for SettingsError {
 impl From<SettingsError> for SettingsServiceError {
     fn from(error: SettingsError) -> Self {
         match error {
+            SettingsError::InvalidInput { .. } => Self::InvalidInput,
             SettingsError::StorageFailed { .. } => Self::StorageFailed,
             SettingsError::OperationFailed { .. } => Self::OperationFailed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use sealantern_extra::config::SettingsError as ExtraSettingsError;
+    use sealantern_infra::fs::FsError;
+
+    use super::*;
+
+    #[test]
+    fn extra_settings_errors_map_to_stable_contract_categories() {
+        let invalid = SettingsError::from(ExtraSettingsError::invalid_input(
+            "default_port",
+            "must be greater than zero",
+        ));
+        assert_eq!(SettingsServiceError::from(invalid), SettingsServiceError::InvalidInput);
+
+        let storage = SettingsError::from(ExtraSettingsError::Storage {
+            source: FsError::AlreadyLocked(PathBuf::from("settings.json")),
+        });
+        assert_eq!(SettingsServiceError::from(storage), SettingsServiceError::StorageFailed);
     }
 }

--- a/crates/extra/src/config/mod.rs
+++ b/crates/extra/src/config/mod.rs
@@ -8,7 +8,7 @@ pub use sealantern::types::{
     SettingsGroup, StartupMode, UpdateResult,
 };
 pub use sealantern::InstanceRegistry;
-pub use sealantern::SettingsManager;
+pub use sealantern::{SettingsError, SettingsManager};
 
 /// 解析应用数据目录，优先使用环境变量 `SEALANTERN_DATA_DIR`。
 pub use sealantern_infra::platform::get_app_data_dir as resolve_data_dir;

--- a/crates/extra/src/config/sealantern/error.rs
+++ b/crates/extra/src/config/sealantern/error.rs
@@ -1,0 +1,63 @@
+//! SeaLantern 设置管理错误。
+
+use std::fmt;
+
+use sealantern_infra::fs::FsError;
+
+use crate::models::SettingsValidationError;
+
+/// 设置加载、校验和持久化操作失败。
+#[derive(Debug)]
+pub enum SettingsError {
+    /// 设置内容不符合业务约束或导入内容不是有效 JSON。
+    InvalidInput {
+        /// 失败字段或输入类别。
+        field: &'static str,
+        /// 不包含敏感数据的失败原因。
+        message: String,
+    },
+    /// 配置文件读取、锁定或持久化失败。
+    Storage {
+        /// 底层文件系统错误。
+        source: FsError,
+    },
+}
+
+impl SettingsError {
+    /// 创建输入错误。
+    pub fn invalid_input(field: &'static str, message: impl Into<String>) -> Self {
+        Self::InvalidInput { field, message: message.into() }
+    }
+}
+
+impl fmt::Display for SettingsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInput { field, message } => {
+                write!(formatter, "invalid setting '{field}': {message}")
+            }
+            Self::Storage { source } => write!(formatter, "settings storage failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for SettingsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidInput { .. } => None,
+            Self::Storage { source } => Some(source),
+        }
+    }
+}
+
+impl From<FsError> for SettingsError {
+    fn from(source: FsError) -> Self {
+        Self::Storage { source }
+    }
+}
+
+impl From<SettingsValidationError> for SettingsError {
+    fn from(error: SettingsValidationError) -> Self {
+        Self::invalid_input(error.field(), error.message())
+    }
+}

--- a/crates/extra/src/config/sealantern/manager.rs
+++ b/crates/extra/src/config/sealantern/manager.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 
 use sealantern_infra::fs::{read_string_limited, write_atomic, DataLimit, FileLock, FsError};
 use sealantern_infra::persistence::config::ConfigFile;
+use sealantern_infra::persistence::config::UpdatePersistedError;
 use sealantern_infra::persistence::process_lock_registry;
 use sealantern_infra::platform::get_app_data_dir;
 use serde::Deserialize;
@@ -22,6 +23,8 @@ use tokio::sync::OwnedRwLockWriteGuard;
 use super::types::{
     AppSettings, JavaInfo, PartialAppSettings, UpdateResult, CURRENT_CONFIG_VERSION,
 };
+use super::SettingsError;
+use crate::models::SettingsValidationError;
 use crate::observability;
 
 /// 配置文件读取上限：最大 10 MiB。
@@ -74,7 +77,7 @@ impl SettingsManager {
     ///
     /// 默认路径、文件名和持久化策略均由配置模块统一管理；调用方无需了解
     /// 配置文件在不同运行环境中的具体位置。
-    pub async fn load_default() -> Result<Self, FsError> {
+    pub async fn load_default() -> Result<Self, SettingsError> {
         Self::load(default_settings_path()).await
     }
 
@@ -85,7 +88,7 @@ impl SettingsManager {
     /// 2. 文件不存在 → 创建默认配置；
     /// 3. 文件损坏 → 备份隔离原文件，恢复默认配置并告警；
     /// 4. 版本落后 → 备份后分步升级。
-    pub async fn load(path: impl Into<PathBuf>) -> Result<Self, sealantern_infra::fs::FsError> {
+    pub async fn load(path: impl Into<PathBuf>) -> Result<Self, SettingsError> {
         let path = path.into();
 
         // 旧版嵌套格式检测与迁移（锁内执行，迁移前自动备份旧文件）
@@ -105,7 +108,7 @@ impl SettingsManager {
             }
             Err(e) => {
                 // 锁冲突、IO 错误等：直接传播，不能把用户配置当损坏隔离
-                return Err(e);
+                return Err(e.into());
             }
         };
 
@@ -144,7 +147,7 @@ impl SettingsManager {
     pub async fn update_java_cache(
         &mut self,
         installations: Vec<JavaInfo>,
-    ) -> Result<UpdateResult, sealantern_infra::fs::FsError> {
+    ) -> Result<UpdateResult, SettingsError> {
         let partial = PartialAppSettings {
             cached_java_list: Some(installations),
             ..PartialAppSettings::default()
@@ -154,10 +157,8 @@ impl SettingsManager {
 
     /// 全量替换设置并持久化
     /// 持久化失败时回滚内存状态
-    pub async fn update(
-        &mut self,
-        new: AppSettings,
-    ) -> Result<UpdateResult, sealantern_infra::fs::FsError> {
+    pub async fn update(&mut self, new: AppSettings) -> Result<UpdateResult, SettingsError> {
+        new.validate()?;
         let old = self.inner.get().clone();
         let changed_groups = old.changed_groups(&new);
         self.inner.set(new);
@@ -172,7 +173,7 @@ impl SettingsManager {
             Err(e) => {
                 self.inner.set(old);
                 observability::config_settings_persist_failed(&self.path, "update", &e);
-                Err(e)
+                Err(e.into())
             }
         }
     }
@@ -185,20 +186,22 @@ impl SettingsManager {
     pub async fn update_partial(
         &mut self,
         partial: PartialAppSettings,
-    ) -> Result<UpdateResult, sealantern_infra::fs::FsError> {
+    ) -> Result<UpdateResult, SettingsError> {
         let mut changed_groups = Vec::new();
-        let updated = ConfigFile::update_persisted_if_changed(
-            &self.path,
-            AppSettings::default(),
-            false,
-            |settings| {
-                let previous = settings.clone();
-                partial.merge_into(settings);
-                changed_groups = previous.changed_groups(settings);
-                !changed_groups.is_empty()
-            },
-        )
-        .await;
+        let updated: Result<_, UpdatePersistedError<SettingsValidationError>> =
+            ConfigFile::try_update_persisted_if_changed(
+                &self.path,
+                AppSettings::default(),
+                false,
+                |settings| {
+                    let previous = settings.clone();
+                    partial.merge_into(settings);
+                    settings.validate()?;
+                    changed_groups = previous.changed_groups(settings);
+                    Ok::<bool, SettingsValidationError>(!changed_groups.is_empty())
+                },
+            )
+            .await;
 
         match updated {
             Ok(settings) => {
@@ -208,16 +211,17 @@ impl SettingsManager {
                 }
                 Ok(UpdateResult { settings, changed_groups })
             }
-            Err(error) => {
+            Err(UpdatePersistedError::Storage(error)) => {
                 observability::config_settings_persist_failed(&self.path, "update_partial", &error);
-                Err(error)
+                Err(error.into())
             }
+            Err(UpdatePersistedError::Update(error)) => Err(error.into()),
         }
     }
 
     /// 重置为默认设置
     /// 持久化失败时回滚内存状态，与 `update`/`update_partial` 语义一致
-    pub async fn reset(&mut self) -> Result<AppSettings, sealantern_infra::fs::FsError> {
+    pub async fn reset(&mut self) -> Result<AppSettings, SettingsError> {
         let old = self.inner.get().clone();
         let default = AppSettings::default();
         self.inner.set(default.clone());
@@ -229,38 +233,29 @@ impl SettingsManager {
             Err(e) => {
                 self.inner.set(old);
                 observability::config_settings_persist_failed(&self.path, "reset", &e);
-                Err(e)
+                Err(e.into())
             }
         }
     }
 
     /// 导出设置为 JSON 字符串
-    pub fn export_json(&self) -> Result<String, sealantern_infra::fs::FsError> {
-        let json = serde_json::to_string_pretty(self.inner.get()).map_err(|e| {
-            sealantern_infra::fs::FsError::Serialization {
+    pub fn export_json(&self) -> Result<String, SettingsError> {
+        let json = serde_json::to_string_pretty(self.inner.get())
+            .map_err(|e| sealantern_infra::fs::FsError::Serialization {
                 format: "json",
                 operation: "serialize settings",
                 path: self.path.clone(),
                 message: e.to_string(),
-            }
-        })?;
+            })
+            .map_err(SettingsError::from)?;
         observability::config_settings_exported(&self.path);
         Ok(json)
     }
 
     /// 从 JSON 字符串导入设置
-    pub async fn import_json(
-        &mut self,
-        json: &str,
-    ) -> Result<UpdateResult, sealantern_infra::fs::FsError> {
-        let imported: AppSettings = serde_json::from_str(json).map_err(|e| {
-            sealantern_infra::fs::FsError::Serialization {
-                format: "json",
-                operation: "deserialize settings",
-                path: self.path.clone(),
-                message: e.to_string(),
-            }
-        })?;
+    pub async fn import_json(&mut self, json: &str) -> Result<UpdateResult, SettingsError> {
+        let imported: AppSettings = serde_json::from_str(json)
+            .map_err(|error| SettingsError::invalid_input("json", error.to_string()))?;
         let result = self.update(imported).await?;
         observability::config_settings_imported(&self.path, &result.changed_groups);
         Ok(result)
@@ -465,6 +460,8 @@ mod tests {
     use crate::config::{AppSettings, JavaInfo, PartialAppSettings};
     use sealantern_infra::fs::{FileLock, FsError};
 
+    use super::SettingsError;
+
     #[test]
     fn default_path_uses_owned_settings_file_name() {
         assert_eq!(
@@ -616,7 +613,10 @@ mod tests {
             })
             .await;
 
-        assert!(matches!(result, Err(FsError::AlreadyLocked(_))));
+        assert!(matches!(
+            result,
+            Err(SettingsError::Storage { source: FsError::AlreadyLocked(_) })
+        ));
         assert_eq!(manager.get().theme, "auto");
         assert_eq!(
             tokio::fs::read_to_string(&path)
@@ -625,5 +625,89 @@ mod tests {
             before
         );
         drop(file_lock);
+    }
+
+    #[tokio::test]
+    async fn invalid_full_update_keeps_memory_and_disk_unchanged() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut manager = SettingsManager::load(&path)
+            .await
+            .expect("settings manager should load");
+        let before = tokio::fs::read_to_string(&path)
+            .await
+            .expect("settings fixture should be readable");
+        let mut invalid = manager.get().clone();
+        invalid.default_min_memory = invalid.default_max_memory + 1;
+
+        let result = manager.update(invalid).await;
+
+        assert!(matches!(
+            result,
+            Err(SettingsError::InvalidInput { field: "default_min_memory", .. })
+        ));
+        assert_eq!(manager.get().default_min_memory, 512);
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("settings should remain readable"),
+            before
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_partial_update_keeps_memory_and_disk_unchanged() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut manager = SettingsManager::load(&path)
+            .await
+            .expect("settings manager should load");
+        let before = tokio::fs::read_to_string(&path)
+            .await
+            .expect("settings fixture should be readable");
+
+        let result = manager
+            .update_partial(PartialAppSettings {
+                default_port: Some(0),
+                ..PartialAppSettings::default()
+            })
+            .await;
+
+        assert!(matches!(result, Err(SettingsError::InvalidInput { field: "default_port", .. })));
+        assert_eq!(manager.get().default_port, 25565);
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("settings should remain readable"),
+            before
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_import_is_classified_without_mutating_settings() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut manager = SettingsManager::load(&path)
+            .await
+            .expect("settings manager should load");
+        let before = tokio::fs::read_to_string(&path)
+            .await
+            .expect("settings fixture should be readable");
+
+        let malformed = manager.import_json("not-json").await;
+        assert!(matches!(malformed, Err(SettingsError::InvalidInput { field: "json", .. })));
+
+        let invalid = manager.import_json(r#"{"default_port":0}"#).await;
+        assert!(matches!(
+            invalid,
+            Err(SettingsError::InvalidInput { field: "default_port", .. })
+        ));
+        assert_eq!(manager.get().default_port, 25565);
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("settings should remain readable"),
+            before
+        );
     }
 }

--- a/crates/extra/src/config/sealantern/mod.rs
+++ b/crates/extra/src/config/sealantern/mod.rs
@@ -1,7 +1,9 @@
+mod error;
 pub mod manager;
 pub mod registry;
 pub mod store;
 pub mod types;
 
+pub use error::SettingsError;
 pub use manager::SettingsManager;
 pub use registry::InstanceRegistry;

--- a/crates/extra/src/models/app.rs
+++ b/crates/extra/src/models/app.rs
@@ -12,6 +12,37 @@ pub const CURRENT_CONFIG_VERSION: u32 = 2;
 /// 亚克力模糊级别的默认值，旧配置缺字段时回落到这里。
 pub const DEFAULT_ACRYLIC_BLUR_LEVEL: &str = "medium";
 
+/// 完整设置不符合业务约束。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingsValidationError {
+    field: &'static str,
+    message: &'static str,
+}
+
+impl SettingsValidationError {
+    fn new(field: &'static str, message: &'static str) -> Self {
+        Self { field, message }
+    }
+
+    /// 返回违反约束的设置字段。
+    pub fn field(self) -> &'static str {
+        self.field
+    }
+
+    /// 返回不包含用户数据的稳定校验原因。
+    pub fn message(self) -> &'static str {
+        self.message
+    }
+}
+
+impl std::fmt::Display for SettingsValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "invalid setting '{}': {}", self.field, self.message)
+    }
+}
+
+impl std::error::Error for SettingsValidationError {}
+
 /// 设置变更分组，用于调用方按组刷新状态。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SettingsGroup {
@@ -123,6 +154,46 @@ impl Default for AppSettings {
 }
 
 impl AppSettings {
+    /// 校验写入配置文件前必须满足的业务不变量。
+    pub fn validate(&self) -> Result<(), SettingsValidationError> {
+        if self.default_min_memory == 0 {
+            return Err(SettingsValidationError::new(
+                "default_min_memory",
+                "must be greater than zero",
+            ));
+        }
+        if self.default_max_memory == 0 {
+            return Err(SettingsValidationError::new(
+                "default_max_memory",
+                "must be greater than zero",
+            ));
+        }
+        if self.default_min_memory > self.default_max_memory {
+            return Err(SettingsValidationError::new(
+                "default_min_memory",
+                "must not exceed default_max_memory",
+            ));
+        }
+        if self.default_port == 0 {
+            return Err(SettingsValidationError::new("default_port", "must be greater than zero"));
+        }
+        validate_unit_interval("background_opacity", self.background_opacity)?;
+        validate_unit_interval("background_brightness", self.background_brightness)?;
+        if self.window_width == Some(0) {
+            return Err(SettingsValidationError::new(
+                "window_width",
+                "must be greater than zero when set",
+            ));
+        }
+        if self.window_height == Some(0) {
+            return Err(SettingsValidationError::new(
+                "window_height",
+                "must be greater than zero when set",
+            ));
+        }
+        Ok(())
+    }
+
     /// 返回与 `other` 相比发生变更的分组列表。
     pub fn changed_groups(&self, other: &Self) -> Vec<SettingsGroup> {
         let mut groups = Vec::new();
@@ -197,6 +268,17 @@ impl AppSettings {
     }
 }
 
+fn validate_unit_interval(field: &'static str, value: f32) -> Result<(), SettingsValidationError> {
+    if value.is_finite() && (0.0..=1.0).contains(&value) {
+        Ok(())
+    } else {
+        Err(SettingsValidationError::new(
+            field,
+            "must be a finite value between zero and one",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{AppSettings, SettingsGroup, DEFAULT_ACRYLIC_BLUR_LEVEL};
@@ -216,5 +298,116 @@ mod tests {
         changed.acrylic_blur_level = "high".into();
 
         assert_eq!(current.changed_groups(&changed), vec![SettingsGroup::Appearance]);
+    }
+
+    #[test]
+    fn default_settings_satisfy_validation_rules() {
+        AppSettings::default()
+            .validate()
+            .expect("default settings should always remain valid");
+    }
+
+    #[test]
+    fn validation_rejects_invalid_memory_and_port_values() {
+        let settings = AppSettings {
+            default_min_memory: 0,
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("zero minimum memory should fail")
+                .field(),
+            "default_min_memory"
+        );
+
+        let settings = AppSettings {
+            default_max_memory: 0,
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("zero maximum memory should fail")
+                .field(),
+            "default_max_memory"
+        );
+
+        let settings = AppSettings {
+            default_min_memory: AppSettings::default().default_max_memory + 1,
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("minimum memory above maximum should fail")
+                .field(),
+            "default_min_memory"
+        );
+
+        let settings = AppSettings {
+            default_port: 0,
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("zero port should fail")
+                .field(),
+            "default_port"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_invalid_visual_numeric_values() {
+        for invalid in [-0.1, 1.1, f32::NAN, f32::INFINITY] {
+            let settings = AppSettings {
+                background_opacity: invalid,
+                ..AppSettings::default()
+            };
+            assert_eq!(
+                settings
+                    .validate()
+                    .expect_err("invalid opacity should fail")
+                    .field(),
+                "background_opacity"
+            );
+        }
+
+        let settings = AppSettings {
+            background_brightness: f32::NEG_INFINITY,
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("invalid brightness should fail")
+                .field(),
+            "background_brightness"
+        );
+
+        let settings = AppSettings {
+            window_width: Some(0),
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("zero window width should fail")
+                .field(),
+            "window_width"
+        );
+
+        let settings = AppSettings {
+            window_height: Some(0),
+            ..AppSettings::default()
+        };
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("zero window height should fail")
+                .field(),
+            "window_height"
+        );
     }
 }

--- a/crates/extra/src/models/mod.rs
+++ b/crates/extra/src/models/mod.rs
@@ -10,7 +10,10 @@ mod java;
 mod server;
 mod task;
 
-pub use app::{AppSettings, SettingsGroup, CURRENT_CONFIG_VERSION, DEFAULT_ACRYLIC_BLUR_LEVEL};
+pub use app::{
+    AppSettings, SettingsGroup, SettingsValidationError, CURRENT_CONFIG_VERSION,
+    DEFAULT_ACRYLIC_BLUR_LEVEL,
+};
 pub use app_update::{NullablePatch, PartialAppSettings, UpdateResult};
 pub use download_link::{BaseDownloadLinks, DownloadLink, TypeDownloadLinks};
 pub use java::JavaInfo;

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -62,6 +62,12 @@ impl<E> From<FsError> for UpdatePersistedError<E> {
     }
 }
 
+impl<E> From<ConfigError> for UpdatePersistedError<E> {
+    fn from(error: ConfigError) -> Self {
+        Self::Storage(error.into())
+    }
+}
+
 impl std::fmt::Display for ConfigError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -290,21 +296,13 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         update: impl FnOnce(&mut T) -> Result<bool, E>,
     ) -> Result<T, UpdatePersistedError<E>> {
         let path = path.into();
-        let format = ConfigFormat::from_extension(&path)
-            .map_err(FsError::from)
-            .map_err(UpdatePersistedError::Storage)?;
-        let _guard = lock_config(&path)
-            .await
-            .map_err(UpdatePersistedError::Storage)?;
-        let mut data = load_data_or_default(&path, format, default)
-            .await
-            .map_err(UpdatePersistedError::Storage)?;
+        let format = ConfigFormat::from_extension(&path)?;
+        let _guard = lock_config(&path).await?;
+        let mut data = load_data_or_default(&path, format, default).await?;
 
         if update(&mut data).map_err(UpdatePersistedError::Update)? {
             if auto_backup && path.exists() {
-                backup_path(&path)
-                    .await
-                    .map_err(UpdatePersistedError::Storage)?;
+                backup_path(&path).await?;
             }
             let content = format.serialize(&data).map_err(|error| {
                 UpdatePersistedError::Storage(FsError::serialization(
@@ -314,9 +312,7 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
                     error.to_string(),
                 ))
             })?;
-            write_atomic(&path, content.as_bytes())
-                .await
-                .map_err(UpdatePersistedError::Storage)?;
+            write_atomic(&path, content.as_bytes()).await?;
         }
         Ok(data)
     }
@@ -679,5 +675,21 @@ mod tests {
         assert!(matches!(result, Err(UpdatePersistedError::Update(Rejected))));
         assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), original);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn fallible_update_preserves_config_format_error_classification() {
+        let result = ConfigFile::<TestConfig>::try_update_persisted_if_changed(
+            "settings.invalid",
+            TestConfig::default(),
+            false,
+            |_| Ok::<bool, Infallible>(false),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(UpdatePersistedError::Storage(FsError::InvalidPath { .. }))
+        ));
     }
 }

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::path::{Path, PathBuf};
 
 use serde::de::DeserializeOwned;
@@ -26,6 +27,39 @@ pub enum ConfigError {
     },
     /// 文件扩展名不匹配任何支持的格式。
     UnsupportedFormat { path: PathBuf },
+}
+
+/// 锁内配置更新失败。
+#[derive(Debug)]
+pub enum UpdatePersistedError<E> {
+    /// 配置读取、锁定、序列化或写入失败。
+    Storage(FsError),
+    /// 更新回调拒绝了本次修改。
+    Update(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for UpdatePersistedError<E> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Storage(error) => write!(formatter, "persisted config storage failed: {error}"),
+            Self::Update(error) => write!(formatter, "persisted config update rejected: {error}"),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for UpdatePersistedError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Storage(error) => Some(error),
+            Self::Update(error) => Some(error),
+        }
+    }
+}
+
+impl<E> From<FsError> for UpdatePersistedError<E> {
+    fn from(error: FsError) -> Self {
+        Self::Storage(error)
+    }
 }
 
 impl std::fmt::Display for ConfigError {
@@ -234,19 +268,55 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         auto_backup: bool,
         update: impl FnOnce(&mut T) -> bool,
     ) -> Result<T, FsError> {
-        let path = path.into();
-        let format = ConfigFormat::from_extension(&path)?;
-        let _guard = lock_config(&path).await?;
-        let mut data = load_data_or_default(&path, format, default).await?;
+        match Self::try_update_persisted_if_changed(path, default, auto_backup, |data| {
+            Ok::<bool, Infallible>(update(data))
+        })
+        .await
+        {
+            Ok(data) => Ok(data),
+            Err(UpdatePersistedError::Storage(error)) => Err(error),
+            Err(UpdatePersistedError::Update(never)) => match never {},
+        }
+    }
 
-        if update(&mut data) {
+    /// 在单个文件锁内加载、校验并按需持久化配置。
+    ///
+    /// 与 [`Self::update_persisted_if_changed`] 的锁内执行约定相同，但允许更新
+    /// 回调以业务错误拒绝修改。回调失败时不会执行备份或写盘。
+    pub async fn try_update_persisted_if_changed<E>(
+        path: impl Into<PathBuf>,
+        default: T,
+        auto_backup: bool,
+        update: impl FnOnce(&mut T) -> Result<bool, E>,
+    ) -> Result<T, UpdatePersistedError<E>> {
+        let path = path.into();
+        let format = ConfigFormat::from_extension(&path)
+            .map_err(FsError::from)
+            .map_err(UpdatePersistedError::Storage)?;
+        let _guard = lock_config(&path)
+            .await
+            .map_err(UpdatePersistedError::Storage)?;
+        let mut data = load_data_or_default(&path, format, default)
+            .await
+            .map_err(UpdatePersistedError::Storage)?;
+
+        if update(&mut data).map_err(UpdatePersistedError::Update)? {
             if auto_backup && path.exists() {
-                backup_path(&path).await?;
+                backup_path(&path)
+                    .await
+                    .map_err(UpdatePersistedError::Storage)?;
             }
             let content = format.serialize(&data).map_err(|error| {
-                FsError::serialization("config", "encode", &path, error.to_string())
+                UpdatePersistedError::Storage(FsError::serialization(
+                    "config",
+                    "encode",
+                    &path,
+                    error.to_string(),
+                ))
             })?;
-            write_atomic(&path, content.as_bytes()).await?;
+            write_atomic(&path, content.as_bytes())
+                .await
+                .map_err(UpdatePersistedError::Storage)?;
         }
         Ok(data)
     }
@@ -581,6 +651,32 @@ mod tests {
 
         assert_eq!(loaded.port, 30000);
         assert!(!loaded.enabled);
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), original);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn fallible_update_rejection_does_not_rewrite_the_file() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Rejected;
+
+        let dir = test_dir("fallible_update_rejected");
+        let path = dir.join("settings.json");
+        let original = r#"{"name":"latest","port":30000,"enabled":false}"#;
+        tokio::fs::write(&path, original).await.unwrap();
+
+        let result = ConfigFile::<TestConfig>::try_update_persisted_if_changed(
+            &path,
+            TestConfig::default(),
+            false,
+            |config| {
+                config.port = 25565;
+                Err(Rejected)
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(UpdatePersistedError::Update(Rejected))));
         assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), original);
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- 在 extra 定义设置校验规则与设置域错误
- 覆盖全量、部分及导入写入口并保证失败不落盘
- 增加可失败的锁内持久化事务并贯通应用错误映射

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

通过引入设置验证和结构化错误分类，确保无效的配置更改在未持久化前就被拒绝，同时将“额外配置层”的错误映射到稳定的“服务层级”错误类别中。

New Features:
- 在每一次写入之前，对应用设置进行业务规则验证，覆盖内存限制、端口、窗口尺寸以及视觉数值范围。
- 暴露一种可失败且在锁内执行的配置更新机制，使其能够以领域特定错误拒绝变更，而不触及底层配置文件。
- 在额外配置层提供专门的设置错误类型，并将其传播到应用错误模型中，统一归类为稳定的 `InvalidInput` 与 `StorageFailed` 两大类别。

Bug Fixes:
- 确保完整、部分以及导入式设置更新在验证失败或输入格式错误时，不会修改内存中的配置或磁盘上的配置文件。

Enhancements:
- 优化设置管理器 API，使用新的设置错误类型替代原始文件系统错误，提高错误分类的精度和可观测性。
- 在基础设施层、额外配置层和应用层增添单元测试，以验证各项校验规则、对被拒绝更新的不持久化行为，以及错误类别映射的正确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce settings validation and structured error categorization to ensure invalid configuration changes are rejected without persisting, while mapping extra-layer errors into stable service-level categories.

New Features:
- Add business-rule validation for application settings before any write, covering memory limits, ports, window dimensions, and visual numeric ranges.
- Expose a fallible, in-lock config update mechanism that can reject changes with domain-specific errors without touching the backing file.
- Provide a dedicated settings error type in the extra config layer and propagate it to the application error model with stable InvalidInput vs StorageFailed categories.

Bug Fixes:
- Ensure full, partial, and imported settings updates do not mutate in-memory or on-disk configuration when validation fails or input is malformed.

Enhancements:
- Refine settings manager APIs to use the new settings error type instead of raw filesystem errors, improving error classification and observability.
- Add unit tests across infra, extra, and application layers to verify validation rules, non-persistence on rejected updates, and correct error category mapping.

</details>