### PR TITLE
feat(plugin): 增加插件应用服务

### DIFF
--- a/application/src/plugin/mod.rs
+++ b/application/src/plugin/mod.rs
@@ -1,5 +1,7 @@
 //! 插件授权状态、审批令牌和审计记录。
 
 mod policy;
+mod service;
 
 pub use policy::{AuditEntry, PluginPolicyError, PluginPolicyStore, SessionApproval, SessionGrant};
+pub use service::{CorePluginService, PluginService, PluginServiceError};

--- a/application/src/plugin/service.rs
+++ b/application/src/plugin/service.rs
@@ -1,0 +1,179 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sealantern_extra::app_plugin::{AsyncPluginManager, PluginInfo, PluginManagerConfig};
+use sealantern_infra::platform::get_app_data_dir;
+
+use super::{PluginPolicyError, PluginPolicyStore};
+
+/// 应用插件生命周期的宿主入口。
+#[async_trait]
+pub trait PluginService: Send + Sync {
+    async fn discover(&self) -> Result<Vec<PathBuf>, PluginServiceError>;
+    async fn load(&self, plugin_dir: &Path) -> Result<PluginInfo, PluginServiceError>;
+    async fn enable(&self, plugin_id: &str) -> Result<(), PluginServiceError>;
+    async fn disable(&self, plugin_id: &str) -> Result<(), PluginServiceError>;
+    async fn unload(&self, plugin_id: &str) -> Result<(), PluginServiceError>;
+    async fn plugins(&self) -> Result<Vec<PluginInfo>, PluginServiceError>;
+}
+
+/// 应用插件服务的可恢复错误。
+#[derive(Debug)]
+pub enum PluginServiceError {
+    Runtime(sealantern_extra::app_plugin::AppPluginError),
+    Policy(PluginPolicyError),
+    Initialization(String),
+}
+
+impl std::fmt::Display for PluginServiceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Runtime(error) => write!(formatter, "plugin runtime failed: {error}"),
+            Self::Policy(error) => write!(formatter, "plugin policy state failed: {error}"),
+            Self::Initialization(error) => {
+                write!(formatter, "plugin service initialization failed: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PluginServiceError {}
+
+impl From<sealantern_extra::app_plugin::AppPluginError> for PluginServiceError {
+    fn from(error: sealantern_extra::app_plugin::AppPluginError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+impl From<PluginPolicyError> for PluginServiceError {
+    fn from(error: PluginPolicyError) -> Self {
+        Self::Policy(error)
+    }
+}
+
+/// 将插件运行时和安全策略状态组合为单一宿主服务。
+pub struct CorePluginService {
+    runtime: AsyncPluginManager,
+    policy: Arc<PluginPolicyStore>,
+}
+
+impl CorePluginService {
+    /// 使用应用数据目录中的插件目录、私有数据和策略数据库构造服务。
+    pub async fn open_default() -> Result<Self, PluginServiceError> {
+        let root = get_app_data_dir().join("plugins");
+        Self::open(&root, root.join("data"), root.join("plugin-state.sqlite")).await
+    }
+
+    /// 使用明确的目录构造服务，适用于宿主配置和测试注入。
+    pub async fn open(
+        plugins_dir: impl Into<PathBuf>,
+        data_dir: impl Into<PathBuf>,
+        state_path: impl Into<PathBuf>,
+    ) -> Result<Self, PluginServiceError> {
+        Ok(Self {
+            runtime: AsyncPluginManager::new(PluginManagerConfig::new(plugins_dir, data_dir)),
+            policy: Arc::new(PluginPolicyStore::open(state_path).await?),
+        })
+    }
+
+    pub fn policy(&self) -> &Arc<PluginPolicyStore> {
+        &self.policy
+    }
+}
+
+#[async_trait]
+impl PluginService for CorePluginService {
+    async fn discover(&self) -> Result<Vec<PathBuf>, PluginServiceError> {
+        self.runtime.discover().await.map_err(Into::into)
+    }
+
+    async fn load(&self, plugin_dir: &Path) -> Result<PluginInfo, PluginServiceError> {
+        let info = self.runtime.load(plugin_dir).await?;
+        self.policy.set_enabled(&info.manifest.id, false).await?;
+        Ok(info)
+    }
+
+    async fn enable(&self, plugin_id: &str) -> Result<(), PluginServiceError> {
+        self.runtime.enable(plugin_id).await?;
+        if let Err(error) = self.policy.set_enabled(plugin_id, true).await {
+            let _ = self.runtime.disable(plugin_id).await;
+            tracing::error!(
+                target: "sealantern.application.plugin",
+                plugin_id,
+                error = %error,
+                "plugin enable state could not be persisted"
+            );
+            return Err(error.into());
+        }
+        Ok(())
+    }
+
+    async fn disable(&self, plugin_id: &str) -> Result<(), PluginServiceError> {
+        self.runtime.disable(plugin_id).await?;
+        self.policy.set_enabled(plugin_id, false).await?;
+        Ok(())
+    }
+
+    async fn unload(&self, plugin_id: &str) -> Result<(), PluginServiceError> {
+        self.runtime.unload(plugin_id).await?;
+        self.policy.set_enabled(plugin_id, false).await?;
+        Ok(())
+    }
+
+    async fn plugins(&self) -> Result<Vec<PluginInfo>, PluginServiceError> {
+        self.runtime.plugins().await.map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn manifest() -> &'static str {
+        r#"{
+            "apiVersion": 2,
+            "id": "example.plugin",
+            "name": "Example Plugin",
+            "version": "1.0.0",
+            "main": "main.lua",
+            "capabilities": []
+        }"#
+    }
+
+    #[tokio::test]
+    async fn service_keeps_persisted_enabled_state_in_sync_with_lifecycle() {
+        let root = tempfile::tempdir().expect("temporary root should be created");
+        let plugin_dir = root.path().join("plugins").join("example.plugin");
+        fs::create_dir_all(&plugin_dir).expect("plugin directory should be created");
+        fs::write(plugin_dir.join("manifest.json"), manifest())
+            .expect("manifest should be written");
+        fs::write(
+            plugin_dir.join("main.lua"),
+            "function on_load() end function on_enable() end function on_disable() end",
+        )
+        .expect("script should be written");
+        let service = CorePluginService::open(
+            root.path().join("plugins"),
+            root.path().join("data"),
+            root.path().join("plugin-state.sqlite"),
+        )
+        .await
+        .expect("service should open");
+
+        service.load(&plugin_dir).await.expect("plugin should load");
+        assert!(!service.policy().is_enabled("example.plugin").await.unwrap());
+        service
+            .enable("example.plugin")
+            .await
+            .expect("plugin should enable");
+        assert!(service.policy().is_enabled("example.plugin").await.unwrap());
+        service
+            .disable("example.plugin")
+            .await
+            .expect("plugin should disable");
+        assert!(!service.policy().is_enabled("example.plugin").await.unwrap());
+    }
+}

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::error::InstanceError;
+use crate::plugin::{CorePluginService, PluginServiceError};
 use crate::service::{
     CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreServerService,
     CoreSettingsService, CoreSystemService, CoreUpdateCheckService, ProxyMonitoringService,
@@ -49,6 +50,8 @@ pub struct AppServicesInner {
     pub system: Arc<CoreSystemService>,
     /// 应用更新检查服务。
     pub update: Arc<CoreUpdateCheckService>,
+    /// 惰性初始化的应用插件服务。
+    plugin: tokio::sync::OnceCell<Arc<CorePluginService>>,
 }
 
 /// 进程级全局容器。惰性初始化，可替换。
@@ -75,6 +78,7 @@ impl AppServices {
                 proxy_monitoring: Arc::new(ProxyMonitoringService::new()),
                 system: Arc::new(CoreSystemService),
                 update: Arc::new(CoreUpdateCheckService::new()),
+                plugin: tokio::sync::OnceCell::new(),
             }),
         }
     }
@@ -232,5 +236,23 @@ impl AppServices {
     /// 便捷访问入口：一步拿到更新检查服务的共享句柄（惰性初始化 + 可替换）。
     pub async fn update_service() -> Result<Arc<CoreUpdateCheckService>, InstanceError> {
         Ok(Self::get().await?.update().clone())
+    }
+
+    /// 获取应用插件服务；首次调用才打开策略数据库，避免阻塞常规启动路径。
+    pub async fn plugin(&self) -> Result<&Arc<CorePluginService>, PluginServiceError> {
+        self.inner
+            .plugin
+            .get_or_try_init(|| async { CorePluginService::open_default().await.map(Arc::new) })
+            .await
+    }
+
+    /// 便捷访问入口：一步拿到应用插件服务的共享句柄。
+    pub async fn plugin_service() -> Result<Arc<CorePluginService>, PluginServiceError> {
+        Ok(Self::get()
+            .await
+            .map_err(|error| PluginServiceError::Initialization(error.to_string()))?
+            .plugin()
+            .await?
+            .clone())
     }
 }


### PR DESCRIPTION
装配插件运行时、策略状态和应用服务入口。

## Summary by Sourcery

引入一个延迟初始化的应用插件服务，用于托管插件的生命周期与策略状态。

New Features:
- 添加一个插件服务接口及核心实现，将插件运行时管理与持久化的策略状态结合起来。
- 暴露应用级访问器，以便获取指向核心插件服务的共享句柄，并在首次使用时进行初始化。

Enhancements:
- 使插件策略持久化与运行时生命周期保持一致，从而在启用/禁用操作时使存储状态保持同步。

Tests:
- 添加集成风格的测试，确保插件服务在加载、启用和禁用操作中，始终保持持久化的启用状态一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a lazily-initialized application plugin service that hosts plugin lifecycle and policy state.

New Features:
- Add a plugin service interface and core implementation combining plugin runtime management with persisted policy state.
- Expose application-level accessors to obtain shared handles to the core plugin service, initialized on first use.

Enhancements:
- Align plugin policy persistence with runtime lifecycle so enable/disable operations keep stored state in sync.

Tests:
- Add integration-style tests ensuring the plugin service keeps the persisted enabled state consistent across load, enable, and disable operations.

</details>