### PR TITLE
feat(settings): 持久化全局代理配置

### DIFF
--- a/crates/extra/src/config/sealantern/manager.rs
+++ b/crates/extra/src/config/sealantern/manager.rs
@@ -449,6 +449,7 @@ fn upgrade_settings(settings: &mut AppSettings, from_version: u32) {
     while version < CURRENT_CONFIG_VERSION {
         // v0 → v1：扁平结构首次引入，此前旧版数据由 legacy 迁移处理。
         // v1 → v2：Java 缓存新增置信度字段，缺失值由 serde 默认补齐。
+        // v2 → v3：新增全局代理设置，缺失值由 serde 默认补为 Adaptive。
         version += 1;
     }
     settings.config_version = CURRENT_CONFIG_VERSION;
@@ -458,7 +459,9 @@ fn upgrade_settings(settings: &mut AppSettings, from_version: u32) {
 mod tests {
     use super::{default_settings_path, SettingsManager, SETTINGS_FILE_NAME};
     use crate::config::{AppSettings, JavaInfo, PartialAppSettings};
+    use crate::models::CURRENT_CONFIG_VERSION;
     use sealantern_infra::fs::{FileLock, FsError};
+    use sealantern_infra::net::proxy::{ProxyMode, ProxySettings};
 
     use super::SettingsError;
 
@@ -709,5 +712,39 @@ mod tests {
                 .expect("settings should remain readable"),
             before
         );
+    }
+
+    #[tokio::test]
+    async fn version_two_settings_upgrade_with_adaptive_proxy() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut version_two = serde_json::to_value(AppSettings::default())
+            .expect("settings fixture should serialize");
+        version_two["config_version"] = 2.into();
+        version_two
+            .as_object_mut()
+            .expect("settings fixture should be an object")
+            .remove("proxy");
+        tokio::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&version_two).expect("settings fixture should encode"),
+        )
+        .await
+        .expect("version two fixture should be written");
+
+        let manager = SettingsManager::load(&path)
+            .await
+            .expect("version two settings should upgrade");
+
+        assert_eq!(manager.get().config_version, CURRENT_CONFIG_VERSION);
+        assert_eq!(manager.get().proxy, ProxySettings::default());
+        let persisted: AppSettings = serde_json::from_slice(
+            &tokio::fs::read(&path)
+                .await
+                .expect("upgraded settings should be readable"),
+        )
+        .expect("upgraded settings should decode");
+        assert_eq!(persisted.config_version, CURRENT_CONFIG_VERSION);
+        assert_eq!(persisted.proxy.mode, ProxyMode::Adaptive);
     }
 }

--- a/crates/extra/src/models/app.rs
+++ b/crates/extra/src/models/app.rs
@@ -1,5 +1,6 @@
 //! 应用设置模型与变更分组。
 
+use sealantern_infra::net::proxy::ProxySettings;
 use serde::{Deserialize, Serialize};
 
 use super::JavaInfo;
@@ -7,7 +8,7 @@ use super::JavaInfo;
 /// 当前配置版本号。
 ///
 /// 每次配置结构变更时递增，由配置管理器据此执行数据迁移。
-pub const CURRENT_CONFIG_VERSION: u32 = 2;
+pub const CURRENT_CONFIG_VERSION: u32 = 3;
 
 /// 亚克力模糊级别的默认值，旧配置缺字段时回落到这里。
 pub const DEFAULT_ACRYLIC_BLUR_LEVEL: &str = "medium";
