### PR TITLE
feat(plugin): 增加插件安全能力契约

### DIFF
--- a/crates/core/src/app_plugin/catalog.rs
+++ b/crates/core/src/app_plugin/catalog.rs
@@ -1,0 +1,520 @@
+use super::{ApprovalMode, AuditMode, GrantKind, RiskLevel, ScopeKind};
+
+/// 由宿主编译进程序的不可变能力元数据。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityDescriptor {
+    pub id: &'static str,
+    pub risk: RiskLevel,
+    pub grant: GrantKind,
+    pub approval: ApprovalMode,
+    pub audit: AuditMode,
+    pub scope: Option<ScopeKind>,
+    pub declaration_required: bool,
+    pub max_calls_per_minute: Option<u32>,
+    pub enabled: bool,
+}
+
+macro_rules! capability {
+    ($id:literal, $risk:ident, $grant:ident, $approval:ident, $audit:ident, $scope:expr, $declared:expr, $rate:expr, $enabled:expr) => {
+        CapabilityDescriptor {
+            id: $id,
+            risk: RiskLevel::$risk,
+            grant: GrantKind::$grant,
+            approval: ApprovalMode::$approval,
+            audit: AuditMode::$audit,
+            scope: $scope,
+            declaration_required: $declared,
+            max_calls_per_minute: $rate,
+            enabled: $enabled,
+        }
+    };
+}
+
+const CAPABILITIES: &[CapabilityDescriptor] = &[
+    capability!("plugin.log.emit", L0, None, None, None, None, false, None, true),
+    capability!(
+        "market.search",
+        L0,
+        None,
+        None,
+        None,
+        Some(ScopeKind::MarketArtifact),
+        true,
+        Some(20),
+        true
+    ),
+    capability!(
+        "market.resource.read",
+        L0,
+        None,
+        None,
+        None,
+        Some(ScopeKind::MarketArtifact),
+        true,
+        Some(20),
+        true
+    ),
+    capability!(
+        "market.versions.read",
+        L0,
+        None,
+        None,
+        None,
+        Some(ScopeKind::MarketArtifact),
+        true,
+        Some(20),
+        true
+    ),
+    capability!(
+        "host.system.facts",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::AppGlobal),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "plugin.installed.list",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::AppGlobal),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.instance.list",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.status.read",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.metrics.read",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.metadata.read",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.config.redacted",
+        L1,
+        Persistent,
+        None,
+        Default,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.config.sensitive",
+        L2,
+        Persistent,
+        None,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(30),
+        true
+    ),
+    capability!(
+        "server.logs.read",
+        L2,
+        Persistent,
+        None,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(30),
+        true
+    ),
+    capability!(
+        "server.file.metadata",
+        L2,
+        Persistent,
+        None,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "server.file.read",
+        L2,
+        Persistent,
+        None,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(30),
+        true
+    ),
+    capability!(
+        "plugin.bundle.metadata",
+        L2,
+        Persistent,
+        None,
+        Required,
+        Some(ScopeKind::PluginBundle),
+        true,
+        Some(60),
+        true
+    ),
+    capability!(
+        "plugin.bundle.read",
+        L2,
+        Persistent,
+        None,
+        Required,
+        Some(ScopeKind::PluginBundle),
+        true,
+        Some(30),
+        true
+    ),
+    capability!(
+        "plugin.storage.read",
+        M1,
+        Session,
+        PerSession,
+        Required,
+        Some(ScopeKind::PluginData),
+        true,
+        Some(300),
+        true
+    ),
+    capability!(
+        "plugin.storage.write",
+        M1,
+        Session,
+        PerSession,
+        Required,
+        Some(ScopeKind::PluginData),
+        true,
+        Some(300),
+        true
+    ),
+    capability!(
+        "plugin.lifecycle.load",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::PluginBundle),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "plugin.lifecycle.enable",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::PluginBundle),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "plugin.lifecycle.disable",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::PluginBundle),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "plugin.lifecycle.unload",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::PluginBundle),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "server.lifecycle.start",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "server.lifecycle.stop",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "server.lifecycle.restart",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "server.console.send",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "server.config.patch",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::ServerInstance),
+        true,
+        Some(10),
+        true
+    ),
+    capability!(
+        "network.request.public_allowlisted",
+        M2,
+        Session,
+        PerCall,
+        Required,
+        Some(ScopeKind::NetworkOrigin),
+        true,
+        Some(20),
+        true
+    ),
+    capability!(
+        "fs.write",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "fs.delete",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "fs.rename",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "fs.move",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "fs.create",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "market.install",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::MarketArtifact),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "market.uninstall",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::MarketArtifact),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "market.update",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::MarketArtifact),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "security.secrets.read",
+        H2,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "security.permissions.change",
+        H2,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::AppGlobal),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "process.execute",
+        H2,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::ApprovedExecutable),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "network.request.authenticated_private",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::NetworkOrigin),
+        true,
+        None,
+        false
+    ),
+    capability!(
+        "network.request.unrestricted",
+        H1,
+        None,
+        PerCall,
+        Required,
+        Some(ScopeKind::NetworkOrigin),
+        true,
+        None,
+        false
+    ),
+];
+
+pub fn capabilities() -> &'static [CapabilityDescriptor] {
+    CAPABILITIES
+}
+
+pub fn capability(id: &str) -> Option<&'static CapabilityDescriptor> {
+    CAPABILITIES.iter().find(|descriptor| descriptor.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn catalog_ids_are_unique_and_valid() {
+        let mut ids = HashSet::new();
+        for descriptor in capabilities() {
+            assert!(ids.insert(descriptor.id), "duplicate capability {}", descriptor.id);
+            assert!(crate::app_plugin::CapabilityId::new(descriptor.id).is_ok());
+        }
+    }
+
+    #[test]
+    fn high_risk_capabilities_are_registered_but_disabled() {
+        for descriptor in capabilities()
+            .iter()
+            .filter(|item| item.risk >= RiskLevel::H1)
+        {
+            assert!(!descriptor.enabled, "{} must remain disabled", descriptor.id);
+        }
+    }
+}

