### PR TITLE
feat(network): 建立全局网络运行时

### DIFF
--- a/crates/infra/src/net/client.rs
+++ b/crates/infra/src/net/client.rs
@@ -387,6 +387,10 @@ fn apply_async_proxy_routes(
     mut builder: reqwest::ClientBuilder,
     effective_proxy: &EffectiveProxy,
 ) -> Result<reqwest::ClientBuilder, NetError> {
+    if matches!(effective_proxy, EffectiveProxy::Direct) {
+        return Ok(builder.no_proxy());
+    }
+
     for proxy in configured_proxy_routes(effective_proxy)?
         .into_iter()
         .flatten()
@@ -401,6 +405,10 @@ fn apply_blocking_proxy_routes(
     mut builder: reqwest::blocking::ClientBuilder,
     effective_proxy: &EffectiveProxy,
 ) -> Result<reqwest::blocking::ClientBuilder, NetError> {
+    if matches!(effective_proxy, EffectiveProxy::Direct) {
+        return Ok(builder.no_proxy());
+    }
+
     for proxy in configured_proxy_routes(effective_proxy)?
         .into_iter()
         .flatten()

--- a/crates/infra/src/net/mod.rs
+++ b/crates/infra/src/net/mod.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod error;
 pub mod proxy;
 pub mod request;
+mod runtime;
 
 pub use client::{ClientConfig, NetClient, RemoteFileInfo, RetryPolicy, TimeoutPolicy};
 pub use error::NetError;
@@ -10,6 +11,9 @@ pub use proxy::{
     ProxyUpdate, SystemProxyProvider, SystemProxySnapshot,
 };
 pub use request::RequestBuilder;
+pub use runtime::{
+    apply_proxy_settings, apply_system_proxy_snapshot, global_client, NetworkUpdate,
+};
 
 #[cfg(feature = "blocking")]
 pub use client::NetBlockingClient;

--- a/crates/infra/src/net/runtime.rs
+++ b/crates/infra/src/net/runtime.rs
@@ -67,7 +67,7 @@ impl NetworkRuntime {
         system_proxy: SystemProxySnapshot,
     ) -> Result<NetworkUpdate, NetError> {
         let mut state = self.write_state()?;
-        let Some(current) = state.as_ref() else {
+        let Some(current) = state.as_mut() else {
             let initialized = build_state(settings, system_proxy, 1)?;
             *state = Some(initialized);
             return Ok(NetworkUpdate { client_rebuilt: true, revision: 1 });
@@ -78,28 +78,7 @@ impl NetworkRuntime {
             .update_settings(settings, system_proxy)
             .map_err(proxy_config_error)?;
 
-        if update.changed() {
-            let next_client = NetClient::from_config_with_effective_proxy(
-                &ClientConfig::default(),
-                &update.current,
-            )?;
-            let revision = next_revision(current.revision)?;
-            *state = Some(NetworkState {
-                controller: next_controller,
-                client: next_client,
-                revision,
-            });
-            Ok(NetworkUpdate { client_rebuilt: true, revision })
-        } else {
-            let revision = current.revision;
-            let client = current.client.clone();
-            *state = Some(NetworkState {
-                controller: next_controller,
-                client,
-                revision,
-            });
-            Ok(NetworkUpdate { client_rebuilt: false, revision })
-        }
+        commit_proxy_update(current, next_controller, update)
     }
 
     /// 应用操作系统代理变化。
@@ -110,7 +89,7 @@ impl NetworkRuntime {
         system_proxy: SystemProxySnapshot,
     ) -> Result<NetworkUpdate, NetError> {
         let mut state = self.write_state()?;
-        let Some(current) = state.as_ref() else {
+        let Some(current) = state.as_mut() else {
             let initialized = build_state(ProxySettings::default(), system_proxy, 1)?;
             *state = Some(initialized);
             return Ok(NetworkUpdate { client_rebuilt: true, revision: 1 });
@@ -118,42 +97,17 @@ impl NetworkRuntime {
 
         let mut next_controller = current.controller.clone();
         let update = next_controller.handle_system_proxy_change(system_proxy);
-        if update.changed() {
-            let next_client = NetClient::from_config_with_effective_proxy(
-                &ClientConfig::default(),
-                &update.current,
-            )?;
-            let revision = next_revision(current.revision)?;
-            *state = Some(NetworkState {
-                controller: next_controller,
-                client: next_client,
-                revision,
-            });
-            Ok(NetworkUpdate { client_rebuilt: true, revision })
-        } else {
-            let revision = current.revision;
-            let client = current.client.clone();
-            *state = Some(NetworkState {
-                controller: next_controller,
-                client,
-                revision,
-            });
-            Ok(NetworkUpdate { client_rebuilt: false, revision })
-        }
+        commit_proxy_update(current, next_controller, update)
     }
 
     fn read_state(&self) -> Result<std::sync::RwLockReadGuard<'_, Option<NetworkState>>, NetError> {
-        self.state
-            .read()
-            .map_err(|_| NetError::Config("全局网络运行时不可用".into()))
+        self.state.read().map_err(runtime_lock_poisoned)
     }
 
     fn write_state(
         &self,
     ) -> Result<std::sync::RwLockWriteGuard<'_, Option<NetworkState>>, NetError> {
-        self.state
-            .write()
-            .map_err(|_| NetError::Config("全局网络运行时不可用".into()))
+        self.state.write().map_err(runtime_lock_poisoned)
     }
 }
 
@@ -170,8 +124,37 @@ fn build_state(
     Ok(NetworkState { controller, client, revision })
 }
 
-fn proxy_config_error(_error: ProxyConfigError) -> NetError {
-    NetError::Config("代理设置无效".into())
+fn commit_proxy_update(
+    current: &mut NetworkState,
+    next_controller: ProxyController,
+    update: super::ProxyUpdate,
+) -> Result<NetworkUpdate, NetError> {
+    if !update.changed() {
+        current.controller = next_controller;
+        return Ok(NetworkUpdate {
+            client_rebuilt: false,
+            revision: current.revision,
+        });
+    }
+
+    let next_client =
+        NetClient::from_config_with_effective_proxy(&ClientConfig::default(), &update.current)?;
+    let revision = next_revision(current.revision)?;
+    current.controller = next_controller;
+    current.client = next_client;
+    current.revision = revision;
+    Ok(NetworkUpdate { client_rebuilt: true, revision })
+}
+
+fn proxy_config_error(error: ProxyConfigError) -> NetError {
+    let message = match error {
+        ProxyConfigError::EmptyManualProxy => "手动代理地址不能为空",
+    };
+    NetError::Config(message.into())
+}
+
+fn runtime_lock_poisoned<T>(_error: std::sync::PoisonError<T>) -> NetError {
+    NetError::Config("全局网络运行时状态锁已污染".into())
 }
 
 fn next_revision(revision: u64) -> Result<u64, NetError> {
@@ -257,6 +240,41 @@ mod tests {
 
         assert_eq!(first, NetworkUpdate { client_rebuilt: true, revision: 2 });
         assert_eq!(repeated, NetworkUpdate { client_rebuilt: false, revision: 2 });
+    }
+
+    #[test]
+    fn policy_change_without_effective_proxy_change_updates_only_controller() {
+        let runtime = NetworkRuntime::new();
+        runtime.client().expect("default client should initialize");
+
+        let update = runtime
+            .apply_proxy_settings(settings(ProxyMode::Disabled), SystemProxySnapshot::direct())
+            .expect("disabled mode should apply");
+
+        assert_eq!(update, NetworkUpdate { client_rebuilt: false, revision: 1 });
+        let state = runtime_state(&runtime);
+        assert_eq!(state.controller.settings().mode, ProxyMode::Disabled);
+        assert_eq!(state.controller.effective_proxy(), &EffectiveProxy::Direct);
+    }
+
+    #[test]
+    fn invalid_proxy_settings_return_a_specific_reason_and_keep_state() {
+        let runtime = NetworkRuntime::new();
+        runtime.client().expect("default client should initialize");
+        let before = runtime_state(&runtime);
+
+        let error = runtime
+            .apply_proxy_settings(
+                settings(ProxyMode::Manual { proxy_url: "  ".into() }),
+                SystemProxySnapshot::direct(),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "配置错误: 手动代理地址不能为空");
+        let after = runtime_state(&runtime);
+        assert_eq!(after.revision, before.revision);
+        assert_eq!(after.controller.settings(), before.controller.settings());
+        assert_eq!(after.controller.effective_proxy(), before.controller.effective_proxy());
     }
 
     #[test]

--- a/crates/infra/src/net/runtime.rs
+++ b/crates/infra/src/net/runtime.rs
@@ -1,0 +1,345 @@
+//! 进程级全局网络运行时。
+//!
+//! 集中维护当前代理策略和可复用的 HTTP 客户端。配置文件的读取与持久化由
+//! 上层负责；本模块只接收已解析的代理设置或系统代理快照。
+
+use std::sync::RwLock;
+
+use super::proxy::{ProxyConfigError, ProxyController, ProxySettings, SystemProxySnapshot};
+use super::{ClientConfig, NetClient, NetError};
+
+/// 网络客户端更新结果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NetworkUpdate {
+    /// 是否创建并替换了当前 HTTP 客户端。
+    pub client_rebuilt: bool,
+    /// 当前客户端世代；初始客户端为第一代。
+    pub revision: u64,
+}
+
+/// 网络运行时状态容器，仅由本模块的进程级全局实例对外提供能力。
+struct NetworkRuntime {
+    state: RwLock<Option<NetworkState>>,
+}
+
+#[derive(Clone)]
+struct NetworkState {
+    controller: ProxyController,
+    client: NetClient,
+    revision: u64,
+}
+
+impl NetworkRuntime {
+    /// 创建尚未初始化的网络运行时。
+    const fn new() -> Self {
+        Self { state: RwLock::new(None) }
+    }
+
+    /// 获取当前网络客户端的廉价克隆。
+    ///
+    /// 首次获取时使用默认自适应策略和直连系统快照初始化第一代客户端。
+    fn client(&self) -> Result<NetClient, NetError> {
+        if let Some(client) = self
+            .read_state()?
+            .as_ref()
+            .map(|state| state.client.clone())
+        {
+            return Ok(client);
+        }
+
+        let mut state = self.write_state()?;
+        if let Some(existing) = state.as_ref() {
+            return Ok(existing.client.clone());
+        }
+
+        let initialized = build_state(ProxySettings::default(), SystemProxySnapshot::direct(), 1)?;
+        let client = initialized.client.clone();
+        *state = Some(initialized);
+        Ok(client)
+    }
+
+    /// 应用由上层下发的代理设置。
+    ///
+    /// 新客户端构建成功后才会替换当前状态；失败时保留旧策略和旧客户端。
+    fn apply_proxy_settings(
+        &self,
+        settings: ProxySettings,
+        system_proxy: SystemProxySnapshot,
+    ) -> Result<NetworkUpdate, NetError> {
+        let mut state = self.write_state()?;
+        let Some(current) = state.as_ref() else {
+            let initialized = build_state(settings, system_proxy, 1)?;
+            *state = Some(initialized);
+            return Ok(NetworkUpdate { client_rebuilt: true, revision: 1 });
+        };
+
+        let mut next_controller = current.controller.clone();
+        let update = next_controller
+            .update_settings(settings, system_proxy)
+            .map_err(proxy_config_error)?;
+
+        if update.changed() {
+            let next_client = NetClient::from_config_with_effective_proxy(
+                &ClientConfig::default(),
+                &update.current,
+            )?;
+            let revision = next_revision(current.revision)?;
+            *state = Some(NetworkState {
+                controller: next_controller,
+                client: next_client,
+                revision,
+            });
+            Ok(NetworkUpdate { client_rebuilt: true, revision })
+        } else {
+            let revision = current.revision;
+            let client = current.client.clone();
+            *state = Some(NetworkState {
+                controller: next_controller,
+                client,
+                revision,
+            });
+            Ok(NetworkUpdate { client_rebuilt: false, revision })
+        }
+    }
+
+    /// 应用操作系统代理变化。
+    ///
+    /// 只有自适应策略会根据新快照改变有效代理并重建客户端。
+    fn apply_system_proxy_snapshot(
+        &self,
+        system_proxy: SystemProxySnapshot,
+    ) -> Result<NetworkUpdate, NetError> {
+        let mut state = self.write_state()?;
+        let Some(current) = state.as_ref() else {
+            let initialized = build_state(ProxySettings::default(), system_proxy, 1)?;
+            *state = Some(initialized);
+            return Ok(NetworkUpdate { client_rebuilt: true, revision: 1 });
+        };
+
+        let mut next_controller = current.controller.clone();
+        let update = next_controller.handle_system_proxy_change(system_proxy);
+        if update.changed() {
+            let next_client = NetClient::from_config_with_effective_proxy(
+                &ClientConfig::default(),
+                &update.current,
+            )?;
+            let revision = next_revision(current.revision)?;
+            *state = Some(NetworkState {
+                controller: next_controller,
+                client: next_client,
+                revision,
+            });
+            Ok(NetworkUpdate { client_rebuilt: true, revision })
+        } else {
+            let revision = current.revision;
+            let client = current.client.clone();
+            *state = Some(NetworkState {
+                controller: next_controller,
+                client,
+                revision,
+            });
+            Ok(NetworkUpdate { client_rebuilt: false, revision })
+        }
+    }
+
+    fn read_state(&self) -> Result<std::sync::RwLockReadGuard<'_, Option<NetworkState>>, NetError> {
+        self.state
+            .read()
+            .map_err(|_| NetError::Config("全局网络运行时不可用".into()))
+    }
+
+    fn write_state(
+        &self,
+    ) -> Result<std::sync::RwLockWriteGuard<'_, Option<NetworkState>>, NetError> {
+        self.state
+            .write()
+            .map_err(|_| NetError::Config("全局网络运行时不可用".into()))
+    }
+}
+
+fn build_state(
+    settings: ProxySettings,
+    system_proxy: SystemProxySnapshot,
+    revision: u64,
+) -> Result<NetworkState, NetError> {
+    let controller = ProxyController::new(settings, system_proxy).map_err(proxy_config_error)?;
+    let client = NetClient::from_config_with_effective_proxy(
+        &ClientConfig::default(),
+        controller.effective_proxy(),
+    )?;
+    Ok(NetworkState { controller, client, revision })
+}
+
+fn proxy_config_error(_error: ProxyConfigError) -> NetError {
+    NetError::Config("代理设置无效".into())
+}
+
+fn next_revision(revision: u64) -> Result<u64, NetError> {
+    revision
+        .checked_add(1)
+        .ok_or_else(|| NetError::Config("网络客户端世代已耗尽".into()))
+}
+
+static GLOBAL_NETWORK_RUNTIME: NetworkRuntime = NetworkRuntime::new();
+
+/// 获取进程级全局网络客户端。
+pub fn global_client() -> Result<NetClient, NetError> {
+    GLOBAL_NETWORK_RUNTIME.client()
+}
+
+/// 向进程级全局网络运行时下发代理设置。
+pub fn apply_proxy_settings(
+    settings: ProxySettings,
+    system_proxy: SystemProxySnapshot,
+) -> Result<NetworkUpdate, NetError> {
+    GLOBAL_NETWORK_RUNTIME.apply_proxy_settings(settings, system_proxy)
+}
+
+/// 向进程级全局网络运行时下发系统代理快照。
+pub fn apply_system_proxy_snapshot(
+    system_proxy: SystemProxySnapshot,
+) -> Result<NetworkUpdate, NetError> {
+    GLOBAL_NETWORK_RUNTIME.apply_system_proxy_snapshot(system_proxy)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::net::proxy::{EffectiveProxy, ProxyMode};
+
+    const FIRST_PROXY: &str = "http://127.0.0.1:7890";
+    const SECOND_PROXY: &str = "http://127.0.0.1:7891";
+
+    fn settings(mode: ProxyMode) -> ProxySettings {
+        ProxySettings { mode }
+    }
+
+    fn runtime_state(runtime: &NetworkRuntime) -> NetworkState {
+        runtime
+            .read_state()
+            .expect("network state lock should be available")
+            .clone()
+            .expect("network runtime should be initialized")
+    }
+
+    #[test]
+    fn client_initializes_once_with_direct_adaptive_state() {
+        let runtime = NetworkRuntime::new();
+
+        runtime.client().expect("first client should initialize");
+        runtime.client().expect("second client should reuse state");
+
+        let state = runtime_state(&runtime);
+        assert_eq!(state.revision, 1);
+        assert_eq!(state.controller.settings(), &ProxySettings::default());
+        assert_eq!(state.controller.effective_proxy(), &EffectiveProxy::Direct);
+    }
+
+    #[test]
+    fn manual_proxy_rebuilds_only_when_effective_proxy_changes() {
+        let runtime = NetworkRuntime::new();
+        runtime.client().expect("default client should initialize");
+
+        let first = runtime
+            .apply_proxy_settings(
+                settings(ProxyMode::Manual { proxy_url: FIRST_PROXY.into() }),
+                SystemProxySnapshot::direct(),
+            )
+            .expect("manual proxy should apply");
+        let repeated = runtime
+            .apply_proxy_settings(
+                settings(ProxyMode::Manual { proxy_url: FIRST_PROXY.into() }),
+                SystemProxySnapshot::direct(),
+            )
+            .expect("same manual proxy should remain valid");
+
+        assert_eq!(first, NetworkUpdate { client_rebuilt: true, revision: 2 });
+        assert_eq!(repeated, NetworkUpdate { client_rebuilt: false, revision: 2 });
+    }
+
+    #[test]
+    fn failed_candidate_keeps_previous_runtime_state() {
+        let runtime = NetworkRuntime::new();
+        runtime
+            .apply_proxy_settings(
+                settings(ProxyMode::Manual { proxy_url: FIRST_PROXY.into() }),
+                SystemProxySnapshot::direct(),
+            )
+            .expect("initial manual proxy should apply");
+        let before = runtime_state(&runtime);
+
+        let result = runtime.apply_proxy_settings(
+            settings(ProxyMode::Manual {
+                proxy_url: "http://user:secret@[::1".into(),
+            }),
+            SystemProxySnapshot::direct(),
+        );
+
+        assert!(matches!(result, Err(NetError::Config(_))));
+        let after = runtime_state(&runtime);
+        assert_eq!(after.revision, before.revision);
+        assert_eq!(after.controller.settings(), before.controller.settings());
+        assert_eq!(after.controller.effective_proxy(), before.controller.effective_proxy());
+    }
+
+    #[test]
+    fn adaptive_mode_rebuilds_for_system_proxy_changes() {
+        let runtime = NetworkRuntime::new();
+        runtime.client().expect("default client should initialize");
+
+        let first = runtime
+            .apply_system_proxy_snapshot(SystemProxySnapshot::proxy(FIRST_PROXY))
+            .expect("first system proxy should apply");
+        let second = runtime
+            .apply_system_proxy_snapshot(SystemProxySnapshot::proxy(SECOND_PROXY))
+            .expect("second system proxy should apply");
+
+        assert!(first.client_rebuilt);
+        assert!(second.client_rebuilt);
+        assert_eq!(second.revision, 3);
+    }
+
+    #[test]
+    fn preserve_and_disabled_modes_ignore_system_proxy_changes() {
+        let preserve = NetworkRuntime::new();
+        let initialized = preserve
+            .apply_proxy_settings(
+                settings(ProxyMode::Preserve),
+                SystemProxySnapshot::proxy(FIRST_PROXY),
+            )
+            .expect("preserve mode should initialize");
+        let unchanged = preserve
+            .apply_system_proxy_snapshot(SystemProxySnapshot::proxy(SECOND_PROXY))
+            .expect("preserve mode should accept system events");
+        assert_eq!(initialized.revision, 1);
+        assert_eq!(unchanged, NetworkUpdate { client_rebuilt: false, revision: 1 });
+
+        let disabled = NetworkRuntime::new();
+        disabled
+            .apply_proxy_settings(
+                settings(ProxyMode::Disabled),
+                SystemProxySnapshot::proxy(FIRST_PROXY),
+            )
+            .expect("disabled mode should initialize");
+        assert_eq!(runtime_state(&disabled).controller.effective_proxy(), &EffectiveProxy::Direct);
+    }
+
+    #[test]
+    fn concurrent_client_reads_share_one_initialized_generation() {
+        let runtime = Arc::new(NetworkRuntime::new());
+        let threads = (0..8)
+            .map(|_| {
+                let runtime = runtime.clone();
+                std::thread::spawn(move || runtime.client().expect("client should initialize"))
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            thread.join().expect("client thread should finish");
+        }
+
+        assert_eq!(runtime_state(&runtime).revision, 1);
+    }
+}


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

引入一个进程范围的全局网络运行时，用于集中管理代理策略和复用 HTTP 客户端，并通过修订跟踪来管理客户端的代际变更。

New Features:
- 提供一个全局网络客户端访问器，用于在整个进程中共享可复用的 HTTP 客户端。
- 允许将解析后的代理设置和系统代理快照应用到全局运行时，并返回结构化的更新信息。

Bug Fixes:
- 确保在构建异步和阻塞式 HTTP 客户端时，直接代理模式会显式禁用所有代理路由。

Enhancements:
- 增加测试，用于覆盖全局网络运行时的初始化、代理更新行为、系统代理响应、错误处理以及并发客户端访问等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a process-wide global network runtime that centralizes proxy policy management and HTTP client reuse, with revision tracking for client generations.

New Features:
- Provide a global network client accessor for sharing a reusable HTTP client across the process.
- Allow applying parsed proxy settings and system proxy snapshots to the global runtime, returning structured update information.

Bug Fixes:
- Ensure direct proxy mode explicitly disables all proxy routes when building async and blocking HTTP clients.

Enhancements:
- Add tests covering initialization, proxy update behavior, system proxy reactions, error handling, and concurrent client access for the global network runtime.

</details>