### PR TITLE
feat(network): 提供系统代理快照来源

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
@@ -326,7 +335,7 @@ checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
  "base64 0.22.1",
  "http",
- "log",
+ "log 0.4.33",
  "url",
 ]
 
@@ -396,7 +405,7 @@ checksum = "2107e98239afa5fec35a81ce5562a90dda1118fd461d507a844fdb34b387cf56"
 dependencies = [
  "axum",
  "include_dir",
- "log",
+ "log 0.4.33",
  "mime_guess",
  "reqwest 0.12.28",
  "serde_json",
@@ -844,7 +853,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "log",
+ "log 0.4.33",
  "publicsuffix",
  "serde",
  "serde_derive",
@@ -1468,7 +1477,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.3+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1666,7 +1675,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
 ]
 
@@ -1982,7 +1991,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "log",
+ "log 0.4.33",
  "rustversion",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -2227,6 +2236,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb04af2006ea09d985fef82b81e0eb25337e51b691c76403332378a53d521edc"
+dependencies = [
+ "lazy_static 0.2.11",
+ "log 0.3.9",
+ "pest",
+ "quick-error",
+ "regex 0.2.11",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,7 +2392,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
- "log",
+ "log 0.4.33",
  "markup5ever",
 ]
 
@@ -2521,7 +2545,7 @@ dependencies = [
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log",
+ "log 0.4.33",
  "wasm-bindgen",
  "windows-core 0.62.2",
 ]
@@ -2673,7 +2697,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "log",
+ "log 0.4.33",
  "rand",
  "tokio",
  "url",
@@ -2738,6 +2762,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "interfaces"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec8f50a973916cac3da5057c986db05cd3346f38c78e9bc24f64cc9f6a3978f"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "handlebars",
+ "lazy_static 1.5.0",
+ "libc",
+ "nix",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2994,7 +3034,7 @@ dependencies = [
  "tempfile",
  "walkdir",
  "windows 0.62.2",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3030,7 +3070,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-sys 0.3.1",
- "log",
+ "log 0.4.33",
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
@@ -3046,7 +3086,7 @@ dependencies = [
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
- "log",
+ "log 0.4.33",
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
@@ -3140,6 +3180,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+
+[[package]]
+name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
@@ -3154,7 +3200,7 @@ dependencies = [
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
- "log",
+ "log 0.4.33",
 ]
 
 [[package]]
@@ -3248,6 +3294,15 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.33",
+]
+
+[[package]]
+name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
@@ -3311,7 +3366,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
- "log",
+ "log 0.4.33",
  "tendril",
  "web_atoms",
 ]
@@ -3342,6 +3397,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -3524,7 +3588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
- "log",
+ "log 0.4.33",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3542,7 +3606,7 @@ checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.13.1",
  "jni-sys 0.3.1",
- "log",
+ "log 0.4.33",
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
@@ -3608,7 +3672,7 @@ checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
- "log",
+ "log 0.4.33",
  "netlink-packet-core",
 ]
 
@@ -3621,7 +3685,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "log",
+ "log 0.4.33",
  "netlink-packet-core",
  "netlink-sys",
  "thiserror 2.0.19",
@@ -3636,7 +3700,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "libc",
- "log",
+ "log 0.4.33",
  "tokio",
 ]
 
@@ -3682,6 +3746,19 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+]
 
 [[package]]
 name = "nom"