--- a/crates/core/src/app_plugin/mod.rs
+++ b/crates/core/src/app_plugin/mod.rs
@@ -1,0 +1,16 @@
+//! 应用插件能力与安全决策的稳定领域契约。
+//!
+//! 本模块不执行插件代码、不访问持久化，也不依赖具体宿主。运行时负责构造调用，
+//! 应用层负责提供授权事实并执行最终能力。
+
+mod catalog;
+mod policy;
+mod types;
+
+pub use catalog::{capabilities, capability, CapabilityDescriptor};
+pub use policy::{evaluate, PolicyFacts};
+pub use types::{
+    ApprovalMode, AuditMode, CapabilityDispatchError, CapabilityDispatcher, CapabilityId,
+    CapabilityIdError, CapabilityInvocation, ExecutionPrincipal, GrantKind, PolicyDecision,
+    PolicyDenialReason, RiskLevel, ScopeBinding, ScopeBindingError, ScopeKind, TrustSource,
+};

--- a/crates/core/src/app_plugin/policy.rs
+++ b/crates/core/src/app_plugin/policy.rs
@@ -1,0 +1,156 @@
+use super::{
+    capability, ApprovalMode, GrantKind, PolicyDecision, PolicyDenialReason, RiskLevel,
+    ScopeBinding, TrustSource,
+};
+
+/// 应用层完成授权、审批查询后交给纯策略求值器的事实集合。
+#[derive(Debug, Clone, Copy)]
+pub struct PolicyFacts<'a> {
+    pub capability_id: &'a str,
+    pub scope: Option<&'a ScopeBinding>,
+    pub declared: bool,
+    pub trust_source: TrustSource,
+    pub grant: Option<GrantKind>,
+    pub session_approved: bool,
+    pub single_use_approved: bool,
+}
+
+/// 按固定顺序求值，确保高风险边界、作用域和信任检查不能被授权记录绕过。
+pub fn evaluate(facts: PolicyFacts<'_>) -> PolicyDecision {
+    let Some(descriptor) = capability(facts.capability_id) else {
+        return PolicyDecision::Deny(PolicyDenialReason::UnknownCapability);
+    };
+
+    if !descriptor.enabled || descriptor.risk >= RiskLevel::H1 {
+        return PolicyDecision::Deny(PolicyDenialReason::UnsupportedRiskBoundary);
+    }
+    if descriptor.declaration_required && !facts.declared {
+        return PolicyDecision::Deny(PolicyDenialReason::CapabilityNotDeclared);
+    }
+    match (descriptor.scope, facts.scope) {
+        (Some(_), None) => return PolicyDecision::Deny(PolicyDenialReason::ScopeRequired),
+        (Some(expected), Some(actual)) if expected != actual.kind => {
+            return PolicyDecision::Deny(PolicyDenialReason::ScopeNotAllowed);
+        }
+        (None, Some(_)) => return PolicyDecision::Deny(PolicyDenialReason::ScopeNotAllowed),
+        _ => {}
+    }
+    if descriptor.risk >= RiskLevel::L2 && !facts.trust_source.permits_scoped_capabilities() {
+        return PolicyDecision::Deny(PolicyDenialReason::ExplicitTrustRequired);
+    }
+    match descriptor.grant {
+        GrantKind::None => {}
+        GrantKind::Persistent if facts.grant != Some(GrantKind::Persistent) => {
+            return PolicyDecision::Deny(PolicyDenialReason::PersistentGrantRequired);
+        }
+        GrantKind::Session if facts.grant != Some(GrantKind::Session) => {
+            return PolicyDecision::Deny(PolicyDenialReason::SessionGrantRequired);
+        }
+        GrantKind::Persistent | GrantKind::Session => {}
+    }
+    match descriptor.approval {
+        ApprovalMode::None => {}
+        ApprovalMode::PerSession if !facts.session_approved => {
+            return PolicyDecision::Deny(PolicyDenialReason::SessionApprovalRequired);
+        }
+        ApprovalMode::PerCall if !facts.single_use_approved => {
+            return PolicyDecision::Deny(PolicyDenialReason::SingleUseApprovalRequired);
+        }
+        ApprovalMode::PerSession | ApprovalMode::PerCall => {}
+    }
+    PolicyDecision::Allow
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_plugin::ScopeKind;
+
+    fn scope(kind: ScopeKind) -> ScopeBinding {
+        ScopeBinding::new(kind, "alpha").unwrap()
+    }
+
+    #[test]
+    fn l0_log_is_available_without_manifest_declaration() {
+        assert_eq!(
+            evaluate(PolicyFacts {
+                capability_id: "plugin.log.emit",
+                scope: None,
+                declared: false,
+                trust_source: TrustSource::UntrustedLocal,
+                grant: None,
+                session_approved: false,
+                single_use_approved: false,
+            }),
+            PolicyDecision::Allow
+        );
+    }
+
+    #[test]
+    fn m2_requires_scope_trust_session_grant_and_single_use_approval() {
+        let server_scope = scope(ScopeKind::ServerInstance);
+        let base = PolicyFacts {
+            capability_id: "server.lifecycle.restart",
+            scope: Some(&server_scope),
+            declared: true,
+            trust_source: TrustSource::LocallyTrusted,
+            grant: Some(GrantKind::Session),
+            session_approved: false,
+            single_use_approved: true,
+        };
+        assert_eq!(evaluate(base), PolicyDecision::Allow);
+
+        assert_eq!(
+            evaluate(PolicyFacts {
+                trust_source: TrustSource::UntrustedLocal,
+                ..base
+            }),
+            PolicyDecision::Deny(PolicyDenialReason::ExplicitTrustRequired)
+        );
+        assert_eq!(
+            evaluate(PolicyFacts {
+                grant: Some(GrantKind::Persistent),
+                ..base
+            }),
+            PolicyDecision::Deny(PolicyDenialReason::SessionGrantRequired)
+        );
+        assert_eq!(
+            evaluate(PolicyFacts { single_use_approved: false, ..base }),
+            PolicyDecision::Deny(PolicyDenialReason::SingleUseApprovalRequired)
+        );
+    }
+
+    #[test]
+    fn disabled_high_risk_capability_cannot_be_overridden_by_facts() {
+        let scope = scope(ScopeKind::ApprovedExecutable);
+        assert_eq!(
+            evaluate(PolicyFacts {
+                capability_id: "process.execute",
+                scope: Some(&scope),
+                declared: true,
+                trust_source: TrustSource::BuiltIn,
+                grant: Some(GrantKind::Persistent),
+                session_approved: true,
+                single_use_approved: true,
+            }),
+            PolicyDecision::Deny(PolicyDenialReason::UnsupportedRiskBoundary)
+        );
+    }
+
+    #[test]
+    fn scope_kind_is_checked_before_grants() {
+        let wrong_scope = scope(ScopeKind::NetworkOrigin);
+        assert_eq!(
+            evaluate(PolicyFacts {
+                capability_id: "server.logs.read",
+                scope: Some(&wrong_scope),
+                declared: true,
+                trust_source: TrustSource::LocallyTrusted,
+                grant: Some(GrantKind::Persistent),
+                session_approved: true,
+                single_use_approved: true,
+            }),
+            PolicyDecision::Deny(PolicyDenialReason::ScopeNotAllowed)
+        );
+    }
+}

