### PR TITLE
feat(plugin): 增加受策略保护的市场能力

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5223,6 +5223,7 @@ dependencies = [
  "sealantern-extra",
  "sealantern-infra",
  "sealantern-interface",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -14,6 +14,8 @@ tracing = "0.1"
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 sealantern-core = { path = "../crates/core" }
 sealantern-interface = { path = "../crates/interface" }
 sealantern-extra = { path = "../crates/extra" }

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/lib.rs"
 async-trait = "0.1.91"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "sync", "fs", "time"] }
 tracing = "0.1"
-serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/application/src/plugin/dispatcher.rs
+++ b/application/src/plugin/dispatcher.rs
@@ -1,0 +1,365 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use sealantern_core::app_plugin::{
+    capability, CapabilityDispatchError, CapabilityDispatcher, CapabilityInvocation,
+    ExecutionPrincipal, PolicyDecision, ScopeKind,
+};
+use sealantern_extra::market::{
+    Fetcher, MarketError, MarketSource, ResourceInfo, SearchResult, Version,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use super::PluginPolicyStore;
+
+const MARKET_PAGE_SIZE_LIMIT: u32 = 100;
+const RATE_WINDOW: Duration = Duration::from_secs(60);
+
+/// 只读市场能力的宿主端口。
+#[async_trait]
+pub trait MarketGateway: Send + Sync {
+    async fn search(
+        &self,
+        source: MarketSource,
+        query: &str,
+        page: u32,
+        page_size: u32,
+    ) -> Result<SearchResult, MarketError>;
+    async fn resource(&self, source: MarketSource, id: &str) -> Result<ResourceInfo, MarketError>;
+    async fn versions(&self, source: MarketSource, id: &str) -> Result<Vec<Version>, MarketError>;
+}
+
+/// 基于既有市场抓取器的只读网关。
+pub struct DefaultMarketGateway {
+    modrinth: Arc<dyn Fetcher>,
+    spiget: Arc<dyn Fetcher>,
+}
+
+impl DefaultMarketGateway {
+    pub fn new() -> Result<Self, String> {
+        let client = sealantern_infra::net::NetClient::from_config(&Default::default())
+            .map_err(|error| error.to_string())?;
+        Ok(Self {
+            modrinth: Arc::new(sealantern_extra::market::ModrinthFetcher::new(client.clone())),
+            spiget: Arc::new(sealantern_extra::market::SpigetFetcher::new(client)),
+        })
+    }
+
+    fn fetcher(&self, source: MarketSource) -> &Arc<dyn Fetcher> {
+        match source {
+            MarketSource::Modrinth => &self.modrinth,
+            MarketSource::Spiget => &self.spiget,
+        }
+    }
+}
+
+#[async_trait]
+impl MarketGateway for DefaultMarketGateway {
+    async fn search(
+        &self,
+        source: MarketSource,
+        query: &str,
+        page: u32,
+        page_size: u32,
+    ) -> Result<SearchResult, MarketError> {
+        self.fetcher(source).search(query, page, page_size).await
+    }
+
+    async fn resource(&self, source: MarketSource, id: &str) -> Result<ResourceInfo, MarketError> {
+        self.fetcher(source).get_resource(id).await
+    }
+
+    async fn versions(&self, source: MarketSource, id: &str) -> Result<Vec<Version>, MarketError> {
+        self.fetcher(source).get_resource_versions(id).await
+    }
+}
+
+/// 所有 Lua 宿主能力调用的策略、限流与执行边界。
+pub struct CoreCapabilityDispatcher {
+    policy: Arc<PluginPolicyStore>,
+    market: Arc<dyn MarketGateway>,
+    calls: Mutex<HashMap<(String, String), VecDeque<Instant>>>,
+}
+
+impl CoreCapabilityDispatcher {
+    pub fn new(policy: Arc<PluginPolicyStore>, market: Arc<dyn MarketGateway>) -> Self {
+        Self {
+            policy,
+            market,
+            calls: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn check_rate_limit(
+        &self,
+        plugin_id: &str,
+        capability_id: &str,
+    ) -> Result<(), CapabilityDispatchError> {
+        let Some(limit) =
+            capability(capability_id).and_then(|descriptor| descriptor.max_calls_per_minute)
+        else {
+            return Ok(());
+        };
+        let now = Instant::now();
+        let mut calls = self.calls.lock().await;
+        let entries = calls
+            .entry((plugin_id.to_owned(), capability_id.to_owned()))
+            .or_default();
+        while entries
+            .front()
+            .is_some_and(|timestamp| now.duration_since(*timestamp) >= RATE_WINDOW)
+        {
+            entries.pop_front();
+        }
+        if entries.len() >= limit as usize {
+            return Err(CapabilityDispatchError::Unavailable("capability rate limit exceeded"));
+        }
+        entries.push_back(now);
+        Ok(())
+    }
+
+    async fn dispatch_market(
+        &self,
+        capability_id: &str,
+        scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+        payload: &Value,
+    ) -> Result<Value, CapabilityDispatchError> {
+        match capability_id {
+            "market.search" => {
+                let request: MarketSearchRequest = serde_json::from_value(payload.clone())
+                    .map_err(|_| {
+                        CapabilityDispatchError::InvalidRequest("market search payload")
+                    })?;
+                let page = request.page.unwrap_or(1);
+                let page_size = request.page_size.unwrap_or(20);
+                if request.query.trim().is_empty()
+                    || page == 0
+                    || page_size == 0
+                    || page_size > MARKET_PAGE_SIZE_LIMIT
+                {
+                    return Err(CapabilityDispatchError::InvalidRequest(
+                        "market search pagination",
+                    ));
+                }
+                let result = self
+                    .market
+                    .search(request.source, &request.query, page, page_size)
+                    .await
+                    .map_err(|error| market_error("search", error))?;
+                serde_json::to_value(result)
+                    .map_err(|_| CapabilityDispatchError::Failed("market response encoding"))
+            }
+            "market.resource.read" => {
+                let (source, id) = market_scope(scope)?;
+                let result = self
+                    .market
+                    .resource(source, id)
+                    .await
+                    .map_err(|error| market_error("resource", error))?;
+                serde_json::to_value(result)
+                    .map_err(|_| CapabilityDispatchError::Failed("market response encoding"))
+            }
+            "market.versions.read" => {
+                let (source, id) = market_scope(scope)?;
+                let result = self
+                    .market
+                    .versions(source, id)
+                    .await
+                    .map_err(|error| market_error("versions", error))?;
+                serde_json::to_value(result)
+                    .map_err(|_| CapabilityDispatchError::Failed("market response encoding"))
+            }
+            _ => Err(CapabilityDispatchError::Unavailable(
+                "capability implementation is not available",
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl CapabilityDispatcher for CoreCapabilityDispatcher {
+    async fn invoke(
+        &self,
+        invocation: CapabilityInvocation,
+    ) -> Result<Value, CapabilityDispatchError> {
+        let ExecutionPrincipal::Plugin(plugin_id) = &invocation.principal else {
+            return Err(CapabilityDispatchError::InvalidRequest("plugin principal"));
+        };
+        let decision = self
+            .policy
+            .evaluate(
+                None,
+                plugin_id,
+                invocation.capability.as_str(),
+                invocation.scope.as_ref(),
+                invocation.declared,
+                false,
+            )
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    target: "sealantern.application.plugin",
+                    plugin_id,
+                    capability_id = invocation.capability.as_str(),
+                    error = %error,
+                    "plugin capability policy evaluation failed"
+                );
+                CapabilityDispatchError::Failed("plugin policy evaluation")
+            })?;
+        if let PolicyDecision::Deny(reason) = decision {
+            return Err(CapabilityDispatchError::Denied(reason));
+        }
+        self.check_rate_limit(plugin_id, invocation.capability.as_str())
+            .await?;
+        self.dispatch_market(
+            invocation.capability.as_str(),
+            invocation.scope.as_ref(),
+            &invocation.payload,
+        )
+        .await
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct MarketSearchRequest {
+    source: MarketSource,
+    query: String,
+    page: Option<u32>,
+    page_size: Option<u32>,
+}
+
+fn market_scope(
+    scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+) -> Result<(MarketSource, &str), CapabilityDispatchError> {
+    let scope = scope.ok_or(CapabilityDispatchError::InvalidRequest("market scope"))?;
+    if scope.kind != ScopeKind::MarketArtifact {
+        return Err(CapabilityDispatchError::InvalidRequest("market scope kind"));
+    }
+    let (source, id) = scope
+        .value
+        .split_once(':')
+        .ok_or(CapabilityDispatchError::InvalidRequest("market scope value"))?;
+    let source = match source {
+        "modrinth" => MarketSource::Modrinth,
+        "spiget" => MarketSource::Spiget,
+        _ => return Err(CapabilityDispatchError::InvalidRequest("market source")),
+    };
+    (!id.is_empty())
+        .then_some((source, id))
+        .ok_or(CapabilityDispatchError::InvalidRequest("market resource id"))
+}
+
+fn market_error(operation: &'static str, error: MarketError) -> CapabilityDispatchError {
+    tracing::warn!(
+        target: "sealantern.application.plugin",
+        operation,
+        error = %error,
+        "plugin market capability failed"
+    );
+    match error {
+        MarketError::NotFound { .. } => {
+            CapabilityDispatchError::Unavailable("market resource not found")
+        }
+        _ => CapabilityDispatchError::Failed("market request failed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use sealantern_core::app_plugin::{CapabilityId, ScopeBinding, TrustSource};
+
+    struct FakeMarket {
+        searches: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl MarketGateway for FakeMarket {
+        async fn search(
+            &self,
+            _source: MarketSource,
+            _query: &str,
+            page: u32,
+            page_size: u32,
+        ) -> Result<SearchResult, MarketError> {
+            self.searches.fetch_add(1, Ordering::Relaxed);
+            Ok(SearchResult {
+                resources: vec![],
+                total: 0,
+                offset: u64::from(page - 1) * u64::from(page_size),
+                limit: u64::from(page_size),
+            })
+        }
+
+        async fn resource(&self, _: MarketSource, _: &str) -> Result<ResourceInfo, MarketError> {
+            Err(MarketError::NotFound { resource: "test".to_string() })
+        }
+
+        async fn versions(&self, _: MarketSource, _: &str) -> Result<Vec<Version>, MarketError> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn market_search_requires_enabled_plugin_and_declared_capability() {
+        let root = tempfile::tempdir().unwrap();
+        let policy = Arc::new(
+            PluginPolicyStore::open(root.path().join("state.sqlite"))
+                .await
+                .unwrap(),
+        );
+        policy.set_enabled("example.plugin", true).await.unwrap();
+        let market = Arc::new(FakeMarket { searches: AtomicUsize::new(0) });
+        let dispatcher = CoreCapabilityDispatcher::new(policy, market.clone());
+        let invocation = CapabilityInvocation {
+            principal: ExecutionPrincipal::Plugin("example.plugin".to_string()),
+            trust_source: TrustSource::UntrustedLocal,
+            capability: CapabilityId::new("market.search").unwrap(),
+            scope: None,
+            declared: true,
+            payload: serde_json::json!({"source":"Modrinth", "query":"paper", "page":1, "pageSize":20}),
+            approval_token: None,
+            request_id: "request-1".to_string(),
+        };
+        assert!(dispatcher.invoke(invocation).await.is_ok());
+        assert_eq!(market.searches.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn market_resource_requires_matching_artifact_scope() {
+        let root = tempfile::tempdir().unwrap();
+        let policy = Arc::new(
+            PluginPolicyStore::open(root.path().join("state.sqlite"))
+                .await
+                .unwrap(),
+        );
+        policy.set_enabled("example.plugin", true).await.unwrap();
+        let dispatcher = CoreCapabilityDispatcher::new(
+            policy,
+            Arc::new(FakeMarket { searches: AtomicUsize::new(0) }),
+        );
+        let invocation = CapabilityInvocation {
+            principal: ExecutionPrincipal::Plugin("example.plugin".to_string()),
+            trust_source: TrustSource::UntrustedLocal,
+            capability: CapabilityId::new("market.resource.read").unwrap(),
+            scope: Some(ScopeBinding::new(ScopeKind::MarketArtifact, "modrinth:paper").unwrap()),
+            declared: false,
+            payload: Value::Null,
+            approval_token: None,
+            request_id: "request-2".to_string(),
+        };
+        assert!(matches!(
+            dispatcher.invoke(invocation).await,
+            Err(CapabilityDispatchError::Denied(
+                sealantern_core::app_plugin::PolicyDenialReason::CapabilityNotDeclared
+            ))
+        ));
+    }
+}

--- a/application/src/plugin/mod.rs
+++ b/application/src/plugin/mod.rs
@@ -1,7 +1,9 @@
 //! 插件授权状态、审批令牌和审计记录。
 
+mod dispatcher;
 mod policy;
 mod service;
 
+pub use dispatcher::{CoreCapabilityDispatcher, DefaultMarketGateway, MarketGateway};
 pub use policy::{AuditEntry, PluginPolicyError, PluginPolicyStore, SessionApproval, SessionGrant};
 pub use service::{CorePluginService, PluginService, PluginServiceError};

--- a/application/src/plugin/policy.rs
+++ b/application/src/plugin/policy.rs
@@ -381,6 +381,9 @@ impl PluginPolicyStore {
         declared: bool,
         single_use_approved: bool,
     ) -> Result<PolicyDecision, PluginPolicyError> {
+        if !self.is_enabled(plugin_id).await? {
+            return Ok(PolicyDecision::Deny(PolicyDenialReason::PluginNotEnabled));
+        }
         let trust = self.trust_source(plugin_id).await?;
         let persistent = self
             .has_persistent_grant(plugin_id, capability_id, scope)

--- a/application/src/plugin/service.rs
+++ b/application/src/plugin/service.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use sealantern_extra::app_plugin::{AsyncPluginManager, PluginInfo, PluginManagerConfig};
 use sealantern_infra::platform::get_app_data_dir;
 
-use super::{PluginPolicyError, PluginPolicyStore};
+use super::{CoreCapabilityDispatcher, DefaultMarketGateway, PluginPolicyError, PluginPolicyStore};
 
 /// 应用插件生命周期的宿主入口。
 #[async_trait]
@@ -71,9 +71,15 @@ impl CorePluginService {
         data_dir: impl Into<PathBuf>,
         state_path: impl Into<PathBuf>,
     ) -> Result<Self, PluginServiceError> {
+        let policy = Arc::new(PluginPolicyStore::open(state_path).await?);
+        let market =
+            Arc::new(DefaultMarketGateway::new().map_err(PluginServiceError::Initialization)?);
+        let dispatcher = Arc::new(CoreCapabilityDispatcher::new(policy.clone(), market));
         Ok(Self {
-            runtime: AsyncPluginManager::new(PluginManagerConfig::new(plugins_dir, data_dir)),
-            policy: Arc::new(PluginPolicyStore::open(state_path).await?),
+            runtime: AsyncPluginManager::new(
+                PluginManagerConfig::new(plugins_dir, data_dir).with_dispatcher(dispatcher),
+            ),
+            policy,
         })
     }
 

--- a/crates/core/src/app_plugin/catalog.rs
+++ b/crates/core/src/app_plugin/catalog.rs
@@ -32,17 +32,7 @@ macro_rules! capability {
 
 const CAPABILITIES: &[CapabilityDescriptor] = &[
     capability!("plugin.log.emit", L0, None, None, None, None, false, None, true),
-    capability!(
-        "market.search",
-        L0,
-        None,
-        None,
-        None,
-        Some(ScopeKind::MarketArtifact),
-        true,
-        Some(20),
-        true
-    ),
+    capability!("market.search", L0, None, None, None, None, true, Some(20), true),
     capability!(
         "market.resource.read",
         L0,

--- a/crates/core/src/app_plugin/types.rs
+++ b/crates/core/src/app_plugin/types.rs
@@ -203,6 +203,7 @@ pub struct CapabilityInvocation {
     pub trust_source: TrustSource,
     pub capability: CapabilityId,
     pub scope: Option<ScopeBinding>,
+    pub declared: bool,
     #[serde(default)]
     pub payload: Value,
     pub approval_token: Option<String>,
@@ -246,6 +247,7 @@ impl std::error::Error for CapabilityDispatchError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PolicyDenialReason {
+    PluginNotEnabled,
     UnknownCapability,
     CapabilityNotDeclared,
     ScopeRequired,
@@ -261,6 +263,7 @@ pub enum PolicyDenialReason {
 impl PolicyDenialReason {
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::PluginNotEnabled => "plugin_not_enabled",
             Self::UnknownCapability => "unknown_capability",
             Self::CapabilityNotDeclared => "capability_not_declared",
             Self::ScopeRequired => "scope_required",

--- a/crates/extra/src/app_plugin/engine/mod.rs
+++ b/crates/extra/src/app_plugin/engine/mod.rs
@@ -11,11 +11,16 @@ use std::{
 };
 
 use mlua::{HookTriggers, Lua, LuaOptions, StdLib, Table, Value, VmState};
+use sealantern_core::app_plugin::{
+    CapabilityDispatchError, CapabilityDispatcher, CapabilityId, CapabilityInvocation,
+    ExecutionPrincipal, ScopeBinding, ScopeKind, TrustSource,
+};
+use serde_json::Value as JsonValue;
 
 use crate::app_plugin::{AppPluginError, PluginManifest};
 use crate::observability;
 
-use self::storage::PluginStorage;
+use self::storage::{json_to_lua, lua_to_json, PluginStorage};
 
 const EXECUTION_HOOK_INTERVAL: u32 = 1_000;
 const MAX_EXECUTION_INSTRUCTIONS: u64 = 1_000_000;
@@ -28,6 +33,9 @@ pub struct PluginEngine {
     plugin_dir: PathBuf,
     main: String,
     execution_budget: Arc<Mutex<Option<u64>>>,
+    dispatcher: Option<Arc<dyn CapabilityDispatcher>>,
+    runtime_handle: Option<tokio::runtime::Handle>,
+    trust_source: TrustSource,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -50,10 +58,21 @@ impl Lifecycle {
 }
 
 impl PluginEngine {
+    #[cfg(test)]
     pub(crate) fn new(
         manifest: &PluginManifest,
         plugin_dir: &Path,
         data_dir: &Path,
+    ) -> Result<Self, AppPluginError> {
+        Self::new_with_dispatcher(manifest, plugin_dir, data_dir, None, TrustSource::UntrustedLocal)
+    }
+
+    pub(crate) fn new_with_dispatcher(
+        manifest: &PluginManifest,
+        plugin_dir: &Path,
+        data_dir: &Path,
+        dispatcher: Option<Arc<dyn CapabilityDispatcher>>,
+        trust_source: TrustSource,
     ) -> Result<Self, AppPluginError> {
         // Hook 只作用于当前 Lua 线程，因此首版不暴露 coroutine 以避免绕过执行预算。
         let lua = Lua::new_with(
@@ -87,6 +106,9 @@ impl PluginEngine {
             plugin_dir: plugin_dir.to_path_buf(),
             main: manifest.main.clone(),
             execution_budget,
+            dispatcher,
+            runtime_handle: tokio::runtime::Handle::try_current().ok(),
+            trust_source,
         };
         engine.install_sl(manifest, data_dir)?;
         Ok(engine)
@@ -126,6 +148,7 @@ impl PluginEngine {
         let sl = self.lua.create_table().map_err(engine_error)?;
         self.install_storage(&sl, manifest, data_dir)?;
         self.install_log(&sl, manifest)?;
+        self.install_capabilities(&sl, manifest)?;
         self.lua.globals().set("sl", sl).map_err(engine_error)
     }
 
@@ -220,6 +243,62 @@ impl PluginEngine {
         sl.set("log", table).map_err(engine_error)
     }
 
+    fn install_capabilities(
+        &self,
+        sl: &Table,
+        manifest: &PluginManifest,
+    ) -> Result<(), AppPluginError> {
+        let table = self.lua.create_table().map_err(engine_error)?;
+        let Some(dispatcher) = self.dispatcher.as_ref().cloned() else {
+            sl.set("capabilities", table).map_err(engine_error)?;
+            return Ok(());
+        };
+        let Some(handle) = self.runtime_handle.as_ref().cloned() else {
+            return Err(AppPluginError::Engine(
+                "plugin capability dispatcher requires a Tokio runtime".to_string(),
+            ));
+        };
+        let plugin_id = self.plugin_id.clone();
+        let trust_source = self.trust_source;
+        let declarations = manifest.capabilities.clone();
+        table
+            .set(
+                "invoke",
+                self.lua
+                    .create_function(
+                        move |lua, (id, payload, scope): (String, Option<Value>, Option<Value>)| {
+                            let capability = CapabilityId::new(&id)
+                                .map_err(|error| mlua::Error::runtime(error.to_string()))?;
+                            let scope = parse_scope(scope)?;
+                            let declared = declarations.iter().any(|declaration| {
+                                declaration.id == id && declaration.scope.as_ref() == scope.as_ref()
+                            });
+                            let payload = payload
+                                .map(|value| lua_to_json(&value, 0))
+                                .transpose()?
+                                .unwrap_or(JsonValue::Null);
+                            let invocation = CapabilityInvocation {
+                                principal: ExecutionPrincipal::Plugin(plugin_id.clone()),
+                                trust_source,
+                                capability,
+                                scope,
+                                declared,
+                                payload,
+                                approval_token: None,
+                                request_id: uuid::Uuid::new_v4().to_string(),
+                            };
+                            let response = handle
+                                .block_on(dispatcher.invoke(invocation))
+                                .map_err(dispatcher_error)?;
+                            json_to_lua(lua, &response, 0)
+                        },
+                    )
+                    .map_err(engine_error)?,
+            )
+            .map_err(engine_error)?;
+        sl.set("capabilities", table).map_err(engine_error)
+    }
+
     fn run_with_execution_budget<T>(
         &self,
         operation: &'static str,
@@ -249,6 +328,33 @@ impl PluginEngine {
             }
         })
     }
+}
+
+fn parse_scope(value: Option<Value>) -> mlua::Result<Option<ScopeBinding>> {
+    let Some(Value::Table(table)) = value else {
+        return Ok(None);
+    };
+    let kind: String = table.get("kind")?;
+    let value: String = table.get("value")?;
+    let kind = match kind.as_str() {
+        "plugin_data" => ScopeKind::PluginData,
+        "plugin_bundle" => ScopeKind::PluginBundle,
+        "server_instance" => ScopeKind::ServerInstance,
+        "app_global" => ScopeKind::AppGlobal,
+        "network_origin" => ScopeKind::NetworkOrigin,
+        "ui_extension" => ScopeKind::UiExtension,
+        "host_element" => ScopeKind::HostElement,
+        "market_artifact" => ScopeKind::MarketArtifact,
+        "approved_executable" => ScopeKind::ApprovedExecutable,
+        _ => return Err(mlua::Error::runtime("plugin capability scope kind is invalid")),
+    };
+    ScopeBinding::new(kind, value)
+        .map(Some)
+        .map_err(|error| mlua::Error::runtime(error.to_string()))
+}
+
+fn dispatcher_error(error: CapabilityDispatchError) -> mlua::Error {
+    mlua::Error::runtime(error.to_string())
 }
 
 fn resolve_main_path(plugin_dir: &Path, main: &str) -> Result<PathBuf, AppPluginError> {

--- a/crates/extra/src/app_plugin/engine/storage.rs
+++ b/crates/extra/src/app_plugin/engine/storage.rs
@@ -160,7 +160,7 @@ fn storage_limit(subject: &str, limit: usize) -> mlua::Error {
     mlua::Error::runtime(format!("plugin storage {subject} exceeds the {limit}-byte limit"))
 }
 
-fn lua_to_json(value: &Value, depth: usize) -> mlua::Result<JsonValue> {
+pub(super) fn lua_to_json(value: &Value, depth: usize) -> mlua::Result<JsonValue> {
     if depth >= MAX_DEPTH {
         return Err(mlua::Error::runtime("storage value exceeds the 64-level nesting limit"));
     }
@@ -247,7 +247,7 @@ fn lua_to_json(value: &Value, depth: usize) -> mlua::Result<JsonValue> {
     }
 }
 
-fn json_to_lua(lua: &Lua, value: &JsonValue, depth: usize) -> mlua::Result<Value> {
+pub(super) fn json_to_lua(lua: &Lua, value: &JsonValue, depth: usize) -> mlua::Result<Value> {
     if depth >= MAX_DEPTH {
         return Err(mlua::Error::runtime("stored value exceeds the 64-level nesting limit"));
     }

--- a/crates/extra/src/app_plugin/manager.rs
+++ b/crates/extra/src/app_plugin/manager.rs
@@ -5,14 +5,19 @@ use std::sync::{Arc, Mutex};
 use super::engine::{Lifecycle, PluginEngine};
 use super::{AppPluginError, PluginLoader, PluginManifest};
 use crate::observability;
+use sealantern_core::app_plugin::{CapabilityDispatcher, TrustSource};
 
 /// 插件管理器需要的宿主无关目录配置。
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PluginManagerConfig {
     /// 已安装插件的根目录。
     pub plugins_dir: PathBuf,
     /// 插件私有持久化数据的根目录。
     pub data_dir: PathBuf,
+    /// 注入后的唯一宿主能力调度器。
+    pub dispatcher: Option<Arc<dyn CapabilityDispatcher>>,
+    /// 宿主已验证的插件来源信任级别。
+    pub trust_source: TrustSource,
 }
 
 impl PluginManagerConfig {
@@ -21,7 +26,19 @@ impl PluginManagerConfig {
         Self {
             plugins_dir: plugins_dir.into(),
             data_dir: data_dir.into(),
+            dispatcher: None,
+            trust_source: TrustSource::UntrustedLocal,
         }
+    }
+
+    pub fn with_dispatcher(mut self, dispatcher: Arc<dyn CapabilityDispatcher>) -> Self {
+        self.dispatcher = Some(dispatcher);
+        self
+    }
+
+    pub fn with_trust_source(mut self, trust_source: TrustSource) -> Self {
+        self.trust_source = trust_source;
+        self
     }
 }
 
@@ -167,7 +184,13 @@ impl PluginManager {
 
         let data_dir = self.config.data_dir.join(&manifest.id);
 
-        let engine = PluginEngine::new(&manifest, &plugin_dir, &data_dir)?;
+        let engine = PluginEngine::new_with_dispatcher(
+            &manifest,
+            &plugin_dir,
+            &data_dir,
+            self.config.dispatcher.clone(),
+            self.config.trust_source,
+        )?;
         if let Err(error) = engine.load() {
             observability::app_plugin_load_failed(&manifest.id, "entry_script", error.kind());
             return Err(error);

--- a/crates/extra/src/market/fetcher/traits.rs
+++ b/crates/extra/src/market/fetcher/traits.rs
@@ -14,7 +14,7 @@ use crate::market::models::{MarketResource, ResourceInfo, SearchResult, Version}
 /// 每个平台（如 Spigot、Modrinth）需要实现该 trait，以提供标准化的
 /// 搜索、项目信息查询、版本列表获取以及资源下载能力。
 #[async_trait]
-pub trait Fetcher {
+pub trait Fetcher: Send + Sync {
     /// 根据关键词搜索资源，支持分页。
     ///
     /// # Parameters


### PR DESCRIPTION
通过统一策略调度提供市场搜索、详情和版本读取。

## Summary by Sourcery

将能力分发器集成到插件引擎和管理器中，以提供受策略保护的主机能力，主要用于只读的市场访问。

新功能：
- 暴露 Lua 层面的 `sl.capabilities.invoke` 入口点，使插件可以通过统一的分发器调用主机能力。
- 引入核心能力分发器和市场网关，以支持受策略控制的市场搜索、资源和版本读取操作。

增强：
- 扩展插件策略评估逻辑，当插件未启用时拒绝其使用能力，并跟踪能力是否在清单中声明。
- 放宽 `market.search` 能力在目录中的定义，移除对制品作用域的强制要求。
- 在存储与能力调用处理之间共享 JSON<->Lua 转换工具，并在使用分发器时要求存在 Tokio 运行时。
- 为市场能力调用添加限流和基础请求校验。

构建：
- 在应用 crate 中添加 serde 和 serde_json 依赖，用于处理能力负载。

测试：
- 添加单元测试，覆盖市场搜索调用的前置条件，以及对市场资源读取声明要求的验证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a capability dispatcher into the plugin engine and manager to provide policy-protected host capabilities, primarily for read-only market access.

New Features:
- Expose a Lua-level `sl.capabilities.invoke` entry point for plugins to call host capabilities via a unified dispatcher.
- Introduce a core capability dispatcher and market gateway to support policy-controlled market search, resource, and version read operations.

Enhancements:
- Extend plugin policy evaluation to deny capability use when the plugin is not enabled and track whether a capability was declared in the manifest.
- Relax the catalog definition of the `market.search` capability to remove the mandatory artifact scope requirement.
- Share JSON<->Lua conversion utilities between storage and capability invocation handling, and require a Tokio runtime when using the dispatcher.
- Add rate limiting and basic request validation for market capability invocations.

Build:
- Add serde and serde_json dependencies to the application crate for capability payload handling.

Tests:
- Add unit tests covering market search invocation requirements and declaration enforcement for market resource reads.

</details>