@@ -4238,6 +4315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4591,6 +4674,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,14 +4870,27 @@ dependencies = [
 
 [[package]]
 name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+dependencies = [
+ "aho-corasick 0.6.10",
+ "memchr",
+ "regex-syntax 0.5.6",
+ "thread_local 0.3.6",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.1.4",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -4797,9 +4899,18 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.1.4",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.11",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+dependencies = [
+ "ucd-util",
 ]
 
 [[package]]
@@ -4831,7 +4942,7 @@ dependencies = [
  "hyper-tls",
  "hyper-util",
  "js-sys",
- "log",
+ "log 0.4.33",
  "mime",
  "native-tls",
  "percent-encoding",
@@ -4875,7 +4986,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "js-sys",
- "log",
+ "log 0.4.33",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -4915,7 +5026,7 @@ dependencies = [
  "gobject-sys",
  "gtk-sys",
  "js-sys",
- "log",
+ "log 0.4.33",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -5012,7 +5123,7 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "log",
+ "log 0.4.33",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5052,7 +5163,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
- "log",
+ "log 0.4.33",
  "once_cell",
  "rustls",
  "rustls-native-certs",
@@ -5253,7 +5364,7 @@ dependencies = [
  "dom_query",
  "java-manager",
  "mlua",
- "regex",
+ "regex 1.13.1",
  "reqwest 0.12.28",
  "sculk",
  "sealantern-core",
@@ -5282,6 +5393,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "sysinfo",
+ "sysproxy",
  "tokio",
  "tokio-util",
  "toml 0.8.2",
@@ -5365,7 +5477,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cssparser",
  "derive_more",
- "log",
+ "log 0.4.33",
  "new_debug_unreachable",
  "phf",
  "phf_codegen",
@@ -5649,7 +5761,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.5.0",
 ]
 
 [[package]]
@@ -5959,6 +6071,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysproxy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9707a79d3b95683aa5a9521e698ffd878b8fb289727c25a69157fb85d529ffff"
+dependencies = [
+ "interfaces",
+ "thiserror 1.0.69",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6018,7 +6142,7 @@ dependencies = [
  "gtk",
  "jni 0.21.1",
  "libc",
- "log",
+ "log 0.4.33",
  "ndk",
  "ndk-sys",
  "objc2",
@@ -6075,7 +6199,7 @@ dependencies = [
  "http-range",
  "jni 0.21.1",
  "libc",
- "log",
+ "log 0.4.33",
  "mime",
  "muda",
  "objc2",
@@ -6191,7 +6315,7 @@ version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
 dependencies = [
- "log",
+ "log 0.4.33",
  "raw-window-handle",
  "rfd",
  "serde",
@@ -6212,7 +6336,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "glob",
- "log",
+ "log 0.4.33",
  "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
@@ -6237,7 +6361,7 @@ dependencies = [
  "cookie_store",
  "data-url",
  "http",
- "regex",
+ "regex 1.13.1",
  "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",
@@ -6290,7 +6414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
  "bitflags 2.13.1",
- "log",
+ "log 0.4.33",
  "serde",
  "serde_json",
  "tauri",
@@ -6332,7 +6456,7 @@ dependencies = [
  "gtk",
  "http",
  "jni 0.21.1",
- "log",
+ "log 0.4.33",
  "objc2",
  "objc2-app-kit",
  "once_cell",
@@ -6365,13 +6489,13 @@ dependencies = [
  "http",
  "infer",
  "json-patch",
- "log",
+ "log 0.4.33",
  "memchr",
  "phf",
  "plist",
  "proc-macro2",
  "quote",
- "regex",
+ "regex 1.13.1",
  "schemars 0.8.22",
  "semver",
  "serde",
@@ -6458,6 +6582,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+dependencies = [
+ "lazy_static 1.5.0",
 ]
 
 [[package]]
@@ -6804,7 +6937,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
+ "log 0.4.33",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6837,7 +6970,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log",
+ "log 0.4.33",
  "once_cell",
  "tracing-core",
 ]
@@ -6854,7 +6987,7 @@ dependencies = [
  "regex-automata",
  "sharded-slab",
  "smallvec",
- "thread_local",
+ "thread_local 1.1.10",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -6901,12 +7034,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -7023,11 +7162,17 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d"
 dependencies = [
- "regex",
+ "regex 1.13.1",
  "serde",
  "unic-ucd-ident",
  "url",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -8014,6 +8159,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -8061,7 +8215,7 @@ checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "chrono",
  "futures",
- "log",
+ "log 0.4.33",
  "serde",
  "thiserror 2.0.19",
  "windows 0.62.2",
@@ -8127,7 +8281,7 @@ dependencies = [
  "async_io_stream",
  "futures",
  "js-sys",
- "log",
+ "log 0.4.33",
  "pharos",
  "rustc_version",
  "send_wrapper",
@@ -8382,7 +8536,7 @@ checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",
- "log",
+ "log 0.4.33",
  "simd-adler32",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,15 +57,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
@@ -335,7 +326,7 @@ checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
  "base64 0.22.1",
  "http",
- "log 0.4.33",
+ "log",
  "url",
 ]
 
@@ -405,7 +396,7 @@ checksum = "2107e98239afa5fec35a81ce5562a90dda1118fd461d507a844fdb34b387cf56"
 dependencies = [
  "axum",
  "include_dir",
- "log 0.4.33",
+ "log",
  "mime_guess",
  "reqwest 0.12.28",
  "serde_json",
@@ -853,7 +844,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "log 0.4.33",
+ "log",
  "publicsuffix",
  "serde",
  "serde_derive",
@@ -1477,7 +1468,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.3+spec-1.1.0",
  "vswhom",
- "winreg 0.55.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1675,7 +1666,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -1991,7 +1982,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "log 0.4.33",
+ "log",
  "rustversion",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -2236,21 +2227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "handlebars"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb04af2006ea09d985fef82b81e0eb25337e51b691c76403332378a53d521edc"
-dependencies = [
- "lazy_static 0.2.11",
- "log 0.3.9",
- "pest",
- "quick-error",
- "regex 0.2.11",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,7 +2368,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
- "log 0.4.33",
+ "log",
  "markup5ever",
 ]
 
@@ -2545,7 +2521,7 @@ dependencies = [
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log 0.4.33",
+ "log",
  "wasm-bindgen",
  "windows-core 0.62.2",
 ]
@@ -2697,7 +2673,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "log 0.4.33",
+ "log",
  "rand",
  "tokio",
  "url",
@@ -2762,22 +2738,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "interfaces"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec8f50a973916cac3da5057c986db05cd3346f38c78e9bc24f64cc9f6a3978f"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "handlebars",
- "lazy_static 1.5.0",
- "libc",
- "nix",
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3034,7 +2994,7 @@ dependencies = [
  "tempfile",
  "walkdir",
  "windows 0.62.2",
- "winreg 0.55.0",
+ "winreg",
 ]
 
 [[package]]
@@ -3070,7 +3030,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-sys 0.3.1",
- "log 0.4.33",
+ "log",
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
@@ -3086,7 +3046,7 @@ dependencies = [
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
- "log 0.4.33",
+ "log",
  "simd_cesu8",
  "thiserror 2.0.19",
  "walkdir",
@@ -3180,12 +3140,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
@@ -3200,7 +3154,7 @@ dependencies = [
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
- "log 0.4.33",
+ "log",
 ]
 
 [[package]]
@@ -3294,15 +3248,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.33",
-]
-
-[[package]]
-name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
@@ -3366,7 +3311,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
- "log 0.4.33",
+ "log",
  "tendril",
  "web_atoms",
 ]
@@ -3397,15 +3342,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -3588,7 +3524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
- "log 0.4.33",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -3606,7 +3542,7 @@ checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.13.1",
  "jni-sys 0.3.1",
- "log 0.4.33",
+ "log",
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
@@ -3672,7 +3608,7 @@ checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
- "log 0.4.33",
+ "log",
  "netlink-packet-core",
 ]
 
@@ -3685,7 +3621,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "log 0.4.33",
+ "log",
  "netlink-packet-core",
  "netlink-sys",
  "thiserror 2.0.19",
@@ -3700,7 +3636,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "libc",
- "log 0.4.33",
+ "log",
  "tokio",
 ]
 
@@ -3746,19 +3682,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
 
 [[package]]
 name = "nom"
@@ -4315,12 +4238,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4674,12 +4591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,27 +4781,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local 0.3.6",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.11",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4899,18 +4797,9 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
- "aho-corasick 1.1.4",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.8.11",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4942,7 +4831,7 @@ dependencies = [
  "hyper-tls",
  "hyper-util",
  "js-sys",
- "log 0.4.33",
+ "log",
  "mime",
  "native-tls",
  "percent-encoding",
@@ -4986,7 +4875,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "js-sys",
- "log 0.4.33",
+ "log",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -5026,7 +4915,7 @@ dependencies = [
  "gobject-sys",
  "gtk-sys",
  "js-sys",
- "log 0.4.33",
+ "log",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -5123,7 +5012,7 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "log 0.4.33",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5163,7 +5052,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
- "log 0.4.33",
+ "log",
  "once_cell",
  "rustls",
  "rustls-native-certs",
@@ -5364,7 +5253,7 @@ dependencies = [
  "dom_query",
  "java-manager",
  "mlua",
- "regex 1.13.1",
+ "regex",
  "reqwest 0.12.28",
  "sculk",
  "sealantern-core",
@@ -5398,6 +5287,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.2",
  "tracing",
+ "url",
  "uuid",
  "zip",
 ]
@@ -5477,7 +5367,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cssparser",
  "derive_more",
- "log 0.4.33",
+ "log",
  "new_debug_unreachable",
  "phf",
  "phf_codegen",
@@ -5761,7 +5651,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "lazy_static 1.5.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -6072,14 +5962,15 @@ dependencies = [
 
 [[package]]
 name = "sysproxy"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9707a79d3b95683aa5a9521e698ffd878b8fb289727c25a69157fb85d529ffff"
+version = "0.5.1"
 dependencies = [
- "interfaces",
- "thiserror 1.0.69",
- "winapi",
- "winreg 0.10.1",
+ "log",
+ "system-configuration",
+ "thiserror 2.0.19",
+ "url",
+ "windows 0.58.0",
+ "winreg",
+ "xdg",
 ]
 
 [[package]]
@@ -6142,7 +6033,7 @@ dependencies = [
  "gtk",
  "jni 0.21.1",
  "libc",
- "log 0.4.33",
+ "log",
  "ndk",
  "ndk-sys",
  "objc2",
@@ -6199,7 +6090,7 @@ dependencies = [
  "http-range",
  "jni 0.21.1",
  "libc",
- "log 0.4.33",
+ "log",
  "mime",
  "muda",
  "objc2",
@@ -6315,7 +6206,7 @@ version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
 dependencies = [
- "log 0.4.33",
+ "log",
  "raw-window-handle",
  "rfd",
  "serde",
@@ -6336,7 +6227,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "glob",
- "log 0.4.33",
+ "log",
  "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
@@ -6361,7 +6252,7 @@ dependencies = [
  "cookie_store",
  "data-url",
  "http",
- "regex 1.13.1",
+ "regex",
  "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",
@@ -6414,7 +6305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
 dependencies = [
  "bitflags 2.13.1",
- "log 0.4.33",
+ "log",
  "serde",
  "serde_json",
  "tauri",
@@ -6456,7 +6347,7 @@ dependencies = [
  "gtk",
  "http",
  "jni 0.21.1",
- "log 0.4.33",
+ "log",
  "objc2",
  "objc2-app-kit",
  "once_cell",
@@ -6489,13 +6380,13 @@ dependencies = [
  "http",
  "infer",
  "json-patch",
- "log 0.4.33",
+ "log",
  "memchr",
  "phf",
  "plist",
  "proc-macro2",
  "quote",
- "regex 1.13.1",
+ "regex",
  "schemars 0.8.22",
  "semver",
  "serde",
@@ -6582,15 +6473,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static 1.5.0",
 ]
 
 [[package]]
@@ -6937,7 +6819,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log 0.4.33",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6970,7 +6852,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.33",
+ "log",
  "once_cell",
  "tracing-core",
 ]
@@ -6987,7 +6869,7 @@ dependencies = [
  "regex-automata",
  "sharded-slab",
  "smallvec",
- "thread_local 1.1.10",
+ "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -7034,18 +6916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "ucd-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
-
-[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -7162,17 +7038,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d"
 dependencies = [
- "regex 1.13.1",
+ "regex",
  "serde",
  "unic-ucd-ident",
  "url",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"
@@ -7567,6 +7437,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7631,6 +7511,19 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -7690,6 +7583,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -7704,6 +7608,17 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7775,6 +7690,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -7789,6 +7713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8159,15 +8093,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -8215,7 +8140,7 @@ checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "chrono",
  "futures",
- "log 0.4.33",
+ "log",
  "serde",
  "thiserror 2.0.19",
  "windows 0.62.2",
@@ -8281,7 +8206,7 @@ dependencies = [
  "async_io_stream",
  "futures",
  "js-sys",
- "log 0.4.33",
+ "log",
  "pharos",
  "rustc_version",
  "send_wrapper",
@@ -8311,6 +8236,12 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xml-rs"
@@ -8536,7 +8467,7 @@ checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",
- "log 0.4.33",
+ "log",
  "simd-adler32",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/vendor/java-manager",
 ]
 resolver = "2"
+exclude = ["crates/vendor/sysproxy"]
 
 # 优化配置（从 src-tauri/Cargo.toml 移到这里统一管理）
 [profile.release]

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -37,4 +37,5 @@ uuid = { version = "1", features = ["v4"] }
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
 sysinfo = "0.32"
 dirs = "5"
-sysproxy = "0.3"
+sysproxy = { path = "../vendor/sysproxy" }
+url = "2"

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -37,3 +37,4 @@ uuid = { version = "1", features = ["v4"] }
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
 sysinfo = "0.32"
 dirs = "5"
+sysproxy = "0.3"

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -8,6 +8,7 @@ mod elevation;
 mod environment;
 mod error;
 mod locations;
+mod proxy;
 mod system;
 
 pub use certificate::{
@@ -17,6 +18,7 @@ pub use elevation::{is_elevated, request_elevation, ElevationLaunch};
 pub use environment::{Environment, EnvironmentError};
 pub use error::PlatformError;
 pub use locations::{get_app_data_dir, get_or_create_app_data_dir};
+pub use proxy::{current_system_proxy, PlatformSystemProxyProvider, SystemProxyReadError};
 pub use system::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
     collect_system_info, cpu_brand_name, directory_size, path_disk_capacity, process_count,

--- a/crates/infra/src/platform/proxy.rs
+++ b/crates/infra/src/platform/proxy.rs
@@ -137,9 +137,19 @@ fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
         format!("{host}:{port}")
     };
     let proxy_url = format!("http://{authority}");
-    reqwest::Proxy::all(&proxy_url)
-        .map(|_| proxy_url)
-        .map_err(|_| SystemProxyReadError::InvalidProxy)
+    let parsed = url::Url::parse(&proxy_url).map_err(|_| SystemProxyReadError::InvalidProxy)?;
+    let valid = parsed.scheme() == "http"
+        && parsed.host().is_some()
+        && parsed.port_or_known_default() == Some(port)
+        && parsed.username().is_empty()
+        && parsed.password().is_none()
+        && parsed.path() == "/"
+        && parsed.query().is_none()
+        && parsed.fragment().is_none();
+    if !valid {
+        return Err(SystemProxyReadError::InvalidProxy);
+    }
+    Ok(proxy_url)
 }
 
 fn convert_bypass_rules(bypass: &str) -> (Vec<String>, usize) {
@@ -218,12 +228,22 @@ mod tests {
     }
 
     #[test]
+    fn default_http_proxy_port_is_valid() {
+        let snapshot = snapshot_from_sysproxy(&enabled_proxy("proxy.example.com", 80, "")).unwrap();
+
+        assert_eq!(snapshot.routes().http_proxy(), Some("http://proxy.example.com:80"));
+    }
+
+    #[test]
     fn invalid_enabled_proxy_is_rejected() {
         let empty_host = snapshot_from_sysproxy(&enabled_proxy("", 7890, "")).unwrap_err();
         let zero_port = snapshot_from_sysproxy(&enabled_proxy("127.0.0.1", 0, "")).unwrap_err();
+        let injected_scheme =
+            snapshot_from_sysproxy(&enabled_proxy("http://example.com", 7890, "")).unwrap_err();
 
         assert!(matches!(empty_host, SystemProxyReadError::InvalidProxy));
         assert!(matches!(zero_port, SystemProxyReadError::InvalidProxy));
+        assert!(matches!(injected_scheme, SystemProxyReadError::InvalidProxy));
     }
 
     #[test]

--- a/crates/infra/src/platform/proxy.rs
+++ b/crates/infra/src/platform/proxy.rs
@@ -1,0 +1,245 @@
+//! 当前系统代理快照的平台代理实现。
+//!
+//! 本模块通过 `sysproxy-rs` 执行一次性读取，不修改系统设置，也不启动轮询或
+//! 操作系统事件监听。
+
+use std::fmt;
+use std::net::Ipv6Addr;
+
+use crate::net::proxy::ProxyRoutes;
+use crate::net::{SystemProxyProvider, SystemProxySnapshot};
+
+/// 读取或解析系统代理配置时发生的错误。
+#[derive(Debug)]
+pub enum SystemProxyReadError {
+    /// `sysproxy-rs` 无法读取平台配置。
+    Read { source: sysproxy::Error },
+    /// 当前编译平台不受 `sysproxy-rs` 支持。
+    UnsupportedPlatform,
+    /// `sysproxy-rs` 返回的端点无法可靠映射为 HTTP 或 HTTPS 代理。
+    UnsupportedProxyKind,
+    /// 静态代理端点无效。
+    InvalidProxy,
+}
+
+impl fmt::Display for SystemProxyReadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read { source } => write!(formatter, "failed to read system proxy: {source}"),
+            Self::UnsupportedPlatform => {
+                formatter.write_str("system proxy is unsupported on this platform")
+            }
+            Self::UnsupportedProxyKind => formatter.write_str("system proxy kind is unsupported"),
+            Self::InvalidProxy => formatter.write_str("invalid system proxy endpoint"),
+        }
+    }
+}
+
+impl std::error::Error for SystemProxyReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read { source } => Some(source),
+            Self::UnsupportedPlatform | Self::UnsupportedProxyKind | Self::InvalidProxy => None,
+        }
+    }
+}
+
+/// 当前平台的系统代理提供器。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PlatformSystemProxyProvider;
+
+impl SystemProxyProvider for PlatformSystemProxyProvider {
+    type Error = SystemProxyReadError;
+
+    fn current_system_proxy(&self) -> Result<SystemProxySnapshot, Self::Error> {
+        platform_system_proxy()
+    }
+}
+
+/// 读取当前平台此刻报告的系统代理快照。
+pub fn current_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    crate::net::proxy::read_system_proxy(&PlatformSystemProxyProvider)
+}
+
+#[cfg(target_os = "windows")]
+fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    let proxy = sysproxy::Sysproxy::get_system_proxy()
+        .map_err(|source| SystemProxyReadError::Read { source })?;
+    snapshot_from_sysproxy(&proxy)
+}
+
+#[cfg(target_os = "linux")]
+fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    let enabled =
+        sysproxy::Sysproxy::get_enable().map_err(|source| SystemProxyReadError::Read { source })?;
+    if !enabled {
+        return Ok(SystemProxySnapshot::direct());
+    }
+
+    let http =
+        sysproxy::Sysproxy::get_http().map_err(|source| SystemProxyReadError::Read { source })?;
+    let https =
+        sysproxy::Sysproxy::get_https().map_err(|source| SystemProxyReadError::Read { source })?;
+    let bypass =
+        sysproxy::Sysproxy::get_bypass().map_err(|source| SystemProxyReadError::Read { source })?;
+    let http_proxy = optional_proxy_url(&http.host, http.port)?;
+    let https_proxy = optional_proxy_url(&https.host, https.port)?;
+    if http_proxy.is_none() && https_proxy.is_none() {
+        return Err(SystemProxyReadError::UnsupportedProxyKind);
+    }
+
+    let (no_proxy, skipped) = convert_bypass_rules(&bypass);
+    report_skipped_bypass_rules(skipped);
+    Ok(SystemProxySnapshot::from_routes(
+        ProxyRoutes::split(http_proxy, https_proxy).with_no_proxy(no_proxy),
+    ))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    Err(SystemProxyReadError::UnsupportedPlatform)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn snapshot_from_sysproxy(
+    proxy: &sysproxy::Sysproxy,
+) -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    if !proxy.enable {
+        return Ok(SystemProxySnapshot::direct());
+    }
+
+    let proxy_url = proxy_url(&proxy.host, proxy.port)?;
+    let (no_proxy, skipped) = convert_bypass_rules(&proxy.bypass);
+    report_skipped_bypass_rules(skipped);
+
+    Ok(SystemProxySnapshot::from_routes(
+        ProxyRoutes::all(proxy_url).with_no_proxy(no_proxy),
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn optional_proxy_url(host: &str, port: u16) -> Result<Option<String>, SystemProxyReadError> {
+    if host.trim().is_empty() {
+        return Ok(None);
+    }
+    proxy_url(host, port).map(Some)
+}
+
+fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
+    let host = host.trim();
+    if host.is_empty() || port == 0 {
+        return Err(SystemProxyReadError::InvalidProxy);
+    }
+
+    let authority = if host.parse::<Ipv6Addr>().is_ok() {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
+    let proxy_url = format!("http://{authority}");
+    reqwest::Proxy::all(&proxy_url)
+        .map(|_| proxy_url)
+        .map_err(|_| SystemProxyReadError::InvalidProxy)
+}
+
+fn convert_bypass_rules(bypass: &str) -> (Vec<String>, usize) {
+    let mut converted = Vec::new();
+    let mut skipped = 0;
+
+    for rule in bypass
+        .split([',', ';'])
+        .map(str::trim)
+        .filter(|rule| !rule.is_empty())
+    {
+        if rule.eq_ignore_ascii_case("<local>") {
+            skipped += 1;
+        } else if let Some(domain) = rule.strip_prefix("*.") {
+            if domain.is_empty() || domain.contains('*') {
+                skipped += 1;
+            } else {
+                converted.push(format!(".{domain}"));
+            }
+        } else if rule != "*" && rule.contains('*') {
+            skipped += 1;
+        } else {
+            converted.push(rule.to_owned());
+        }
+    }
+
+    (converted, skipped)
+}
+
+fn report_skipped_bypass_rules(skipped: usize) {
+    if skipped > 0 {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            skipped_rules = skipped,
+            "system proxy bypass rules could not be represented exactly"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_proxy(host: &str, port: u16, bypass: &str) -> sysproxy::Sysproxy {
+        sysproxy::Sysproxy {
+            enable: true,
+            host: host.into(),
+            port,
+            bypass: bypass.into(),
+        }
+    }
+
+    #[test]
+    fn disabled_system_proxy_is_direct() {
+        let snapshot = snapshot_from_sysproxy(&sysproxy::Sysproxy::default()).unwrap();
+
+        assert_eq!(snapshot, SystemProxySnapshot::direct());
+    }
+
+    #[test]
+    fn enabled_system_proxy_applies_to_http_and_https() {
+        let snapshot =
+            snapshot_from_sysproxy(&enabled_proxy("127.0.0.1", 7890, "localhost;*.example.com"))
+                .unwrap();
+
+        assert_eq!(snapshot.routes().http_proxy(), Some("http://127.0.0.1:7890"));
+        assert_eq!(snapshot.routes().https_proxy(), Some("http://127.0.0.1:7890"));
+        assert_eq!(snapshot.routes().no_proxy(), &["localhost", ".example.com"]);
+    }
+
+    #[test]
+    fn ipv6_proxy_host_is_bracketed() {
+        let snapshot = snapshot_from_sysproxy(&enabled_proxy("::1", 7890, "")).unwrap();
+
+        assert_eq!(snapshot.routes().http_proxy(), Some("http://[::1]:7890"));
+    }
+
+    #[test]
+    fn invalid_enabled_proxy_is_rejected() {
+        let empty_host = snapshot_from_sysproxy(&enabled_proxy("", 7890, "")).unwrap_err();
+        let zero_port = snapshot_from_sysproxy(&enabled_proxy("127.0.0.1", 0, "")).unwrap_err();
+
+        assert!(matches!(empty_host, SystemProxyReadError::InvalidProxy));
+        assert!(matches!(zero_port, SystemProxyReadError::InvalidProxy));
+    }
+
+    #[test]
+    fn bypass_conversion_is_conservative() {
+        let (converted, skipped) =
+            convert_bypass_rules("localhost;<local>;*.example.com;10.*;*;127.0.0.1;bad*rule");
+
+        assert_eq!(converted, ["localhost", ".example.com", "*", "127.0.0.1"]);
+        assert_eq!(skipped, 3);
+    }
+
+    #[test]
+    fn bypass_conversion_accepts_platform_separators() {
+        let (converted, skipped) = convert_bypass_rules("localhost,.example.com;127.0.0.1");
+
+        assert_eq!(converted, ["localhost", ".example.com", "127.0.0.1"]);
+        assert_eq!(skipped, 0);
+    }
+}

--- a/crates/vendor/sysproxy/.gitignore
+++ b/crates/vendor/sysproxy/.gitignore
@@ -1,0 +1,12 @@
+debug/
+target/
+Cargo.lock
+**/*.rs.bk
+*.pdb
+
+.vscode
+.DS_Store
+.idea
+
+node_modules/
+*.node

--- a/crates/vendor/sysproxy/Cargo.toml
+++ b/crates/vendor/sysproxy/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name = "sysproxy"
+version = "0.5.1"
+edition = "2021"
+authors = ["zzzgydi"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/mihomo-party-org/sysproxy-rs-opti.git"
+keywords = ["system-proxy", "proxy", "networksetup", "gsettings"]
+description = "A library for set/get system proxy. Supports Windows, macOS and linux (via gsettings)."
+
+[lib]
+crate-type = ["lib"]
+[dependencies]
+log = "0.4"
+thiserror = "2.0"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+url = "2"
+[target.'cfg(target_os = "linux")'.dependencies]
+xdg = "3.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+system-configuration = "0.7"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = { version = "0.55", features = ["transactions"] }
+windows = { version = "0.58", features = [
+    "Win32_Networking_WinInet",
+    "Win32_NetworkManagement_Rras",
+    "Win32_Foundation",
+] }
+
+[lints.clippy]
+# Core categories - most important for code safety and correctness
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+
+# Critical safety lints - warn for now due to extensive existing usage
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "deny"
+unimplemented = "deny"
+
+# Development quality lints
+todo = "warn"
+dbg_macro = "warn"
+#print_stdout = "warn"
+#print_stderr = "warn"
+
+# Performance lints for proxy application
+clone_on_ref_ptr = "warn"
+rc_clone_in_vec_init = "warn"
+large_stack_arrays = "warn"
+large_const_arrays = "warn"
+
+# Security lints
+#integer_division = "warn"
+#lossy_float_literal = "warn"
+#default_numeric_fallback = "warn"
+
+# Mutex and async lints - strict control
+async_yields_async = "deny" # Prevents missing await in async blocks
+mutex_atomic = "deny" # Use atomics instead of Mutex<bool/int>
+mutex_integer = "deny" # Use AtomicInt instead of Mutex<int>
+rc_mutex = "deny" # Single-threaded Rc with Mutex is wrong
+unused_async = "deny" # Too many false positives in Tauri/framework code
+await_holding_lock = "deny"
+large_futures = "deny"
+future_not_send = "deny"
+
+# Common style improvements
+redundant_else = "deny" # Too many in existing code
+needless_continue = "deny" # Too many in existing code
+needless_raw_string_hashes = "deny" # Too many in existing code
+
+# Disable noisy categories for existing codebase but keep them available
+#style = { level = "allow", priority = -1 }
+#complexity = { level = "allow", priority = -1 }
+#perf = { level = "allow", priority = -1 }
+#pedantic = { level = "allow", priority = -1 }
+#nursery = { level = "allow", priority = -1 }
+#restriction = { level = "allow", priority = -1 }
+
+or_fun_call = "deny"
+cognitive_complexity = "deny"

--- a/crates/vendor/sysproxy/LICENSE
+++ b/crates/vendor/sysproxy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 zzzgydi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/vendor/sysproxy/README.md
+++ b/crates/vendor/sysproxy/README.md
@@ -1,0 +1,3 @@
+# sysproxy-rs
+
+A library for set/get system proxy. Supports Windows, macOS and linux (via gsettings/kconfig).

--- a/crates/vendor/sysproxy/SOURCE.md
+++ b/crates/vendor/sysproxy/SOURCE.md
@@ -1,0 +1,17 @@
+# 来源与本地调整
+
+本目录基于 `mihomo-party-org/sysproxy-rs-opti`：
+
+- 上游仓库：<https://github.com/mihomo-party-org/sysproxy-rs-opti>
+- 基准提交：`0e242650d7b4c568ab1b91cb319e0b44b2a445bd`
+- 上游版本：`0.5.1`
+- 许可证：MIT，见 `LICENSE`
+
+为缩小本项目的供应链与编译面，本地副本移除了未使用的 N-API 绑定、代理守护器、
+工具函数、基准测试和 JavaScript 包装，只保留 Windows、Linux 与 macOS 的核心系统
+代理实现。同时将上游 `url` 的 `<2.5` 版本上限放宽为工作区已使用的兼容 `2.x`。
+
+本地还收紧了只读解析：Windows 多协议配置不再把缺少 `http=` 的 SOCKS 等条目回退
+为 HTTP 代理；Linux KDE 配置必须使用与目标服务一致的 scheme，且不得携带用户信息、
+路径、查询或片段。除此之外，保留的平台实现来自上述基准提交；rustfmt 产生的差异仅
+为机械排版。

--- a/crates/vendor/sysproxy/src/lib.rs
+++ b/crates/vendor/sysproxy/src/lib.rs
@@ -1,0 +1,78 @@
+//! Get/Set system proxy. Supports Windows, macOS and linux (via gsettings).
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Sysproxy {
+    pub host: String,
+    pub bypass: String,
+    pub port: u16,
+    pub enable: bool,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Autoproxy {
+    pub url: String,
+    pub enable: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("failed to parse string `{0}`")]
+    ParseStr(String),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to get default network interface")]
+    NetworkInterface,
+
+    #[error("failed to set proxy for this environment")]
+    NotSupport,
+
+    #[error("admin privileges required to modify system proxy")]
+    RequiresAdminPrivileges,
+
+    #[cfg(target_os = "macos")]
+    #[error("failed to interact with SCPreferences")]
+    SCPreferences,
+
+    #[cfg(target_os = "macos")]
+    #[error("failed to interact with SCDynamicStore")]
+    SCDynamicStore,
+
+    #[cfg(target_os = "macos")]
+    #[error("networksetup failed: {0}")]
+    NetworkSetup(String),
+
+    #[cfg(target_os = "linux")]
+    #[error(transparent)]
+    Xdg(#[from] xdg::BaseDirectoriesError),
+
+    #[cfg(target_os = "windows")]
+    #[error("system call failed")]
+    SystemCall(#[from] windows::Win32Error),
+
+    #[cfg(target_os = "windows")]
+    #[error("failed to set ProxyEnable to {expected}; current value is {actual}")]
+    ProxyEnableMismatch { expected: u32, actual: u32 },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Sysproxy {
+    pub const fn is_support() -> bool {
+        cfg!(any(target_os = "linux", target_os = "macos", target_os = "windows",))
+    }
+}
+
+impl Autoproxy {
+    pub const fn is_support() -> bool {
+        cfg!(any(target_os = "linux", target_os = "macos", target_os = "windows",))
+    }
+}

--- a/crates/vendor/sysproxy/src/linux.rs
+++ b/crates/vendor/sysproxy/src/linux.rs
@@ -1,0 +1,698 @@
+use crate::{Autoproxy, Error, Result, Sysproxy};
+use std::{env, process::Command, str::from_utf8, sync::LazyLock};
+use url::Url;
+
+const CMD_KEY: &str = "org.gnome.system.proxy";
+
+static IS_APPIMAGE: LazyLock<bool> = LazyLock::new(|| std::env::var("APPIMAGE").is_ok());
+
+impl Sysproxy {
+    #[inline]
+    pub fn get_system_proxy() -> Result<Sysproxy> {
+        let enable = Sysproxy::get_enable()?;
+
+        let mut socks = get_proxy("socks")?;
+        let https = get_proxy("https")?;
+        let http = get_proxy("http")?;
+
+        if socks.host.is_empty() {
+            if !http.host.is_empty() {
+                socks.host = http.host;
+                socks.port = http.port;
+            }
+            if !https.host.is_empty() {
+                socks.host = https.host;
+                socks.port = https.port;
+            }
+        }
+
+        socks.enable = enable;
+        socks.bypass = Sysproxy::get_bypass().unwrap_or_else(|_| "".into());
+
+        Ok(socks)
+    }
+
+    #[inline]
+    pub fn set_system_proxy(&self) -> Result<()> {
+        self.set_enable()?;
+
+        if self.enable {
+            self.set_socks()?;
+            self.set_https()?;
+            self.set_http()?;
+            self.set_bypass()?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn get_enable() -> Result<bool> {
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "KDE" => {
+                let config_path = kioslaverc_path()?;
+
+                let mode = kreadconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                    ])
+                    .output()?;
+                let mode = from_utf8(&mode.stdout)
+                    .map_err(|_| Error::ParseStr("mode".into()))?
+                    .trim();
+                Ok(mode == "1")
+            }
+            _ => {
+                let mode = gsettings().args(["get", CMD_KEY, "mode"]).output()?;
+                let mode = from_utf8(&mode.stdout)
+                    .map_err(|_| Error::ParseStr("mode".into()))?
+                    .trim();
+                Ok(mode == "'manual'")
+            }
+        }
+    }
+
+    #[inline]
+    pub fn get_bypass() -> Result<String> {
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "KDE" => {
+                let config_path = kioslaverc_path()?;
+
+                let bypass = kreadconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "NoProxyFor",
+                    ])
+                    .output()?;
+                let bypass = from_utf8(&bypass.stdout)
+                    .map_err(|_| Error::ParseStr("bypass".into()))?
+                    .trim();
+
+                let bypass = bypass
+                    .split(',')
+                    .map(|h| strip_str(h.trim()))
+                    .collect::<Vec<&str>>()
+                    .join(",");
+
+                Ok(bypass)
+            }
+            _ => {
+                let bypass = gsettings()
+                    .args(["get", CMD_KEY, "ignore-hosts"])
+                    .output()?;
+                let bypass = from_utf8(&bypass.stdout)
+                    .map_err(|_| Error::ParseStr("bypass".into()))?
+                    .trim();
+
+                let bypass = bypass.strip_prefix('[').unwrap_or(bypass);
+                let bypass = bypass.strip_suffix(']').unwrap_or(bypass);
+
+                let bypass = bypass
+                    .split(',')
+                    .map(|h| strip_str(h.trim()))
+                    .collect::<Vec<&str>>()
+                    .join(",");
+
+                Ok(bypass)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn get_http() -> Result<Sysproxy> {
+        get_proxy("http")
+    }
+
+    #[inline]
+    pub fn get_https() -> Result<Sysproxy> {
+        get_proxy("https")
+    }
+
+    #[inline]
+    pub fn get_socks() -> Result<Sysproxy> {
+        get_proxy("socks")
+    }
+
+    #[inline]
+    pub fn set_enable(&self) -> Result<()> {
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "KDE" => {
+                let config_path = kioslaverc_path()?;
+                let mode = if self.enable { "1" } else { "0" };
+                kwriteconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                        mode,
+                    ])
+                    .status()?;
+                let gmode = if self.enable { "'manual'" } else { "'none'" };
+                gsettings().args(["set", CMD_KEY, "mode", gmode]).status()?;
+                write_dconf("/system/proxy/mode", gmode);
+                Ok(())
+            }
+            _ => {
+                let mode = if self.enable { "'manual'" } else { "'none'" };
+                gsettings().args(["set", CMD_KEY, "mode", mode]).status()?;
+                write_dconf("/system/proxy/mode", mode);
+                Ok(())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn set_bypass(&self) -> Result<()> {
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "KDE" => {
+                let config_path = kioslaverc_path()?;
+
+                let bypass = self
+                    .bypass
+                    .split(',')
+                    .map(|h| {
+                        let mut host = String::from(h.trim());
+                        if !host.starts_with('\'') && !host.starts_with('"') {
+                            host = String::from("'") + &host;
+                        }
+                        if !host.ends_with('\'') && !host.ends_with('"') {
+                            host += "'";
+                        }
+                        host
+                    })
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                let bypass = format!("[{bypass}]");
+
+                gsettings()
+                    .args(["set", CMD_KEY, "ignore-hosts", bypass.as_str()])
+                    .status()?;
+                write_dconf("/system/proxy/ignore-hosts", bypass.as_str());
+
+                kwriteconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "NoProxyFor",
+                        self.bypass.as_str(),
+                    ])
+                    .status()?;
+                Ok(())
+            }
+            _ => {
+                let bypass = self
+                    .bypass
+                    .split(',')
+                    .map(|h| {
+                        let mut host = String::from(h.trim());
+                        if !host.starts_with('\'') && !host.starts_with('"') {
+                            host = String::from("'") + &host;
+                        }
+                        if !host.ends_with('\'') && !host.ends_with('"') {
+                            host += "'";
+                        }
+                        host
+                    })
+                    .collect::<Vec<String>>()
+                    .join(", ");
+
+                let bypass = format!("[{bypass}]");
+
+                gsettings()
+                    .args(["set", CMD_KEY, "ignore-hosts", bypass.as_str()])
+                    .status()?;
+                write_dconf("/system/proxy/ignore-hosts", bypass.as_str());
+                Ok(())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn set_http(&self) -> Result<()> {
+        set_proxy(self, "http")
+    }
+
+    #[inline]
+    pub fn set_https(&self) -> Result<()> {
+        set_proxy(self, "https")
+    }
+
+    #[inline]
+    pub fn set_socks(&self) -> Result<()> {
+        set_proxy(self, "socks")
+    }
+}
+
+#[inline]
+fn gsettings() -> Command {
+    let mut command = Command::new("gsettings");
+    if *IS_APPIMAGE {
+        command.env_remove("LD_LIBRARY_PATH");
+    }
+    command
+}
+
+#[inline]
+fn dconf() -> Command {
+    let mut command = Command::new("dconf");
+    if *IS_APPIMAGE {
+        command.env_remove("LD_LIBRARY_PATH");
+    }
+    command
+}
+
+#[inline]
+fn write_dconf(path: &str, value: &str) {
+    let _ = dconf().arg("write").arg(path).arg(value).status();
+}
+
+#[inline]
+fn kioslaverc_path() -> Result<String> {
+    let xdg_dir = xdg::BaseDirectories::new();
+    let config = xdg_dir
+        .get_config_file("kioslaverc")
+        .ok_or_else(|| Error::ParseStr("config".into()))?;
+    config
+        .to_str()
+        .map(|value| value.to_owned())
+        .ok_or_else(|| Error::ParseStr("config".into()))
+}
+
+#[inline]
+fn quoted(value: &str) -> String {
+    if value.starts_with('\'') && value.ends_with('\'') {
+        value.to_string()
+    } else {
+        format!("'{}'", value)
+    }
+}
+
+#[inline]
+fn kreadconfig() -> Command {
+    let command = match env::var("KDE_SESSION_VERSION").unwrap_or_default().as_str() {
+        "6" => "kreadconfig6",
+        _ => "kreadconfig5",
+    };
+    let mut command = Command::new(command);
+    if *IS_APPIMAGE {
+        command.env_remove("LD_LIBRARY_PATH");
+    }
+    command
+}
+
+#[inline]
+fn kwriteconfig() -> Command {
+    let command = match env::var("KDE_SESSION_VERSION").unwrap_or_default().as_str() {
+        "6" => "kwriteconfig6",
+        _ => "kwriteconfig5",
+    };
+    let mut command = Command::new(command);
+    if *IS_APPIMAGE {
+        command.env_remove("LD_LIBRARY_PATH");
+    }
+    command
+}
+
+#[inline]
+fn format_kde_proxy_value(service: &str, host: &str, port: u16) -> String {
+    let host = if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+
+    format!("{service}://{host}:{port}")
+}
+
+#[inline]
+fn set_proxy(proxy: &Sysproxy, service: &str) -> Result<()> {
+    match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+        "KDE" => {
+            let schema = format!("{CMD_KEY}.{service}");
+            let schema = schema.as_str();
+
+            let host = format!("'{}'", proxy.host);
+            let host = host.as_str();
+            let port = format!("{}", proxy.port);
+            let port = port.as_str();
+            let dconf_service = service;
+
+            gsettings().args(["set", schema, "host", host]).status()?;
+            gsettings().args(["set", schema, "port", port]).status()?;
+            let host_path = format!("/system/proxy/{dconf_service}/host");
+            let port_path = format!("/system/proxy/{dconf_service}/port");
+            write_dconf(host_path.as_str(), host);
+            write_dconf(port_path.as_str(), port);
+
+            let config_path = kioslaverc_path()?;
+
+            let key = format!("{service}Proxy");
+            let key = key.as_str();
+
+            let service = match service {
+                "socks" => "socks",
+                _ => "http",
+            };
+
+            let schema = format_kde_proxy_value(service, proxy.host.as_str(), proxy.port);
+            let schema = schema.as_str();
+
+            kwriteconfig()
+                .args([
+                    "--file",
+                    config_path.as_str(),
+                    "--group",
+                    "Proxy Settings",
+                    "--key",
+                    key,
+                    schema,
+                ])
+                .status()?;
+
+            Ok(())
+        }
+        _ => {
+            let schema = format!("{CMD_KEY}.{service}");
+            let schema = schema.as_str();
+
+            let host = format!("'{}'", proxy.host);
+            let host = host.as_str();
+            let port = format!("{}", proxy.port);
+            let port = port.as_str();
+            let dconf_service = service;
+
+            gsettings().args(["set", schema, "host", host]).status()?;
+            gsettings().args(["set", schema, "port", port]).status()?;
+            let host_path = format!("/system/proxy/{dconf_service}/host");
+            let port_path = format!("/system/proxy/{dconf_service}/port");
+            write_dconf(host_path.as_str(), host);
+            write_dconf(port_path.as_str(), port);
+
+            Ok(())
+        }
+    }
+}
+
+#[inline]
+fn get_proxy(service: &str) -> Result<Sysproxy> {
+    match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+        "KDE" => {
+            let config_path = kioslaverc_path()?;
+
+            let key = format!("{service}Proxy");
+            let key = key.as_str();
+
+            let schema = kreadconfig()
+                .args(["--file", config_path.as_str(), "--group", "Proxy Settings", "--key", key])
+                .output()?;
+            let schema = from_utf8(&schema.stdout)
+                .map_err(|_| Error::ParseStr("schema".into()))?
+                .trim();
+            let schema = strip_str(schema);
+            let (host, port) = parse_kde_proxy(schema, service)?;
+
+            Ok(Sysproxy {
+                enable: false,
+                host,
+                port,
+                bypass: "".into(),
+            })
+        }
+        _ => {
+            let schema = format!("{CMD_KEY}.{service}");
+            let schema = schema.as_str();
+
+            let host = gsettings().args(["get", schema, "host"]).output()?;
+            let host = from_utf8(&host.stdout)
+                .map_err(|_| Error::ParseStr("host".into()))?
+                .trim();
+            let host = strip_str(host);
+
+            let port = gsettings().args(["get", schema, "port"]).output()?;
+            let port = from_utf8(&port.stdout)
+                .map_err(|_| Error::ParseStr("port".into()))?
+                .trim();
+            let port = port.parse().unwrap_or(80u16);
+
+            Ok(Sysproxy {
+                enable: false,
+                host: String::from(host),
+                port,
+                bypass: "".into(),
+            })
+        }
+    }
+}
+
+#[inline]
+fn strip_str(text: &str) -> &str {
+    text.strip_prefix('\'')
+        .unwrap_or(text)
+        .strip_suffix('\'')
+        .unwrap_or(text)
+}
+
+#[inline]
+fn parse_url(schema: &str, expected_scheme: &str) -> Option<(String, u16)> {
+    let url = Url::parse(schema.trim()).ok()?;
+    let valid = url.scheme().eq_ignore_ascii_case(expected_scheme)
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.path() == "/"
+        && url.query().is_none()
+        && url.fragment().is_none();
+    if !valid {
+        return None;
+    }
+    Some((url.host_str()?.to_string(), url.port_or_known_default().unwrap_or(0u16)))
+}
+
+#[inline]
+fn parse_kde_proxy(schema: &str, service: &str) -> Result<(String, u16)> {
+    let schema = schema.trim();
+    if schema.is_empty() {
+        // KDE's default kioslaverc may not contain per-scheme proxy entries at all.
+        // Treat an empty value as "not configured" instead of a hard error.
+        return Ok(("".into(), 0));
+    }
+
+    let (scheme, default_port) = match service {
+        "socks" => ("socks", 1080),
+        "https" => ("https", 443),
+        _ => ("http", 80),
+    };
+
+    let parse = |candidate: &str| {
+        parse_url(candidate, scheme)
+            .map(|(host, port)| (host, if port == 0 { default_port } else { port }))
+    };
+
+    if let Some(result) = parse(schema) {
+        return Ok(result);
+    }
+
+    // Legacy KDE format: "<endpoint> <port>"
+    let mut whitespace = schema.split_whitespace();
+    if let (Some(endpoint), Some(port)) = (whitespace.next(), whitespace.next()) {
+        let candidate = if endpoint.contains("://") {
+            format!("{endpoint}:{port}")
+        } else {
+            format!("{scheme}://{endpoint}:{port}")
+        };
+        if let Some(result) = parse(candidate.as_str()) {
+            return Ok(result);
+        }
+    }
+
+    if !schema.contains("://") {
+        let candidate = format!("{scheme}://{schema}");
+        if let Some(result) = parse(candidate.as_str()) {
+            return Ok(result);
+        }
+    }
+
+    Err(Error::ParseStr("schema".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_legacy_spaced_http_entry() {
+        let (host, port) = parse_kde_proxy("http://127.0.0.1 7897", "http").unwrap();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 7897);
+    }
+
+    #[test]
+    fn parse_legacy_spaced_socks_entry_without_scheme() {
+        let (host, port) = parse_kde_proxy("127.0.0.1 7897", "socks").unwrap();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 7897);
+    }
+
+    #[test]
+    fn parse_plasma_colon_entry() {
+        let (host, port) = parse_kde_proxy("http://127.0.0.1:7897", "http").unwrap();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 7897);
+    }
+
+    #[test]
+    fn parse_url_without_port_defaults_to_80() {
+        let (host, port) = parse_kde_proxy("http://127.0.0.1", "http").unwrap();
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 80);
+    }
+
+    #[test]
+    fn parse_https_without_port_defaults_to_443() {
+        let (host, port) = parse_kde_proxy("https://proxy.example.com", "https").unwrap();
+        assert_eq!(host, "proxy.example.com");
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn empty_schema_returns_empty_result() {
+        let (host, port) = parse_kde_proxy("", "http").unwrap();
+        assert_eq!(host, "");
+        assert_eq!(port, 0);
+    }
+
+    #[test]
+    fn rejects_mismatched_or_ambiguous_proxy_urls() {
+        for schema in [
+            "socks://127.0.0.1:1080",
+            "http://user:password@127.0.0.1:7890",
+            "http://127.0.0.1:7890/path",
+            "http://127.0.0.1:7890?query=1",
+            "http://127.0.0.1:7890#fragment",
+        ] {
+            assert!(parse_kde_proxy(schema, "http").is_err());
+        }
+    }
+}
+
+impl Autoproxy {
+    #[inline]
+    pub fn get_auto_proxy() -> Result<Autoproxy> {
+        let (enable, url) = match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "KDE" => {
+                let config_path = kioslaverc_path()?;
+
+                let mode = kreadconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                    ])
+                    .output()?;
+                let mode = from_utf8(&mode.stdout)
+                    .map_err(|_| Error::ParseStr("mode".into()))?
+                    .trim();
+                let url = kreadconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "Proxy Config Script",
+                    ])
+                    .output()?;
+                let url = from_utf8(&url.stdout)
+                    .map_err(|_| Error::ParseStr("url".into()))?
+                    .trim();
+                (mode == "2", url.to_string())
+            }
+            _ => {
+                let mode = gsettings().args(["get", CMD_KEY, "mode"]).output()?;
+                let mode = from_utf8(&mode.stdout)
+                    .map_err(|_| Error::ParseStr("mode".into()))?
+                    .trim();
+                let url = gsettings()
+                    .args(["get", CMD_KEY, "autoconfig-url"])
+                    .output()?;
+                let url: &str = from_utf8(&url.stdout)
+                    .map_err(|_| Error::ParseStr("url".into()))?
+                    .trim();
+                let url = strip_str(url);
+                (mode == "'auto'", url.to_string())
+            }
+        };
+
+        Ok(Autoproxy { enable, url })
+    }
+
+    #[inline]
+    pub fn set_auto_proxy(&self) -> Result<()> {
+        match env::var("XDG_CURRENT_DESKTOP").unwrap_or_default().as_str() {
+            "KDE" => {
+                let config_path = kioslaverc_path()?;
+                let mode = if self.enable { "2" } else { "0" };
+                kwriteconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "ProxyType",
+                        mode,
+                    ])
+                    .status()?;
+                kwriteconfig()
+                    .args([
+                        "--file",
+                        config_path.as_str(),
+                        "--group",
+                        "Proxy Settings",
+                        "--key",
+                        "Proxy Config Script",
+                        &self.url,
+                    ])
+                    .status()?;
+                let gmode = if self.enable { "'auto'" } else { "'none'" };
+                gsettings().args(["set", CMD_KEY, "mode", gmode]).status()?;
+                write_dconf("/system/proxy/mode", gmode);
+                let autoconfig = quoted(&self.url);
+                gsettings()
+                    .args(["set", CMD_KEY, "autoconfig-url", autoconfig.as_str()])
+                    .status()?;
+                write_dconf("/system/proxy/autoconfig-url", autoconfig.as_str());
+            }
+            _ => {
+                let mode = if self.enable { "'auto'" } else { "'none'" };
+                gsettings().args(["set", CMD_KEY, "mode", mode]).status()?;
+                write_dconf("/system/proxy/mode", mode);
+                let autoconfig = quoted(&self.url);
+                gsettings()
+                    .args(["set", CMD_KEY, "autoconfig-url", autoconfig.as_str()])
+                    .status()?;
+                write_dconf("/system/proxy/autoconfig-url", autoconfig.as_str());
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/vendor/sysproxy/src/macos.rs
+++ b/crates/vendor/sysproxy/src/macos.rs
@@ -1,0 +1,692 @@
+use crate::{Autoproxy, Error, Result, Sysproxy};
+use log::debug;
+use std::{
+    borrow::Cow,
+    process::{Command, Output, Stdio},
+    str::from_utf8,
+};
+use system_configuration::{
+    core_foundation::dictionary::CFDictionary, dynamic_store::SCDynamicStore,
+    preferences::SCPreferences,
+};
+use system_configuration::{
+    core_foundation::{array::CFArray, base::TCFType},
+    network_configuration::SCNetworkService,
+    sys::network_configuration::{
+        SCNetworkProtocolGetConfiguration, SCNetworkServiceCopy, SCNetworkServiceCopyProtocol,
+        SCNetworkServiceGetName,
+    },
+    sys::preferences::{SCPreferencesLock, SCPreferencesUnlock},
+};
+use system_configuration::{
+    core_foundation::{
+        base::{CFRelease, CFType, ItemRef},
+        number::CFNumber,
+        string::{CFString, CFStringRef},
+    },
+    dynamic_store::SCDynamicStoreBuilder,
+};
+
+#[derive(Debug)]
+enum ProxyType {
+    Http,
+    Https,
+    Socks,
+}
+
+impl ProxyType {
+    #[inline]
+    const fn as_enable(&self) -> &'static str {
+        match self {
+            Self::Http => "HTTPEnable",
+            Self::Https => "HTTPSEnable",
+            Self::Socks => "SOCKSEnable",
+        }
+    }
+    #[inline]
+    const fn as_host(&self) -> &'static str {
+        match self {
+            Self::Http => "HTTPProxy",
+            Self::Https => "HTTPSProxy",
+            Self::Socks => "SOCKSProxy",
+        }
+    }
+    #[inline]
+    const fn as_port(&self) -> &'static str {
+        match self {
+            Self::Http => "HTTPPort",
+            Self::Https => "HTTPSPort",
+            Self::Socks => "SOCKSPort",
+        }
+    }
+}
+
+impl ProxyType {
+    #[inline]
+    const fn as_set_str(&self) -> &'static str {
+        match self {
+            Self::Http => "-setwebproxy",
+            Self::Https => "-setsecurewebproxy",
+            Self::Socks => "-setsocksfirewallproxy",
+        }
+    }
+    #[inline]
+    const fn as_state_cmd(&self) -> &'static str {
+        match self {
+            Self::Http => "-setwebproxystate",
+            Self::Https => "-setsecurewebproxystate",
+            Self::Socks => "-setsocksfirewallproxystate",
+        }
+    }
+}
+
+impl Sysproxy {
+    #[inline]
+    pub fn get_system_proxy() -> Result<Sysproxy> {
+        let service_uuid = get_active_network_service_uuid()?;
+        let scp = SCPreferences::default(&CFString::new("sysproxy-rs"));
+        let proxies_dict = get_proxies_by_service_uuid(&scp, &service_uuid)?;
+
+        let mut socks = parse_proxies_from_dict(&proxies_dict, ProxyType::Socks)?;
+        debug!("Getting SOCKS proxy: {:?}", socks);
+
+        let http = parse_proxies_from_dict(&proxies_dict, ProxyType::Http)?;
+        debug!("Getting HTTP proxy: {:?}", http);
+
+        let https = parse_proxies_from_dict(&proxies_dict, ProxyType::Https)?;
+        debug!("Getting HTTPS proxy: {:?}", https);
+
+        let bypass = parse_bypass_from_dict(&proxies_dict)?.join(",");
+        debug!("Getting bypass domains: {:?}", bypass);
+
+        socks.bypass = bypass;
+
+        if !socks.enable {
+            if http.enable {
+                socks.enable = true;
+                socks.host = http.host;
+                socks.port = http.port;
+            }
+
+            if https.enable {
+                socks.enable = true;
+                socks.host = https.host;
+                socks.port = https.port;
+            }
+        }
+
+        Ok(socks)
+    }
+
+    #[inline]
+    pub fn set_system_proxy(&self) -> Result<()> {
+        let service = get_active_network_service()?;
+        let service = service.to_string();
+        let service = service.as_str();
+
+        debug!("Use network service: {}", service);
+
+        debug!("Setting SOCKS proxy");
+        self.set_socks(service)?;
+
+        debug!("Setting HTTPS proxy");
+        self.set_https(service)?;
+
+        debug!("Setting HTTP proxy");
+        self.set_http(service)?;
+
+        debug!("Setting bypass domains");
+        self.set_bypass(service)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn get_http(
+        service: &CFString,
+        cfd: Option<&CFDictionary<CFString, CFType>>,
+    ) -> Result<Sysproxy> {
+        let cfd = match cfd {
+            Some(s) => s,
+            None => &get_proxies_dict_from_service_uuid(service)?,
+        };
+        parse_proxies_from_dict(cfd, ProxyType::Http)
+    }
+
+    #[inline]
+    pub fn get_https(
+        service: &CFString,
+        cfd: Option<&CFDictionary<CFString, CFType>>,
+    ) -> Result<Sysproxy> {
+        let cfd = match cfd {
+            Some(s) => s,
+            None => &get_proxies_dict_from_service_uuid(service)?,
+        };
+        parse_proxies_from_dict(cfd, ProxyType::Https)
+    }
+
+    #[inline]
+    pub fn get_socks(
+        service: &CFString,
+        cfd: Option<&CFDictionary<CFString, CFType>>,
+    ) -> Result<Sysproxy> {
+        let cfd = match cfd {
+            Some(s) => s,
+            None => &get_proxies_dict_from_service_uuid(service)?,
+        };
+        parse_proxies_from_dict(cfd, ProxyType::Socks)
+    }
+
+    #[inline]
+    pub fn get_bypass(
+        service: &CFString,
+        cfd: Option<&CFDictionary<CFString, CFType>>,
+    ) -> Result<String> {
+        let cfd = match cfd {
+            Some(s) => s,
+            None => &get_proxies_dict_from_service_uuid(service)?,
+        };
+        let bypass_list = parse_bypass_from_dict(cfd)?;
+        Ok(bypass_list.join(","))
+    }
+
+    #[inline]
+    pub fn set_http(&self, service: &str) -> Result<()> {
+        set_proxy(self, ProxyType::Http, service)
+    }
+
+    #[inline]
+    pub fn set_https(&self, service: &str) -> Result<()> {
+        set_proxy(self, ProxyType::Https, service)
+    }
+
+    #[inline]
+    pub fn set_socks(&self, service: &str) -> Result<()> {
+        set_proxy(self, ProxyType::Socks, service)
+    }
+
+    #[inline]
+    pub fn set_bypass(&self, service: &str) -> Result<()> {
+        set_bypass(self, service)
+    }
+
+    #[inline]
+    pub fn has_permission() -> bool {
+        let scp = SCPreferences::default(&CFString::new("sysproxy-rs"));
+        unsafe {
+            let locked = SCPreferencesLock(scp.as_concrete_TypeRef(), 0);
+            if locked != 0 {
+                SCPreferencesUnlock(scp.as_concrete_TypeRef());
+                true
+            } else {
+                debug!("Permission check failed: SCPreferencesLock returned false");
+                false
+            }
+        }
+    }
+}
+
+impl Autoproxy {
+    #[inline]
+    pub fn get_auto_proxy() -> Result<Autoproxy> {
+        let service = get_active_network_service_uuid()?;
+        let store = SCDynamicStoreBuilder::new("sysproxy-rs")
+            .build()
+            .ok_or(Error::SCDynamicStore)?;
+        get_autoproxies_by_service_uuid(&store, &service)
+    }
+
+    #[inline]
+    pub fn set_auto_proxy(&self) -> Result<()> {
+        let service = get_active_network_service()?.to_string();
+        let service = service.as_str();
+        let enable = if self.enable { "on" } else { "off" };
+        let url = if self.url.is_empty() {
+            "\"\""
+        } else {
+            &self.url
+        };
+        run_networksetup(&["-setautoproxyurl", service, url])?;
+        run_networksetup(&["-setautoproxystate", service, enable])?;
+
+        Ok(())
+    }
+}
+
+#[inline]
+fn run_networksetup<'a>(args: &[&str]) -> Result<Cow<'a, str>> {
+    let output = Command::new("networksetup")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    parse_networksetup_output(args, output)
+}
+
+#[inline]
+fn parse_networksetup_output<'a>(args: &[&str], output: Output) -> Result<Cow<'a, str>> {
+    let stdout = from_utf8(&output.stdout).map_err(|_| Error::ParseStr("output".into()))?;
+    let stderr = from_utf8(&output.stderr).map_err(|_| Error::ParseStr("error output".into()))?;
+
+    if !output.status.success() {
+        let details = [stdout.trim(), stderr.trim()]
+            .into_iter()
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        if details.contains("requires admin privileges") {
+            log::error!(
+                "Admin privileges required to run networksetup with args: {:?}, error: {}",
+                args,
+                details
+            );
+            return Err(Error::RequiresAdminPrivileges);
+        }
+
+        log::error!(
+            "networksetup failed with args: {:?}, status: {}, error: {}",
+            args,
+            output.status,
+            details
+        );
+        return Err(Error::NetworkSetup(format!(
+            "args={args:?}, status={}, error={details}",
+            output.status
+        )));
+    }
+
+    Ok(Cow::Owned(stdout.to_string()))
+}
+
+#[inline]
+fn set_proxy(proxy: &Sysproxy, proxy_type: ProxyType, service: &str) -> Result<()> {
+    let host = proxy.host.as_str();
+    let port = format!("{}", proxy.port);
+    let port = port.as_str();
+
+    run_networksetup(&[proxy_type.as_set_str(), service, host, port])?;
+
+    let enable = if proxy.enable { "on" } else { "off" };
+
+    run_networksetup(&[proxy_type.as_state_cmd(), service, enable])?;
+
+    Ok(())
+}
+
+#[inline]
+fn set_bypass(proxy: &Sysproxy, service: &str) -> Result<()> {
+    let mut args = vec!["-setproxybypassdomains", service];
+    let domains: Vec<&str> = if proxy.bypass.is_empty() {
+        Vec::new()
+    } else {
+        proxy.bypass.split(",").collect()
+    };
+    args.extend(&domains);
+    run_networksetup(&args)?;
+    Ok(())
+}
+
+fn get_active_network_service() -> Result<CFString> {
+    let service_uuid = get_active_network_service_uuid()?;
+    let scp = SCPreferences::default(&CFString::new("sysproxy-rs"));
+    unsafe {
+        let service_ref =
+            SCNetworkServiceCopy(scp.as_concrete_TypeRef(), service_uuid.as_concrete_TypeRef());
+        if service_ref.is_null() {
+            return Err(Error::NetworkInterface);
+        }
+
+        let name = network_service_name_from_ptr(SCNetworkServiceGetName(service_ref));
+        CFRelease(service_ref);
+        name.ok_or(Error::NetworkInterface)
+    }
+}
+
+unsafe fn network_service_name_from_ptr(name: CFStringRef) -> Option<CFString> {
+    if name.is_null() {
+        None
+    } else {
+        Some(unsafe { CFString::wrap_under_get_rule(name) })
+    }
+}
+
+fn get_active_network_service_uuid() -> Result<CFString> {
+    let store = SCDynamicStoreBuilder::new("sysproxy-rs")
+        .build()
+        .ok_or(Error::SCDynamicStore)?;
+    let global_ipv4_key = CFString::from_static_string("State:/Network/Global/IPv4");
+    let sets = store.get(global_ipv4_key).ok_or(Error::SCDynamicStore)?;
+    if let Some(dict) = sets.downcast_into::<CFDictionary>() {
+        let key = CFString::from_static_string("PrimaryService");
+        let val_ptr = dict.find(key.as_CFTypeRef() as *const _);
+        if let Some(ptr) = val_ptr {
+            let service_id_cf = unsafe { CFString::wrap_under_get_rule(*ptr as _) };
+            return Ok(service_id_cf);
+        }
+    }
+    Err(Error::NetworkInterface)
+}
+
+fn parse_proxies_from_dict(
+    cfd: &CFDictionary<CFString, CFType>,
+    proxy_type: ProxyType,
+) -> Result<Sysproxy> {
+    let enable = read_bool_flag(cfd, proxy_type.as_enable());
+    let port = read_port(cfd, proxy_type.as_port());
+    let host = read_host(cfd, proxy_type.as_host());
+    let enable = enable && !host.is_empty() && port != 0;
+
+    Ok(Sysproxy {
+        enable,
+        host,
+        port,
+        bypass: String::new(),
+    })
+}
+
+fn parse_proxyauto_from_dict(cfd: &CFDictionary<CFString, CFType>) -> Result<Autoproxy> {
+    // When auto proxy is not configured, these keys may not exist - default to disabled
+    let enable = get_proxy_value(cfd, "ProxyAutoConfigEnable")
+        .and_then(|x| x.downcast::<CFNumber>())
+        .and_then(|num| num.to_i32())
+        .map(|v| v != 0)
+        .unwrap_or(false);
+    let url = get_proxy_value(cfd, "ProxyAutoConfigURLString")
+        .and_then(|x| x.downcast::<CFString>().map(|s| s.to_string()))
+        .unwrap_or_default();
+
+    let url = if url == "\"\"" { String::new() } else { url };
+    let enable = enable && !url.is_empty();
+
+    Ok(Autoproxy { enable, url })
+}
+
+fn parse_bypass_from_dict(cfd: &CFDictionary<CFString, CFType>) -> Result<Vec<String>> {
+    let Some(bypass_list_raw) =
+        get_proxy_value(cfd, "ExceptionsList").and_then(|x| x.downcast::<CFArray>())
+    else {
+        return Ok(Vec::new());
+    };
+
+    let mut bypass_list = Vec::with_capacity(bypass_list_raw.len() as usize);
+    for bypass_raw in &bypass_list_raw {
+        let cf_type: CFType = unsafe { TCFType::wrap_under_get_rule(*bypass_raw as _) };
+        if let Some(cf_string) = cf_type.downcast::<CFString>() {
+            bypass_list.push(cf_string.to_string());
+        }
+    }
+
+    Ok(bypass_list)
+}
+
+fn get_proxy_value<'a>(
+    dict: &'a CFDictionary<CFString, CFType>,
+    key: &'static str,
+) -> Option<ItemRef<'a, CFType>> {
+    let cf_key = CFString::from_static_string(key);
+    dict.find(&cf_key)
+}
+
+fn read_bool_flag(cfd: &CFDictionary<CFString, CFType>, key: &'static str) -> bool {
+    get_proxy_value(cfd, key)
+        .and_then(|x| x.downcast::<CFNumber>())
+        .and_then(|num| num.to_i32())
+        .is_some_and(|v| v != 0)
+}
+
+fn read_port(cfd: &CFDictionary<CFString, CFType>, key: &'static str) -> u16 {
+    get_proxy_value(cfd, key)
+        .and_then(|x| x.downcast::<CFNumber>())
+        .and_then(|num| num.to_i32())
+        .filter(|v| (0..=u16::MAX as i32).contains(v))
+        .map_or(0, |v| v as u16)
+}
+
+fn read_host(cfd: &CFDictionary<CFString, CFType>, key: &'static str) -> String {
+    get_proxy_value(cfd, key)
+        .and_then(|x| x.downcast::<CFString>().map(|s| s.to_string()))
+        .unwrap_or_default()
+}
+
+// #[allow(dead_code)]
+// fn get_service_id_by_bsd_name(scp: &SCPreferences, bsd_name: &str) -> Option<CFString> {
+//     let services = SCNetworkService::get_services(scp);
+//     for service in &services {
+//         if let Some(interface) = service
+//             .network_interface()
+//             .and_then(|scn_inter| scn_inter.bsd_name().map(|name| name.to_string()))
+//         {
+//             if interface == bsd_name {
+//                 return service.id();
+//             }
+//         }
+//     }
+//     None
+// }
+
+fn get_service_id_by_display_name(scp: &SCPreferences, name: &CFString) -> Option<CFString> {
+    let services = SCNetworkService::get_services(scp);
+    for service in &services {
+        if let Some(interface) = service
+            .network_interface()
+            .and_then(|scn_inter| scn_inter.display_name())
+        {
+            if interface == *name {
+                return service.id();
+            }
+        }
+    }
+    None
+}
+
+fn get_autoproxies_by_service_uuid(
+    store: &SCDynamicStore,
+    service_uuid: &CFString,
+) -> Result<Autoproxy> {
+    let proxy_key = CFString::new(&format!("Setup:/Network/Service/{}/Proxies", service_uuid));
+
+    let proxies_cf_type = store
+        .get(proxy_key)
+        .ok_or_else(|| Error::ParseStr("Proxy settings not found in DynamicStore".into()))?;
+
+    let proxies_dict_raw = proxies_cf_type
+        .downcast_into::<CFDictionary>()
+        .ok_or_else(|| Error::ParseStr("Not a dictionary".into()))?;
+
+    let proxies_dict: CFDictionary<CFString, CFType> =
+        unsafe { CFDictionary::wrap_under_get_rule(proxies_dict_raw.as_concrete_TypeRef() as _) };
+
+    parse_proxyauto_from_dict(&proxies_dict)
+}
+
+fn get_proxies_by_service_uuid(
+    scp: &SCPreferences,
+    service_uuid: &CFString,
+) -> Result<CFDictionary<CFString, CFType>> {
+    unsafe {
+        let service_ref =
+            SCNetworkServiceCopy(scp.as_concrete_TypeRef(), service_uuid.as_concrete_TypeRef());
+        if service_ref.is_null() {
+            return Err(Error::SCPreferences);
+        }
+
+        let protocol_ref = SCNetworkServiceCopyProtocol(
+            service_ref,
+            CFString::from_static_string("Proxies").as_concrete_TypeRef(),
+        );
+        if protocol_ref.is_null() {
+            CFRelease(service_ref);
+            return Err(Error::SCPreferences);
+        }
+
+        let config = SCNetworkProtocolGetConfiguration(protocol_ref);
+        if config.is_null() {
+            CFRelease(service_ref);
+            CFRelease(protocol_ref);
+            return Err(Error::SCPreferences);
+        }
+
+        let dict: CFDictionary<CFString, CFType> = CFDictionary::wrap_under_get_rule(config as _);
+
+        CFRelease(service_ref);
+        CFRelease(protocol_ref);
+
+        Ok(dict)
+    }
+}
+
+pub fn get_proxies_dict_from_service_uuid(
+    service: &CFString,
+) -> Result<CFDictionary<CFString, CFType>> {
+    let scp = SCPreferences::default(&CFString::new("sysproxy-rs"));
+    let service_uuid =
+        get_service_id_by_display_name(&scp, service).ok_or(Error::NetworkInterface)?;
+    get_proxies_by_service_uuid(&scp, &service_uuid)
+}
+
+#[test]
+fn test_get_service_id_by_display_name() {
+    let scp = SCPreferences::default(&CFString::new("sysproxy-rs"));
+    let services = SCNetworkService::get_services(&scp);
+
+    // Find first service with a valid display name (CI may not have Wi-Fi)
+    let Some(display_name) = services.iter().find_map(|service| {
+        service
+            .network_interface()
+            .and_then(|iface| iface.display_name())
+    }) else {
+        println!("No network service found, skipping test");
+        return;
+    };
+
+    println!("Testing with service: {:?}", display_name);
+    let Some(service_uuid) = get_service_id_by_display_name(&scp, &display_name) else {
+        panic!("Failed to get service UUID for {:?}", display_name);
+    };
+    assert!(!service_uuid.to_string().is_empty());
+    println!("service_uuid: {:?}", service_uuid);
+
+    // Proxy settings may not exist for all services
+    match get_proxies_by_service_uuid(&scp, &service_uuid) {
+        Ok(proxies) => println!("proxies: {:?}", proxies),
+        Err(e) => println!("No proxy settings for this service: {:?}", e),
+    }
+}
+
+#[test]
+fn test_set_bypass() {
+    let proxy = Sysproxy {
+        host: "proxy.example.com".into(),
+        port: 8080,
+        enable: true,
+        bypass: "no".into(),
+    };
+    let result = proxy.set_bypass("Wi-Fi");
+    if let Err(e) = result {
+        assert!(matches!(e, Error::RequiresAdminPrivileges));
+        assert!(!Sysproxy::has_permission());
+    }
+}
+
+#[test]
+fn parse_proxy_missing_fields_disable_proxy() {
+    let dict = CFDictionary::from_CFType_pairs(&[(
+        CFString::from_static_string("HTTPEnable"),
+        CFNumber::from(1).as_CFType(),
+    )]);
+    let proxy = parse_proxies_from_dict(&dict, ProxyType::Http).unwrap();
+    assert!(!proxy.enable);
+    assert_eq!(proxy.host, "");
+    assert_eq!(proxy.port, 0);
+}
+
+#[test]
+fn parse_proxy_negative_port_zeroed() {
+    let dict = CFDictionary::from_CFType_pairs(&[
+        (CFString::from_static_string("HTTPEnable"), CFNumber::from(1).as_CFType()),
+        (
+            CFString::from_static_string("HTTPProxy"),
+            CFString::from_static_string("localhost").as_CFType(),
+        ),
+        (CFString::from_static_string("HTTPPort"), CFNumber::from(-1).as_CFType()),
+    ]);
+    let proxy = parse_proxies_from_dict(&dict, ProxyType::Http).unwrap();
+    assert!(!proxy.enable);
+    assert_eq!(proxy.port, 0);
+}
+
+#[test]
+fn network_service_name_from_ptr_preserves_trailing_space() {
+    let name = CFString::new("Wi-Fi ");
+    let service_name = unsafe { network_service_name_from_ptr(name.as_concrete_TypeRef()) }
+        .map(|name| name.to_string());
+
+    assert_eq!(service_name, Some("Wi-Fi ".to_string()));
+}
+
+#[test]
+fn networksetup_nonzero_exit_returns_error() {
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::{ExitStatus, Output};
+
+    for (stdout, stderr) in [
+        (b"** Error: The parameters were not valid.\n".to_vec(), Vec::new()),
+        (Vec::new(), b"** Error: The parameters were not valid.\n".to_vec()),
+    ] {
+        let output = Output {
+            status: ExitStatus::from_raw(4 << 8),
+            stdout,
+            stderr,
+        };
+
+        let result = parse_networksetup_output(&["-setwebproxy", "Wi-Fi"], output);
+
+        assert!(matches!(
+            result,
+            Err(Error::NetworkSetup(message))
+                if message.contains("The parameters were not valid")
+        ));
+    }
+}
+
+#[test]
+fn parse_proxy_too_large_port_zeroed() {
+    let dict = CFDictionary::from_CFType_pairs(&[
+        (CFString::from_static_string("HTTPEnable"), CFNumber::from(1).as_CFType()),
+        (
+            CFString::from_static_string("HTTPProxy"),
+            CFString::from_static_string("localhost").as_CFType(),
+        ),
+        (CFString::from_static_string("HTTPPort"), CFNumber::from(i32::MAX).as_CFType()),
+    ]);
+    let proxy = parse_proxies_from_dict(&dict, ProxyType::Http).unwrap();
+    assert!(!proxy.enable);
+    assert_eq!(proxy.port, 0);
+}
+
+#[test]
+fn parse_bypass_missing_returns_empty() {
+    let dict: CFDictionary<CFString, CFType> = CFDictionary::from_CFType_pairs(&[]);
+    let bypass = parse_bypass_from_dict(&dict).unwrap();
+    assert!(bypass.is_empty());
+}
+
+#[test]
+fn parse_proxyauto_defaults_to_false_and_empty_url() {
+    let dict: CFDictionary<CFString, CFType> = CFDictionary::from_CFType_pairs(&[]);
+    let auto = parse_proxyauto_from_dict(&dict).unwrap();
+    assert!(!auto.enable);
+    assert_eq!(auto.url, "");
+}
+
+#[test]
+fn parse_proxyauto_disable_when_url_missing() {
+    let dict = CFDictionary::from_CFType_pairs(&[(
+        CFString::from_static_string("ProxyAutoConfigEnable"),
+        CFNumber::from(1).as_CFType(),
+    )]);
+    let auto = parse_proxyauto_from_dict(&dict).unwrap();
+    assert!(!auto.enable);
+    assert_eq!(auto.url, "");
+}

--- a/crates/vendor/sysproxy/src/windows.rs
+++ b/crates/vendor/sysproxy/src/windows.rs
@@ -1,0 +1,425 @@
+use crate::{Autoproxy, Error, Result, Sysproxy};
+use std::{ffi::c_void, mem::size_of};
+use url::Url;
+use windows::{
+    core::{PCWSTR, PWSTR},
+    Win32::{
+        NetworkManagement::Rras::{RasEnumEntriesW, ERROR_BUFFER_TOO_SMALL, RASENTRYNAMEW},
+        Networking::WinInet::{
+            InternetSetOptionW, INTERNET_OPTION_PER_CONNECTION_OPTION,
+            INTERNET_OPTION_PROXY_SETTINGS_CHANGED, INTERNET_OPTION_REFRESH,
+            INTERNET_PER_CONN_AUTOCONFIG_URL, INTERNET_PER_CONN_FLAGS, INTERNET_PER_CONN_OPTIONW,
+            INTERNET_PER_CONN_OPTIONW_0, INTERNET_PER_CONN_OPTION_LISTW,
+            INTERNET_PER_CONN_PROXY_BYPASS, INTERNET_PER_CONN_PROXY_SERVER, PROXY_TYPE_AUTO_DETECT,
+            PROXY_TYPE_AUTO_PROXY_URL, PROXY_TYPE_DIRECT, PROXY_TYPE_PROXY,
+        },
+    },
+};
+use winreg::{enums, RegKey};
+
+pub use windows::core::Error as Win32Error;
+
+const SUB_KEY: &str = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings";
+
+fn set_proxy_enable(enable: bool) -> Result<()> {
+    let expected = u32::from(enable);
+    let hkcu = RegKey::predef(enums::HKEY_CURRENT_USER);
+    let cur_var =
+        hkcu.open_subkey_with_flags(SUB_KEY, enums::KEY_QUERY_VALUE | enums::KEY_SET_VALUE)?;
+
+    cur_var.set_value("ProxyEnable", &expected)?;
+    let actual = cur_var.get_value::<u32, _>("ProxyEnable")?;
+    if actual != expected {
+        return Err(Error::ProxyEnableMismatch { expected, actual });
+    }
+
+    Ok(())
+}
+
+fn encode_wide<S: AsRef<std::ffi::OsStr>>(string: S) -> Vec<u16> {
+    std::os::windows::prelude::OsStrExt::encode_wide(string.as_ref())
+        .chain(std::iter::once(0))
+        .collect::<Vec<u16>>()
+}
+
+/// unset proxy
+///
+/// **对于包含中文字符的拨号连接或 VPN 连接，可能无法正确设置其代理，建议使用全英文重命名该连接名称**
+#[inline]
+fn unset_proxy() -> Result<()> {
+    let mut p_opts = Vec::<INTERNET_PER_CONN_OPTIONW>::with_capacity(1);
+    p_opts.push(INTERNET_PER_CONN_OPTIONW {
+        dwOption: INTERNET_PER_CONN_FLAGS,
+        Value: {
+            let mut v = INTERNET_PER_CONN_OPTIONW_0::default();
+            v.dwValue = PROXY_TYPE_DIRECT;
+            v
+        },
+    });
+    let mut opts = INTERNET_PER_CONN_OPTION_LISTW {
+        dwSize: size_of::<INTERNET_PER_CONN_OPTION_LISTW>() as u32,
+        dwOptionCount: 1,
+        dwOptionError: 0,
+        pOptions: p_opts.as_mut_ptr(),
+        pszConnection: PWSTR::null(),
+    };
+
+    // 局域网 LAN 代理设置
+    apply_option(&opts)?;
+    // 拨号连接/VPN 代理设置
+    let ras_conns = get_ras_connections()?;
+    for ras_conn in ras_conns.iter() {
+        let conn_wide = encode_wide(ras_conn);
+        opts.pszConnection = PWSTR::from_raw(conn_wide.as_ptr() as *mut u16);
+        apply_option(&opts)?;
+        log::debug!("unset RAS[{ras_conn}] proxy success");
+    }
+    set_proxy_enable(false)?;
+    notify_proxy_change()
+}
+
+/// set auto proxy
+///
+/// **对于包含中文字符的拨号连接或 VPN 连接，可能无法正确设置其代理，建议使用全英文重命名该连接名称**
+#[inline]
+fn set_auto_proxy(url: &str) -> Result<()> {
+    let s = encode_wide(url);
+    let mut p_opts = Vec::<INTERNET_PER_CONN_OPTIONW>::with_capacity(2);
+    p_opts.push(INTERNET_PER_CONN_OPTIONW {
+        dwOption: INTERNET_PER_CONN_FLAGS,
+        Value: INTERNET_PER_CONN_OPTIONW_0 {
+            dwValue: PROXY_TYPE_AUTO_DETECT | PROXY_TYPE_AUTO_PROXY_URL | PROXY_TYPE_DIRECT,
+        },
+    });
+    p_opts.push(INTERNET_PER_CONN_OPTIONW {
+        dwOption: INTERNET_PER_CONN_AUTOCONFIG_URL,
+        Value: INTERNET_PER_CONN_OPTIONW_0 {
+            pszValue: PWSTR::from_raw(s.as_ptr() as *mut u16),
+        },
+    });
+
+    let mut opts = INTERNET_PER_CONN_OPTION_LISTW {
+        dwSize: size_of::<INTERNET_PER_CONN_OPTION_LISTW>() as u32,
+        dwOptionCount: 2,
+        dwOptionError: 0,
+        pOptions: p_opts.as_mut_ptr(),
+        pszConnection: PWSTR::null(),
+    };
+
+    // 局域网 LAN 代理设置
+    apply_option(&opts)?;
+    // 拨号连接/VPN 代理设置
+    let ras_conns = get_ras_connections()?;
+    for ras_conn in ras_conns.iter() {
+        let conn_wide = encode_wide(ras_conn);
+        opts.pszConnection = PWSTR::from_raw(conn_wide.as_ptr() as *mut u16);
+        apply_option(&opts)?;
+        log::debug!("set RAS[{ras_conn}] auto proxy success");
+    }
+    set_proxy_enable(false)?;
+    notify_proxy_change()
+}
+
+/// set global proxy
+///
+/// **对于包含中文字符的拨号连接或 VPN 连接，可能无法正确设置其代理，建议使用全英文重命名该连接名称**
+#[inline]
+fn set_global_proxy(server: &str, bypass: &str) -> Result<()> {
+    let s = encode_wide(server);
+    let b = encode_wide(bypass);
+    let mut p_opts = Vec::<INTERNET_PER_CONN_OPTIONW>::with_capacity(3);
+    p_opts.push(INTERNET_PER_CONN_OPTIONW {
+        dwOption: INTERNET_PER_CONN_FLAGS,
+        Value: INTERNET_PER_CONN_OPTIONW_0 {
+            dwValue: PROXY_TYPE_PROXY | PROXY_TYPE_DIRECT,
+        },
+    });
+    p_opts.push(INTERNET_PER_CONN_OPTIONW {
+        dwOption: INTERNET_PER_CONN_PROXY_SERVER,
+        Value: INTERNET_PER_CONN_OPTIONW_0 {
+            pszValue: PWSTR::from_raw(s.as_ptr() as *mut u16),
+        },
+    });
+    p_opts.push(INTERNET_PER_CONN_OPTIONW {
+        dwOption: INTERNET_PER_CONN_PROXY_BYPASS,
+        Value: INTERNET_PER_CONN_OPTIONW_0 {
+            pszValue: PWSTR::from_raw(b.as_ptr() as *mut u16),
+        },
+    });
+
+    let mut opts = INTERNET_PER_CONN_OPTION_LISTW {
+        dwSize: size_of::<INTERNET_PER_CONN_OPTION_LISTW>() as u32,
+        dwOptionCount: 3,
+        dwOptionError: 0,
+        pOptions: p_opts.as_mut_ptr(),
+        pszConnection: PWSTR::null(),
+    };
+    // 局域网 LAN 代理设置
+    apply_option(&opts)?;
+    // 拨号连接/VPN 代理设置
+    let ras_conns = get_ras_connections()?;
+    for ras_conn in ras_conns.iter() {
+        let conn_wide = encode_wide(ras_conn);
+        opts.pszConnection = PWSTR::from_raw(conn_wide.as_ptr() as *mut u16);
+        apply_option(&opts)?;
+        log::debug!("set RAS[{ras_conn}] global proxy success");
+    }
+    set_proxy_enable(true)?;
+    notify_proxy_change()
+}
+
+#[inline]
+fn apply_option(options: &INTERNET_PER_CONN_OPTION_LISTW) -> Result<()> {
+    unsafe {
+        // setting options
+        let opts = options as *const INTERNET_PER_CONN_OPTION_LISTW as *const c_void;
+        InternetSetOptionW(
+            None,
+            INTERNET_OPTION_PER_CONNECTION_OPTION,
+            Some(opts),
+            size_of::<INTERNET_PER_CONN_OPTION_LISTW>() as u32,
+        )?;
+    }
+    Ok(())
+}
+
+#[inline]
+fn notify_proxy_change() -> Result<()> {
+    unsafe {
+        InternetSetOptionW(None, INTERNET_OPTION_PROXY_SETTINGS_CHANGED, None, 0)?;
+        // refreshing
+        InternetSetOptionW(None, INTERNET_OPTION_REFRESH, None, 0)?;
+    }
+    Ok(())
+}
+
+impl Sysproxy {
+    #[inline]
+    pub fn get_system_proxy() -> Result<Sysproxy> {
+        let hkcu = RegKey::predef(enums::HKEY_CURRENT_USER);
+        let cur_var = hkcu.open_subkey_with_flags(SUB_KEY, enums::KEY_QUERY_VALUE)?;
+        let enable = cur_var.get_value::<u32, _>("ProxyEnable").unwrap_or(0u32) == 1u32;
+        let proxy_server = cur_var
+            .get_value::<String, _>("ProxyServer")
+            .unwrap_or_default();
+
+        // 预设默认值
+        let mut host = String::new();
+        let mut port = 0u16;
+
+        if !proxy_server.is_empty() {
+            if proxy_server.contains('=') {
+                // 处理多协议格式: http=127.0.0.1:7890;https=127.0.0.1:7890
+                // 优先查找http代理
+                let http_proxy = find_http_proxy(&proxy_server);
+
+                if let Some(proxy) = http_proxy {
+                    let proxy_value = proxy.split('=').nth(1).unwrap_or("");
+                    parse_proxy_address(proxy_value, &mut host, &mut port);
+                } else {
+                    return Err(Error::NotSupport);
+                }
+            } else {
+                // 处理单一格式: 127.0.0.1:7890
+                parse_proxy_address(&proxy_server, &mut host, &mut port);
+            }
+        }
+
+        let bypass = cur_var.get_value("ProxyOverride").unwrap_or_default();
+
+        Ok(Sysproxy { enable, host, port, bypass })
+    }
+
+    #[inline]
+    pub fn set_system_proxy(&self) -> Result<()> {
+        match self.enable {
+            true => set_global_proxy(&format!("{}:{}", self.host, self.port), &self.bypass),
+            false => unset_proxy(),
+        }
+    }
+}
+
+impl Autoproxy {
+    #[inline]
+    pub fn get_auto_proxy() -> Result<Autoproxy> {
+        let hkcu = RegKey::predef(enums::HKEY_CURRENT_USER);
+        let cur_var = hkcu.open_subkey_with_flags(SUB_KEY, enums::KEY_QUERY_VALUE)?;
+        let url = cur_var.get_value::<String, _>("AutoConfigURL");
+        let enable = url.is_ok();
+        let url = url.unwrap_or_default();
+
+        Ok(Autoproxy { enable, url })
+    }
+
+    #[inline]
+    pub fn set_auto_proxy(&self) -> Result<()> {
+        match self.enable {
+            true => set_auto_proxy(&self.url),
+            false => unset_proxy(),
+        }
+    }
+}
+
+fn find_http_proxy(proxy_server: &str) -> Option<&str> {
+    proxy_server.split(';').find(|part| {
+        let candidate = part.trim().as_bytes();
+        candidate.len() >= 5 && candidate[..5].eq_ignore_ascii_case(b"http=")
+    })
+}
+
+/// 解析代理地址字符串为主机名和端口
+#[inline]
+fn parse_proxy_address(address: &str, host: &mut String, port: &mut u16) {
+    // 快速路径：host:port 或 [ipv6]:port，无需堆分配
+    if let Some((h, p)) = address.rsplit_once(':') {
+        if let Ok(port_num) = p.parse::<u16>() {
+            // 去除 IPv6 方括号: "[::1]" → "::1"
+            let clean = if h.starts_with('[') && h.ends_with(']') {
+                &h[1..h.len() - 1]
+            } else {
+                h
+            };
+            *host = clean.to_string();
+            *port = port_num;
+            return;
+        }
+    }
+
+    // 回退：URL 解析器处理无端口的主机名等边缘情况
+    if let Ok(url) = Url::parse(&format!("http://{}", address)) {
+        *host = url.host_str().unwrap_or("").to_string();
+        *port = url.port().unwrap_or(80);
+        return;
+    }
+
+    // 如果无法解析端口，默认使用主机名和标准HTTP端口
+    *host = address.to_string();
+    *port = 80;
+}
+
+/// refer: https://learn.microsoft.com/zh-cn/windows/win32/api/ras/nf-ras-rasenumentriesw
+///
+/// 获取所有远程访问服务 （包含拨号连接和 VPN 连接）
+fn get_ras_connections() -> Result<Vec<String>> {
+    log::debug!("start get RAS connections...");
+    let mut connections = Vec::new();
+
+    unsafe {
+        let mut buffer_size = 0u32;
+        let mut entry_count = 0u32;
+
+        let result_code = RasEnumEntriesW(
+            PCWSTR::null(),
+            PCWSTR::null(),
+            None,
+            &mut buffer_size,
+            &mut entry_count,
+        );
+
+        log::debug!("get allocate buffer size result code: {result_code}");
+
+        if result_code != ERROR_BUFFER_TOO_SMALL {
+            if entry_count >= 1 {
+                log::error!("The operation failed to acquire the buffer size");
+            } else {
+                log::debug!("There were no RAS entry names found");
+            }
+            return Ok(connections);
+        }
+
+        let entry_capacity = buffer_size as usize / std::mem::size_of::<RASENTRYNAMEW>();
+        if entry_capacity == 0 {
+            return Ok(connections);
+        }
+
+        // 使用 Vec 管理缓冲区内存，避免手动堆分配
+        let mut entries: Vec<RASENTRYNAMEW> = Vec::with_capacity(entry_capacity);
+        for _ in 0..entry_capacity {
+            entries.push(std::mem::zeroed());
+        }
+        // The first RASENTRYNAME structure in the array must contain the structure size
+        entries[0].dwSize = std::mem::size_of::<RASENTRYNAMEW>() as u32;
+
+        // 获取所有 RAS 列表
+        let result_code = RasEnumEntriesW(
+            PCWSTR::null(),
+            PCWSTR::null(),
+            Some(entries.as_mut_ptr()),
+            &mut buffer_size,
+            &mut entry_count,
+        );
+        // 如果函数成功，则返回值 ERROR_SUCCESS, 但是该 API 返回 u32, 参照对比 ERROR_SUCCESS 后，该值应该为 0
+        log::debug!("get RAS entries result code: {result_code}");
+
+        if result_code == 0 && entry_count > 0 {
+            for entry in entries.iter().take(entry_count as usize) {
+                let name_arr = entry.szEntryName;
+                // 去除宽字符多余的 0，以便更好的打印 RAS 名称
+                let len = name_arr.iter().position(|&x| x == 0).unwrap_or(0);
+                let name = String::from_utf16_lossy(&name_arr[..len]);
+                connections.push(name);
+            }
+            log::debug!("找到 {} 个拨号连接/VPN, {:?}", connections.len(), connections);
+        }
+    }
+
+    Ok(connections)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_http_proxy, parse_proxy_address};
+
+    fn parse(addr: &str) -> (String, u16) {
+        let mut host = String::new();
+        let mut port = 0u16;
+        parse_proxy_address(addr, &mut host, &mut port);
+        (host, port)
+    }
+
+    #[test]
+    fn test_ipv4_with_port() {
+        assert_eq!(parse("127.0.0.1:8080"), ("127.0.0.1".into(), 8080));
+    }
+
+    #[test]
+    fn test_hostname_with_port() {
+        assert_eq!(parse("proxy.example.com:3128"), ("proxy.example.com".into(), 3128));
+    }
+
+    #[test]
+    fn test_ipv6_bracketed_with_port() {
+        assert_eq!(parse("[::1]:1080"), ("::1".into(), 1080));
+    }
+
+    #[test]
+    fn test_hostname_only_defaults_port_80() {
+        assert_eq!(parse("proxy.example.com"), ("proxy.example.com".into(), 80));
+    }
+
+    #[test]
+    fn test_ipv4_only_defaults_port_80() {
+        assert_eq!(parse("192.168.1.1"), ("192.168.1.1".into(), 80));
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let (host, port) = parse("");
+        assert_eq!(port, 80);
+        assert!(host.is_empty());
+    }
+
+    #[test]
+    fn test_high_port() {
+        assert_eq!(parse("10.0.0.1:65535"), ("10.0.0.1".into(), 65535));
+    }
+
+    #[test]
+    fn socks_only_mapping_is_not_an_http_proxy() {
+        assert!(find_http_proxy("socks=127.0.0.1:1080").is_none());
+        assert_eq!(
+            find_http_proxy("socks=127.0.0.1:1080;HTTP=127.0.0.1:7890"),
+            Some("HTTP=127.0.0.1:7890")
+        );
+    }
+}

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -6,7 +6,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, "..");
 const workspaceCargo = path.join(rootDir, "Cargo.toml");
-const EXCLUDED_VERSION_MEMBERS = new Set(["crates/vendor/java-manager"]);
+const EXCLUDED_VERSION_MEMBERS = new Set(["crates/vendor/java-manager", "crates/vendor/sysproxy"]);
 
 // ---------------------------------------------------------------------------
 // 工具函数


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

添加一个与平台无关的提供者，通过 sysproxy-rs 读取当前系统代理配置的一次性快照。

新特性：
- 暴露 `current_system_proxy` 辅助函数和 `PlatformSystemProxyProvider`，用于从基础设施平台层获取系统代理快照。

增强：
- 为 Windows 和 Linux 集成基于 sysproxy 的系统代理发现机制，包括对绕过规则的保守转换，以及针对不受支持或无效配置的结构化错误报告。
- 从 platform 模块导出新的代理相关类型，并将 sysproxy 依赖接入 infra crate。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a platform-agnostic provider to read a one-time snapshot of the current system proxy configuration via sysproxy-rs.

New Features:
- Expose a `current_system_proxy` helper and `PlatformSystemProxyProvider` for retrieving system proxy snapshots from the infra platform layer.

Enhancements:
- Integrate sysproxy-based system proxy discovery for Windows and Linux, including conservative conversion of bypass rules and structured error reporting for unsupported or invalid configurations.
- Export new proxy-related types from the platform module and wire the sysproxy dependency into the infra crate.

</details>