--- a/crates/core/src/app_plugin/types.rs
+++ b/crates/core/src/app_plugin/types.rs
@@ -1,0 +1,302 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// 插件能力的风险等级，顺序同时表示风险递增关系。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RiskLevel {
+    L0,
+    L1,
+    L2,
+    M1,
+    M2,
+    H1,
+    H2,
+}
+
+/// 能力授权的生命周期。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantKind {
+    None,
+    Session,
+    Persistent,
+}
+
+/// 用户确认要求。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalMode {
+    None,
+    PerSession,
+    PerCall,
+}
+
+/// 能力调用的审计要求。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditMode {
+    None,
+    Default,
+    Required,
+}
+
+/// 执行请求的身份主体。
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+pub enum ExecutionPrincipal {
+    Plugin(String),
+    AgentSession(String),
+    BuiltInHost,
+}
+
+impl ExecutionPrincipal {
+    /// 返回适合持久化和审计的稳定主体类型。
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Plugin(_) => "plugin",
+            Self::AgentSession(_) => "agent_session",
+            Self::BuiltInHost => "built_in_host",
+        }
+    }
+
+    /// 返回主体标识；内建宿主使用固定标识，避免空值分支扩散。
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Plugin(id) | Self::AgentSession(id) => id,
+            Self::BuiltInHost => "host",
+        }
+    }
+}
+
+/// 插件包来源的宿主判定结果，不能从 manifest 反序列化后直接信任。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustSource {
+    UntrustedLocal,
+    StandardMarketplace,
+    VerifiedPublisher,
+    LocallyTrusted,
+    BuiltIn,
+}
+
+impl TrustSource {
+    /// L2/M2 只接受宿主或用户明确建立的信任。
+    pub const fn permits_scoped_capabilities(self) -> bool {
+        matches!(self, Self::VerifiedPublisher | Self::LocallyTrusted | Self::BuiltIn)
+    }
+}
+
+/// 能力资源的作用域类型。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeKind {
+    PluginData,
+    PluginBundle,
+    ServerInstance,
+    AppGlobal,
+    NetworkOrigin,
+    UiExtension,
+    HostElement,
+    MarketArtifact,
+    ApprovedExecutable,
+}
+
+/// 经过结构化解析的具体作用域绑定。
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ScopeBinding {
+    pub kind: ScopeKind,
+    pub value: String,
+}
+
+impl ScopeBinding {
+    pub fn new(kind: ScopeKind, value: impl Into<String>) -> Result<Self, ScopeBindingError> {
+        let value = value.into();
+        if value.is_empty() || value.len() > 2048 {
+            return Err(ScopeBindingError::InvalidLength);
+        }
+        if value.chars().any(char::is_control) {
+            return Err(ScopeBindingError::ControlCharacter);
+        }
+        Ok(Self { kind, value })
+    }
+}
+
+/// 作用域绑定校验错误。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeBindingError {
+    InvalidLength,
+    ControlCharacter,
+}
+
+impl fmt::Display for ScopeBindingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLength => formatter.write_str("scope value must contain 1 to 2048 bytes"),
+            Self::ControlCharacter => {
+                formatter.write_str("scope value contains control characters")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ScopeBindingError {}
+
+/// 经过语法校验的点分能力标识。
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CapabilityId(String);
+
+impl CapabilityId {
+    pub fn new(value: impl Into<String>) -> Result<Self, CapabilityIdError> {
+        let value = value.into();
+        if !valid_capability_id(&value) {
+            return Err(CapabilityIdError);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CapabilityId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapabilityIdError;
+
+impl fmt::Display for CapabilityIdError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("capability ID must be lowercase ASCII dot-separated segments")
+    }
+}
+
+impl std::error::Error for CapabilityIdError {}
+
+fn valid_capability_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.split('.').all(|segment| {
+            !segment.is_empty()
+                && segment.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'_' | b'-')
+                })
+        })
+}
+
+/// 已完成 manifest 解析的能力调用。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityInvocation {
+    pub principal: ExecutionPrincipal,
+    pub trust_source: TrustSource,
+    pub capability: CapabilityId,
+    pub scope: Option<ScopeBinding>,
+    #[serde(default)]
+    pub payload: Value,
+    pub approval_token: Option<String>,
+    pub request_id: String,
+}
+
+/// 宿主能力执行端口，由应用层实现并注入插件运行时。
+#[async_trait]
+pub trait CapabilityDispatcher: Send + Sync {
+    async fn invoke(
+        &self,
+        invocation: CapabilityInvocation,
+    ) -> Result<Value, CapabilityDispatchError>;
+}
+
+/// 能力执行向运行时公开的稳定错误分类。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapabilityDispatchError {
+    Denied(PolicyDenialReason),
+    InvalidRequest(&'static str),
+    Unavailable(&'static str),
+    Failed(&'static str),
+}
+
+impl fmt::Display for CapabilityDispatchError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Denied(reason) => write!(formatter, "capability denied: {}", reason.as_str()),
+            Self::InvalidRequest(subject) => {
+                write!(formatter, "invalid capability request: {subject}")
+            }
+            Self::Unavailable(subject) => write!(formatter, "capability unavailable: {subject}"),
+            Self::Failed(subject) => write!(formatter, "capability failed: {subject}"),
+        }
+    }
+}
+
+impl std::error::Error for CapabilityDispatchError {}
+
+/// 策略拒绝的机器可读原因。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyDenialReason {
+    UnknownCapability,
+    CapabilityNotDeclared,
+    ScopeRequired,
+    ScopeNotAllowed,
+    UnsupportedRiskBoundary,
+    ExplicitTrustRequired,
+    PersistentGrantRequired,
+    SessionGrantRequired,
+    SessionApprovalRequired,
+    SingleUseApprovalRequired,
+}
+
+impl PolicyDenialReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnknownCapability => "unknown_capability",
+            Self::CapabilityNotDeclared => "capability_not_declared",
+            Self::ScopeRequired => "scope_required",
+            Self::ScopeNotAllowed => "scope_not_allowed",
+            Self::UnsupportedRiskBoundary => "unsupported_risk_boundary",
+            Self::ExplicitTrustRequired => "explicit_trust_required",
+            Self::PersistentGrantRequired => "persistent_grant_required",
+            Self::SessionGrantRequired => "session_grant_required",
+            Self::SessionApprovalRequired => "session_approval_required",
+            Self::SingleUseApprovalRequired => "single_use_approval_required",
+        }
+    }
+}
+
+/// 纯策略求值结果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyDecision {
+    Allow,
+    Deny(PolicyDenialReason),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_ids_require_lowercase_dot_segments() {
+        assert!(CapabilityId::new("server.status.read").is_ok());
+        for value in ["Server.status", "server..read", ".server", "server/read", ""] {
+            assert!(CapabilityId::new(value).is_err(), "{value} should be rejected");
+        }
+    }
+
+    #[test]
+    fn scope_values_reject_control_characters() {
+        assert!(ScopeBinding::new(ScopeKind::ServerInstance, "alpha").is_ok());
+        assert!(ScopeBinding::new(ScopeKind::ServerInstance, "alpha\nsecret").is_err());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+pub mod app_plugin;
 pub mod observability;
 pub mod process;
 


### PR DESCRIPTION
建立插件能力目录、风险分级和策略决策契约。

## Summary by Sourcery

引入一个核心应用插件安全契约，包括集中式能力目录和策略评估。

New Features:
- 为插件能力定义一个强类型契约，包括风险等级、授权（grants）、审批（approvals）、作用域（scopes）、主体（principals）、信任来源（trust sources）以及调用载荷（invocation payloads）。
- 添加面向宿主的能力调度器（capability dispatcher）以及用于执行插件能力的结构化错误模型。
- 提供一个静态的内置插件能力目录，包含风险分类、作用域绑定、速率限制以及启用标志（enablement flags）。
- 实现一个纯策略评估器，根据目录元数据、信任来源、授权、审批和作用域来决定能力访问。

Enhancements:
- 从核心 crate 中暴露新的 `app_plugin` 模块，作为插件安全和能力管理的稳定接口面。

Tests:
- 添加单元测试，用于验证能力 ID 语法以及作用域绑定约束。
- 添加测试，确保目录完整性（唯一 ID 和被禁用的高风险能力），并验证在不同信任、授权、审批和作用域组合下的策略评估行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a core application plugin security contract with a centralized capability catalog and policy evaluation.

New Features:
- Define a typed contract for plugin capabilities, including risk levels, grants, approvals, scopes, principals, trust sources, and invocation payloads.
- Add a host-facing capability dispatcher and structured error model for executing plugin capabilities.
- Provide a static catalog of built-in plugin capabilities with risk classification, scope binding, rate limits, and enablement flags.
- Implement a pure policy evaluator that decides capability access based on catalog metadata, trust source, grants, approvals, and scope.

Enhancements:
- Expose the new app_plugin module from the core crate as the stable surface for plugin security and capability management.

Tests:
- Add unit tests to validate capability ID syntax and scope binding constraints.
- Add tests to ensure catalog integrity (unique IDs and disabled high-risk capabilities) and to verify policy evaluation behavior across trust, grant, approval, and scope combinations.

</details>