@@ -47,6 +48,7 @@ impl std::error::Error for SettingsValidationError {}
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SettingsGroup {
     General,
+    Network,
     ServerDefaults,
     Console,
     Appearance,
@@ -65,6 +67,9 @@ pub struct AppSettings {
     pub close_servers_on_update: bool,
     pub auto_accept_eula: bool,
     pub close_action: String,
+
+    /// 全局出站网络代理策略。
+    pub proxy: ProxySettings,
 
     pub default_max_memory: u32,
     pub default_min_memory: u32,
@@ -115,6 +120,7 @@ impl Default for AppSettings {
             close_servers_on_update: true,
             auto_accept_eula: true,
             close_action: "ask".into(),
+            proxy: ProxySettings::default(),
             default_max_memory: 2048,
             default_min_memory: 512,
             default_port: 25565,
@@ -177,6 +183,16 @@ impl AppSettings {
         if self.default_port == 0 {
             return Err(SettingsValidationError::new("default_port", "must be greater than zero"));
         }
+        self.proxy.validate().map_err(|error| {
+            SettingsValidationError::new(
+                "proxy",
+                match error {
+                    sealantern_infra::net::proxy::ProxyConfigError::EmptyManualProxy => {
+                        "manual proxy URL must not be empty"
+                    }
+                },
+            )
+        })?;
         validate_unit_interval("background_opacity", self.background_opacity)?;
         validate_unit_interval("background_brightness", self.background_brightness)?;
         if self.window_width == Some(0) {
@@ -204,6 +220,10 @@ impl AppSettings {
             || self.close_action != other.close_action
         {
             groups.push(SettingsGroup::General);
+        }
+
+        if self.proxy != other.proxy {
+            groups.push(SettingsGroup::Network);
         }
 
         if self.default_max_memory != other.default_max_memory
@@ -281,6 +301,8 @@ fn validate_unit_interval(field: &'static str, value: f32) -> Result<(), Setting
 
 #[cfg(test)]
 mod tests {
+    use sealantern_infra::net::proxy::{ProxyMode, ProxySettings};
+
     use super::{AppSettings, SettingsGroup, DEFAULT_ACRYLIC_BLUR_LEVEL};
 
     #[test]
@@ -298,6 +320,60 @@ mod tests {
         changed.acrylic_blur_level = "high".into();
 
         assert_eq!(current.changed_groups(&changed), vec![SettingsGroup::Appearance]);
+    }
+
+    #[test]
+    fn legacy_settings_default_to_adaptive_proxy() {
+        let settings: AppSettings =
+            serde_json::from_str("{}").expect("legacy settings should load with defaults");
+
+        assert_eq!(settings.proxy, ProxySettings::default());
+    }
+
+    #[test]
+    fn proxy_settings_use_stable_app_json_shape() {
+        let settings = AppSettings {
+            proxy: ProxySettings {
+                mode: ProxyMode::Manual {
+                    proxy_url: "http://127.0.0.1:7890".into(),
+                },
+            },
+            ..AppSettings::default()
+        };
+
+        let value = serde_json::to_value(&settings).expect("app settings should serialize");
+
+        assert_eq!(value["proxy"]["mode"], "manual");
+        assert_eq!(value["proxy"]["proxy_url"], "http://127.0.0.1:7890");
+    }
+
+    #[test]
+    fn proxy_change_marks_network_group() {
+        let current = AppSettings::default();
+        let changed = AppSettings {
+            proxy: ProxySettings { mode: ProxyMode::Disabled },
+            ..current.clone()
+        };
+
+        assert_eq!(current.changed_groups(&changed), vec![SettingsGroup::Network]);
+    }
+
+    #[test]
+    fn validation_rejects_empty_manual_proxy() {
+        let settings = AppSettings {
+            proxy: ProxySettings {
+                mode: ProxyMode::Manual { proxy_url: "  ".into() },
+            },
+            ..AppSettings::default()
+        };
+
+        assert_eq!(
+            settings
+                .validate()
+                .expect_err("empty manual proxy should fail")
+                .field(),
+            "proxy"
+        );
     }
 
     #[test]

--- a/crates/extra/src/models/app_update.rs
+++ b/crates/extra/src/models/app_update.rs
@@ -1,5 +1,6 @@
 //! 应用设置的部分更新模型。
 
+use sealantern_infra::net::proxy::ProxySettings;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{AppSettings, JavaInfo, SettingsGroup};
@@ -51,6 +52,8 @@ pub struct PartialAppSettings {
     pub close_servers_on_update: Option<bool>,
     pub auto_accept_eula: Option<bool>,
     pub close_action: Option<String>,
+
+    pub proxy: Option<ProxySettings>,
 
     pub default_max_memory: Option<u32>,
     pub default_min_memory: Option<u32>,
@@ -113,6 +116,9 @@ impl PartialAppSettings {
         }
         if let Some(value) = &self.close_action {
             target.close_action.clone_from(value);
+        }
+        if let Some(value) = &self.proxy {
+            target.proxy.clone_from(value);
         }
         if let Some(value) = self.default_max_memory {
             target.default_max_memory = value;
@@ -228,6 +234,8 @@ pub struct UpdateResult {
 
 #[cfg(test)]
 mod tests {
+    use sealantern_infra::net::proxy::{ProxyMode, ProxySettings};
+
     use super::{AppSettings, NullablePatch, PartialAppSettings};
 
     #[test]
@@ -278,5 +286,29 @@ mod tests {
 
         assert!(value.get("window_x").is_none());
         assert!(value.get("locales_base_url").is_none());
+    }
+
+    #[test]
+    fn partial_settings_can_replace_proxy_strategy() {
+        let mut settings = AppSettings::default();
+        let partial = PartialAppSettings {
+            proxy: Some(ProxySettings {
+                mode: ProxyMode::Manual {
+                    proxy_url: "http://127.0.0.1:7890".into(),
+                },
+            }),
+            ..PartialAppSettings::default()
+        };
+
+        partial.merge_into(&mut settings);
+
+        assert_eq!(
+            settings.proxy,
+            ProxySettings {
+                mode: ProxyMode::Manual {
+                    proxy_url: "http://127.0.0.1:7890".into()
+                }
+            }
+        );
     }
 }

--- a/crates/infra/src/net/proxy/config.rs
+++ b/crates/infra/src/net/proxy/config.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 /// 应用程序配置层负责该值的存储位置和迁移方式。此类型故意不包含文件系统行为。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProxySettings {
+    /// 将代理模式的内部 tag 与相关字段直接展开到设置对象，保持持久化 JSON 简洁。
+    #[serde(flatten)]
     pub mode: ProxyMode,
 }
 
@@ -84,5 +86,24 @@ mod tests {
         };
 
         assert_eq!(settings.validate(), Err(ProxyConfigError::EmptyManualProxy));
+    }
+
+    #[test]
+    fn settings_use_a_flat_persisted_shape() {
+        let settings = ProxySettings {
+            mode: ProxyMode::Manual {
+                proxy_url: "http://127.0.0.1:7890".into(),
+            },
+        };
+
+        let value = serde_json::to_value(&settings).expect("proxy settings should serialize");
+
+        assert_eq!(value["mode"], "manual");
+        assert_eq!(value["proxy_url"], "http://127.0.0.1:7890");
+        assert_eq!(
+            serde_json::from_value::<ProxySettings>(value)
+                .expect("proxy settings should round trip"),
+            settings
+        );
     }
 }

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -3,6 +3,7 @@ import type { JavaInfo } from "@api/java";
 
 export type SettingsGroup =
   | "General"
+  | "Network"
   | "ServerDefaults"
   | "Console"
   | "Appearance"
@@ -13,6 +14,12 @@ export type AcrylicBlurLevel = "off" | "low" | "medium" | "high";
 
 /** 亚克力模糊级别的默认值，旧配置缺字段或值非法时回落到这里 */
 export const DEFAULT_ACRYLIC_BLUR_LEVEL: AcrylicBlurLevel = "medium";
+
+export type ProxySettings =
+  | { mode: "adaptive" }
+  | { mode: "preserve" }
+  | { mode: "manual"; proxy_url: string }
+  | { mode: "disabled" };
 
 export interface AppSettings {
   close_servers_on_exit: boolean;
@@ -48,6 +55,7 @@ export interface AppSettings {
   locales_base_url?: string;
   developer_mode: boolean;
   close_action: string;
+  proxy: ProxySettings;
   last_run_path: string;
   minimal_mode: boolean;
   agreed_to_terms: boolean;
@@ -86,6 +94,7 @@ export interface PartialSettings {
   language?: string;
   developer_mode?: boolean;
   close_action?: string;
+  proxy?: ProxySettings;
   last_run_path?: string;
   minimal_mode?: boolean;
   agreed_to_terms?: boolean;

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -71,6 +71,7 @@ const defaultSettings: AppSettings = {
   language: "zh-CN",
   developer_mode: false,
   close_action: "ask",
+  proxy: { mode: "adaptive" },
   last_run_path: "",
   minimal_mode: false,
   agreed_to_terms: false,


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)（改动较少，实测对样式无任何影响，纯逻辑改动）
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- 将代理策略接入完整与部分应用设置模型
- 配置版本升级至 v3 并为旧配置补充自适应代理
- 统一 Rust 与前端代理契约及网络变更分组



<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

在应用配置中持久化全局网络代理设置，并在后端和前端的设置模型中一致地呈现这些设置。

新功能：
- 将全局出站代理配置添加到完整和部分应用设置中，包括专门的网络设置分组和校验。

增强内容：
- 将应用配置模式版本升级到 v3，并通过迁移将缺失的代理设置初始化为自适应模式，同时确保用于代理持久化的 JSON 结构保持扁平且稳定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist global network proxy settings in the application configuration and surface them consistently across backend and frontend settings models.

New Features:
- Add global outbound proxy configuration to full and partial app settings, including a dedicated Network settings group and validation.

Enhancements:
- Upgrade app configuration schema version to v3 with migration to initialize missing proxy settings to adaptive mode and ensure a flat, stable JSON shape for proxy persistence.

</details>