### PR TITLE
refactor(plugin): 迁移能力声明运行时

### DIFF
--- a/crates/extra/src/app_plugin/engine/mod.rs
+++ b/crates/extra/src/app_plugin/engine/mod.rs
@@ -12,7 +12,7 @@ use std::{
 
 use mlua::{HookTriggers, Lua, LuaOptions, StdLib, Table, Value, VmState};
 
-use crate::app_plugin::{AppPluginError, PluginManifest, PluginPermission};
+use crate::app_plugin::{AppPluginError, PluginManifest};
 use crate::observability;
 
 use self::storage::PluginStorage;
@@ -136,7 +136,9 @@ impl PluginEngine {
         data_dir: &Path,
     ) -> Result<(), AppPluginError> {
         let table = self.lua.create_table().map_err(engine_error)?;
-        let permitted = manifest.permissions.contains(&PluginPermission::Storage);
+        let permitted = manifest.capabilities.iter().any(|capability| {
+            matches!(capability.id.as_str(), "plugin.storage.read" | "plugin.storage.write")
+        });
         let storage = PluginStorage::new(&self.plugin_id, data_dir);
 
         let context = storage.clone();
@@ -194,7 +196,10 @@ impl PluginEngine {
 
     fn install_log(&self, sl: &Table, manifest: &PluginManifest) -> Result<(), AppPluginError> {
         let table = self.lua.create_table().map_err(engine_error)?;
-        let permitted = manifest.permissions.contains(&PluginPermission::Log);
+        let permitted = manifest
+            .capabilities
+            .iter()
+            .any(|capability| capability.id == "plugin.log.emit");
         for (name, level) in
             [("debug", "debug"), ("info", "info"), ("warn", "warn"), ("error", "error")]
         {
@@ -316,14 +321,14 @@ mod tests {
             .join(format!("sealantern-extra-engine-{label}-{}-{nonce}", std::process::id()))
     }
 
-    fn manifest(permissions: Vec<PluginPermission>) -> PluginManifest {
+    fn manifest(capabilities: Vec<crate::app_plugin::PluginCapability>) -> PluginManifest {
         PluginManifest {
             api_version: 2,
             id: "example.plugin".to_string(),
             name: "Example".to_string(),
             version: "1.0.0".to_string(),
             main: "main.lua".to_string(),
-            permissions,
+            capabilities,
         }
     }
 
@@ -361,7 +366,7 @@ mod tests {
         let root = test_dir("storage");
         fs::create_dir_all(&root).expect("plugin directory should be created");
         let engine = PluginEngine::new(
-            &manifest(vec![PluginPermission::Storage]),
+            &manifest(vec![crate::app_plugin::PluginCapability::new("plugin.storage.read")]),
             &root,
             &root.join("data"),
         )
@@ -466,7 +471,7 @@ mod tests {
         let root = test_dir("storage-quota");
         fs::create_dir_all(&root).expect("plugin directory should be created");
         let engine = PluginEngine::new(
-            &manifest(vec![PluginPermission::Storage]),
+            &manifest(vec![crate::app_plugin::PluginCapability::new("plugin.storage.write")]),
             &root,
             &root.join("data"),
         )

--- a/crates/extra/src/app_plugin/loader.rs
+++ b/crates/extra/src/app_plugin/loader.rs
@@ -4,7 +4,8 @@ use std::path::{Component, Path, PathBuf};
 use serde_json::{Map, Value};
 
 use super::error::AppPluginError;
-use super::manifest::{PluginManifest, PluginPermission, PLUGIN_API_VERSION};
+use super::manifest::{PluginManifest, PLUGIN_API_VERSION};
+use sealantern_core::app_plugin::capability;
 
 /// Locates and validates plugin manifests without evaluating plugin code.
 pub struct PluginLoader;
@@ -80,7 +81,12 @@ impl PluginLoader {
             })?;
 
         Self::validate_api_version(object, &manifest_path)?;
-        Self::validate_permission_names(object, &manifest_path)?;
+        if object.contains_key("permissions") {
+            return Err(AppPluginError::InvalidManifest {
+                message: "field 'permissions' was removed in plugin API v2; use structured 'capabilities' declarations".to_string(),
+            });
+        }
+        Self::validate_capability_declarations(object, &manifest_path)?;
 
         let manifest: PluginManifest =
             serde_json::from_value(value).map_err(|error| AppPluginError::MalformedManifest {
@@ -151,32 +157,30 @@ impl PluginLoader {
         }
     }
 
-    fn validate_permission_names(
+    fn validate_capability_declarations(
         object: &Map<String, Value>,
         manifest_path: &Path,
     ) -> Result<(), AppPluginError> {
-        let Some(value) = object.get("permissions") else {
+        let Some(value) = object.get("capabilities") else {
             return Ok(());
         };
-        let permissions = value
+        let capabilities = value
             .as_array()
             .ok_or_else(|| AppPluginError::MalformedManifest {
                 path: manifest_path.to_path_buf(),
-                message: "field 'permissions' must be an array of strings".to_string(),
+                message: "field 'capabilities' must be an array of objects".to_string(),
             })?;
 
-        for permission in permissions {
-            let permission =
-                permission
-                    .as_str()
-                    .ok_or_else(|| AppPluginError::MalformedManifest {
-                        path: manifest_path.to_path_buf(),
-                        message: "field 'permissions' must be an array of strings".to_string(),
-                    })?;
-            if PluginPermission::parse(permission).is_none() {
-                return Err(AppPluginError::UnsupportedCapability {
-                    capability: permission.to_string(),
-                });
+        for capability_declaration in capabilities {
+            let id = capability_declaration
+                .get("id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| AppPluginError::MalformedManifest {
+                    path: manifest_path.to_path_buf(),
+                    message: "each capability declaration requires a string 'id'".to_string(),
+                })?;
+            if capability(id).is_none() {
+                return Err(AppPluginError::UnsupportedCapability { capability: id.to_string() });
             }
         }
         Ok(())
@@ -229,7 +233,7 @@ mod tests {
 
     use super::PluginLoader;
     use crate::app_plugin::error::AppPluginError;
-    use crate::app_plugin::manifest::{PluginPermission, PLUGIN_API_VERSION};
+    use crate::app_plugin::manifest::PLUGIN_API_VERSION;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 
@@ -271,7 +275,7 @@ mod tests {
                 "name": "Example Plugin",
                 "version": "1.0.0",
                 "main": "main.lua",
-                "permissions": ["log", "storage"]
+                "capabilities": [{{"id": "plugin.log.emit"}}, {{"id": "plugin.storage.read"}}]
             }}"#
         )
     }
@@ -300,7 +304,7 @@ mod tests {
                 "name": "",
                 "version": "",
                 "main": "../old.lua",
-                "permissions": ["network"]
+                "capabilities": [{"id": "network.request"}]
             }"#,
         );
 
@@ -336,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_permission_has_a_capability_error() {
+    fn unknown_capability_has_a_capability_error() {
         let root = TestDirectory::new();
         let plugin_dir = write_manifest(
             root.path(),
@@ -347,7 +351,7 @@ mod tests {
                 "name": "Example Plugin",
                 "version": "1.0.0",
                 "main": "main.lua",
-                "permissions": ["network"]
+                "capabilities": [{"id": "network.request"}]
             }"#,
         );
 
@@ -356,7 +360,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            AppPluginError::UnsupportedCapability { ref capability } if capability == "network"
+            AppPluginError::UnsupportedCapability { ref capability } if capability == "network.request"
         ));
     }
 
@@ -381,12 +385,35 @@ mod tests {
     }
 
     #[test]
-    fn valid_manifest_returns_typed_permissions() {
+    fn valid_manifest_returns_typed_capabilities() {
         let root = TestDirectory::new();
         let plugin_dir = write_manifest(root.path(), "valid", &valid_manifest());
 
         let manifest = PluginLoader::load_manifest(&plugin_dir).expect("manifest should load");
 
-        assert_eq!(manifest.permissions, vec![PluginPermission::Log, PluginPermission::Storage]);
+        assert_eq!(manifest.capabilities.len(), 2);
+        assert_eq!(manifest.capabilities[0].id, "plugin.log.emit");
+    }
+
+    #[test]
+    fn legacy_permissions_field_has_actionable_migration_error() {
+        let root = TestDirectory::new();
+        let plugin_dir = write_manifest(
+            root.path(),
+            "legacy-permissions",
+            r#"{
+                "apiVersion": 2,
+                "id": "example.plugin",
+                "name": "Example Plugin",
+                "version": "1.0.0",
+                "main": "main.lua",
+                "permissions": ["log"]
+            }"#,
+        );
+
+        let error = PluginLoader::load_manifest(&plugin_dir)
+            .expect_err("legacy permissions must be rejected");
+
+        assert!(error.to_string().contains("use structured 'capabilities'"));
     }
 }

--- a/crates/extra/src/app_plugin/manager.rs
+++ b/crates/extra/src/app_plugin/manager.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use super::engine::{Lifecycle, PluginEngine};
 use super::{AppPluginError, PluginLoader, PluginManifest};
@@ -53,6 +54,73 @@ struct ManagedPlugin {
 pub struct PluginManager {
     config: PluginManagerConfig,
     plugins: HashMap<String, ManagedPlugin>,
+}
+
+/// 在 Tokio 的阻塞线程池中调度 Lua 生命周期，避免阻塞异步宿主线程。
+#[derive(Clone)]
+pub struct AsyncPluginManager {
+    inner: Arc<Mutex<PluginManager>>,
+}
+
+impl AsyncPluginManager {
+    pub fn new(config: PluginManagerConfig) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PluginManager::new(config))),
+        }
+    }
+
+    pub async fn discover(&self) -> Result<Vec<PathBuf>, AppPluginError> {
+        self.run(|manager| manager.discover()).await
+    }
+
+    pub async fn load(&self, plugin_dir: impl Into<PathBuf>) -> Result<PluginInfo, AppPluginError> {
+        let plugin_dir = plugin_dir.into();
+        self.run(move |manager| manager.load(&plugin_dir)).await
+    }
+
+    pub async fn enable(&self, plugin_id: impl Into<String>) -> Result<(), AppPluginError> {
+        let plugin_id = plugin_id.into();
+        self.run(move |manager| manager.enable(&plugin_id)).await
+    }
+
+    pub async fn disable(&self, plugin_id: impl Into<String>) -> Result<(), AppPluginError> {
+        let plugin_id = plugin_id.into();
+        self.run(move |manager| manager.disable(&plugin_id)).await
+    }
+
+    pub async fn unload(&self, plugin_id: impl Into<String>) -> Result<(), AppPluginError> {
+        let plugin_id = plugin_id.into();
+        self.run(move |manager| manager.unload(&plugin_id)).await
+    }
+
+    pub async fn plugin(
+        &self,
+        plugin_id: impl Into<String>,
+    ) -> Result<Option<PluginInfo>, AppPluginError> {
+        let plugin_id = plugin_id.into();
+        self.run(move |manager| Ok(manager.plugin(&plugin_id)))
+            .await
+    }
+
+    pub async fn plugins(&self) -> Result<Vec<PluginInfo>, AppPluginError> {
+        self.run(|manager| Ok(manager.plugins())).await
+    }
+
+    async fn run<T, F>(&self, operation: F) -> Result<T, AppPluginError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut PluginManager) -> Result<T, AppPluginError> + Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            let mut manager = inner.lock().map_err(|_| {
+                AppPluginError::Engine("plugin manager lock is poisoned".to_string())
+            })?;
+            operation(&mut manager)
+        })
+        .await
+        .map_err(|error| AppPluginError::Engine(format!("plugin runtime task failed: {error}")))?
+    }
 }
 
 impl PluginManager {
@@ -292,20 +360,20 @@ mod tests {
     }
 
     fn write_plugin(root: &Path, api_version: u32, script: &str) -> PathBuf {
-        write_plugin_with_permissions(root, api_version, script, &[])
+        write_plugin_with_capabilities(root, api_version, script, &[])
     }
 
-    fn write_plugin_with_permissions(
+    fn write_plugin_with_capabilities(
         root: &Path,
         api_version: u32,
         script: &str,
-        permissions: &[&str],
+        capabilities: &[&str],
     ) -> PathBuf {
         let plugin_dir = root.join("example.plugin");
         fs::create_dir_all(&plugin_dir).expect("plugin directory should be created");
-        let permissions = permissions
+        let capabilities = capabilities
             .iter()
-            .map(|permission| format!(r#""{permission}""#))
+            .map(|capability| format!(r#"{{"id":"{capability}"}}"#))
             .collect::<Vec<_>>()
             .join(", ");
         fs::write(
@@ -317,7 +385,7 @@ mod tests {
                     "name": "Example",
                     "version": "1.0.0",
                     "main": "main.lua",
-                    "permissions": [{permissions}]
+                    "capabilities": [{capabilities}]
                 }}"#
             ),
         )
@@ -408,7 +476,7 @@ mod tests {
     fn load_failure_runs_unload_cleanup() {
         let root = test_root("load-cleanup");
         let data_dir = root.join("data");
-        let plugin_dir = write_plugin_with_permissions(
+        let plugin_dir = write_plugin_with_capabilities(
             &root,
             2,
             r#"
@@ -420,7 +488,7 @@ mod tests {
                     sl.storage.set("unloaded", true)
                 end
             "#,
-            &["storage"],
+            &["plugin.storage.write"],
         );
         let mut manager = PluginManager::new(PluginManagerConfig::new(&root, &data_dir));
 
@@ -440,7 +508,7 @@ mod tests {
     fn enable_failure_runs_disable_then_unload_cleanup() {
         let root = test_root("enable-cleanup");
         let data_dir = root.join("data");
-        let plugin_dir = write_plugin_with_permissions(
+        let plugin_dir = write_plugin_with_capabilities(
             &root,
             2,
             r#"
@@ -455,7 +523,7 @@ mod tests {
                     sl.storage.set("unloaded", true)
                 end
             "#,
-            &["storage"],
+            &["plugin.storage.write"],
         );
         let mut manager = PluginManager::new(PluginManagerConfig::new(&root, &data_dir));
 
@@ -484,6 +552,37 @@ mod tests {
             PluginManager::new(PluginManagerConfig::new(&plugins_root, root.join("data")));
 
         assert!(matches!(manager.load(&plugin_dir), Err(AppPluginError::InvalidPath { .. })));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn async_manager_runs_lifecycle_off_the_async_host_api() {
+        let root = test_root("async-lifecycle");
+        let plugin_dir = write_plugin(
+            &root,
+            2,
+            r#"
+                function on_load() end
+                function on_enable() end
+            "#,
+        );
+        let manager = AsyncPluginManager::new(PluginManagerConfig::new(&root, root.join("data")));
+
+        manager.load(&plugin_dir).await.expect("plugin should load");
+        manager
+            .enable("example.plugin")
+            .await
+            .expect("plugin should enable");
+        assert_eq!(
+            manager
+                .plugin("example.plugin")
+                .await
+                .expect("plugin lookup should work")
+                .expect("plugin should remain loaded")
+                .state,
+            PluginState::Enabled
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/extra/src/app_plugin/manifest.rs
+++ b/crates/extra/src/app_plugin/manifest.rs
@@ -1,24 +1,22 @@
 use serde::{Deserialize, Serialize};
 
+use sealantern_core::app_plugin::ScopeBinding;
+
 /// The only plugin API revision accepted by the first app-plugin engine.
 pub const PLUGIN_API_VERSION: u32 = 2;
 
-/// A capability exposed by the first app-plugin API revision.
+/// API v2 manifest 中声明的一项能力。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum PluginPermission {
-    Log,
-    Storage,
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PluginCapability {
+    pub id: String,
+    #[serde(default)]
+    pub scope: Option<ScopeBinding>,
 }
 
-impl PluginPermission {
-    /// Parses a capability name from the manifest's JSON representation.
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "log" => Some(Self::Log),
-            "storage" => Some(Self::Storage),
-            _ => None,
-        }
+impl PluginCapability {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), scope: None }
     }
 }
 
@@ -32,12 +30,12 @@ pub struct PluginManifest {
     pub version: String,
     pub main: String,
     #[serde(default)]
-    pub permissions: Vec<PluginPermission>,
+    pub capabilities: Vec<PluginCapability>,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{PluginManifest, PluginPermission, PLUGIN_API_VERSION};
+    use super::{PluginCapability, PluginManifest, PLUGIN_API_VERSION};
 
     #[test]
     fn v2_manifest_uses_camel_case_api_version() {
@@ -48,13 +46,19 @@ mod tests {
                 "name": "Example Plugin",
                 "version": "1.0.0",
                 "main": "main.lua",
-                "permissions": ["log", "storage"]
+                "capabilities": [{"id": "plugin.log.emit"}, {"id": "plugin.storage.read"}]
             }"#,
         )
         .expect("v2 manifest should deserialize");
 
         assert_eq!(manifest.api_version, PLUGIN_API_VERSION);
-        assert_eq!(manifest.permissions, vec![PluginPermission::Log, PluginPermission::Storage]);
+        assert_eq!(
+            manifest.capabilities,
+            vec![
+                PluginCapability::new("plugin.log.emit"),
+                PluginCapability::new("plugin.storage.read"),
+            ]
+        );
     }
 
     #[test]
@@ -75,7 +79,10 @@ mod tests {
     }
 
     #[test]
-    fn permission_enum_rejects_unknown_values() {
-        assert!(serde_json::from_str::<PluginPermission>(r#""network""#).is_err());
+    fn capability_rejects_unknown_fields() {
+        assert!(serde_json::from_str::<PluginCapability>(
+            r#"{"id":"plugin.log.emit","legacy":true}"#
+        )
+        .is_err());
     }
 }

--- a/crates/extra/src/app_plugin/mod.rs
+++ b/crates/extra/src/app_plugin/mod.rs
@@ -15,5 +15,7 @@ pub mod manifest;
 
 pub use error::AppPluginError;
 pub use loader::PluginLoader;
-pub use manager::{PluginInfo, PluginManager, PluginManagerConfig, PluginState};
-pub use manifest::{PluginManifest, PluginPermission, PLUGIN_API_VERSION};
+pub use manager::{
+    AsyncPluginManager, PluginInfo, PluginManager, PluginManagerConfig, PluginState,
+};
+pub use manifest::{PluginCapability, PluginManifest, PLUGIN_API_VERSION};


### PR DESCRIPTION
插件清单迁移为能力声明，并提供异步运行时包装。

## Summary by Sourcery

引入一个对异步操作安全的插件管理器封装，并将插件清单从传统的权限字符串迁移到结构化的能力声明。

New Features:
- 添加 `AsyncPluginManager`，在阻塞的 Tokio 线程池上运行插件生命周期操作，从而将 Lua 执行与异步宿主线程解耦。

Enhancements:
- 优化插件引擎的能力检查机制，对存储和日志功能使用结构化的能力 ID，而不是基于枚举的权限。
- 在公共的 `app_plugin` API 表面暴露 `AsyncPluginManager` 和 `PluginCapability`。

Tests:
- 更新并扩展插件加载器、清单、引擎和管理器的测试，用于覆盖基于能力的清单、异步管理器行为，以及传统权限字段的迁移错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an async-safe plugin manager wrapper and migrate plugin manifests from legacy permission strings to structured capability declarations.

New Features:
- Add AsyncPluginManager to run plugin lifecycle operations on a blocking Tokio thread pool, decoupling Lua execution from the async host thread.

Enhancements:
- Refine plugin engine capability checks to use structured capability IDs for storage and logging features instead of enum-based permissions.
- Expose AsyncPluginManager and PluginCapability in the public app_plugin API surface.

Tests:
- Update and extend plugin loader, manifest, engine, and manager tests to cover capability-based manifests, async manager behavior, and migration errors for legacy permissions fields.

</details>