### PR TITLE
feat(plugin): 增加受策略保护的宿主读取

### DIFF
--- a/application/src/plugin/dispatcher.rs
+++ b/application/src/plugin/dispatcher.rs
@@ -10,6 +10,7 @@ use sealantern_core::app_plugin::{
 use sealantern_extra::market::{
     Fetcher, MarketError, MarketSource, ResourceInfo, SearchResult, Version,
 };
+use sealantern_interface::{InstanceService, ServerService, SystemService};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::Mutex;
@@ -82,6 +83,7 @@ impl MarketGateway for DefaultMarketGateway {
 pub struct CoreCapabilityDispatcher {
     policy: Arc<PluginPolicyStore>,
     market: Arc<dyn MarketGateway>,
+    host: Option<Arc<dyn PluginReadHost>>,
     calls: Mutex<HashMap<(String, String), VecDeque<Instant>>>,
 }
 
@@ -90,8 +92,14 @@ impl CoreCapabilityDispatcher {
         Self {
             policy,
             market,
+            host: None,
             calls: Mutex::new(HashMap::new()),
         }
+    }
+
+    pub fn with_read_host(mut self, host: Arc<dyn PluginReadHost>) -> Self {
+        self.host = Some(host);
+        self
     }
 
     async fn check_rate_limit(
@@ -178,6 +186,32 @@ impl CoreCapabilityDispatcher {
             )),
         }
     }
+
+    async fn dispatch_read_host(
+        &self,
+        capability_id: &str,
+        scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+    ) -> Result<Value, CapabilityDispatchError> {
+        let host = self
+            .host
+            .as_ref()
+            .ok_or(CapabilityDispatchError::Unavailable("plugin read host is not configured"))?;
+        match capability_id {
+            "host.system.facts" => host.system_facts().await,
+            "plugin.installed.list" => host.installed_plugins().await,
+            "server.instance.list" => host.instances().await,
+            "server.status.read" => {
+                let id = server_scope(scope)?;
+                host.server_status(id).await
+            }
+            "server.metrics.read" | "server.metadata.read" | "server.config.redacted" => Err(
+                CapabilityDispatchError::Unavailable("server read capability is not implemented"),
+            ),
+            _ => Err(CapabilityDispatchError::Unavailable(
+                "capability implementation is not available",
+            )),
+        }
+    }
 }
 
 #[async_trait]
@@ -215,12 +249,81 @@ impl CapabilityDispatcher for CoreCapabilityDispatcher {
         }
         self.check_rate_limit(plugin_id, invocation.capability.as_str())
             .await?;
-        self.dispatch_market(
-            invocation.capability.as_str(),
-            invocation.scope.as_ref(),
-            &invocation.payload,
-        )
-        .await
+        match invocation.capability.as_str() {
+            capability @ ("market.search" | "market.resource.read" | "market.versions.read") => {
+                self.dispatch_market(capability, invocation.scope.as_ref(), &invocation.payload)
+                    .await
+            }
+            capability => {
+                self.dispatch_read_host(capability, invocation.scope.as_ref())
+                    .await
+            }
+        }
+    }
+}
+
+/// 服务器与宿主只读数据的应用层端口。
+#[async_trait]
+pub trait PluginReadHost: Send + Sync {
+    async fn system_facts(&self) -> Result<Value, CapabilityDispatchError>;
+    async fn installed_plugins(&self) -> Result<Value, CapabilityDispatchError>;
+    async fn instances(&self) -> Result<Value, CapabilityDispatchError>;
+    async fn server_status(&self, instance_id: &str) -> Result<Value, CapabilityDispatchError>;
+}
+
+/// 基于既有应用服务的只读宿主适配器。
+pub struct ApplicationPluginReadHost {
+    system: Arc<dyn SystemService>,
+    instance: Arc<dyn InstanceService>,
+    server: Arc<dyn ServerService>,
+}
+
+impl ApplicationPluginReadHost {
+    pub fn new(
+        system: Arc<dyn SystemService>,
+        instance: Arc<dyn InstanceService>,
+        server: Arc<dyn ServerService>,
+    ) -> Self {
+        Self { system, instance, server }
+    }
+}
+
+#[async_trait]
+impl PluginReadHost for ApplicationPluginReadHost {
+    async fn system_facts(&self) -> Result<Value, CapabilityDispatchError> {
+        let snapshot = self
+            .system
+            .system_snapshot()
+            .await
+            .map_err(|error| host_error("system facts", error))?;
+        serde_json::to_value(snapshot)
+            .map_err(|_| CapabilityDispatchError::Failed("host response encoding"))
+    }
+
+    async fn installed_plugins(&self) -> Result<Value, CapabilityDispatchError> {
+        Ok(Value::Array(vec![]))
+    }
+
+    async fn instances(&self) -> Result<Value, CapabilityDispatchError> {
+        let instances = self
+            .instance
+            .list()
+            .await
+            .map_err(|error| host_error("instance list", error))?;
+        serde_json::to_value(instances)
+            .map_err(|_| CapabilityDispatchError::Failed("host response encoding"))
+    }
+
+    async fn server_status(&self, instance_id: &str) -> Result<Value, CapabilityDispatchError> {
+        let id = sealantern_core::instance::InstanceId::new(instance_id)
+            .map_err(|_| CapabilityDispatchError::InvalidRequest("server instance id"))?;
+        let status = self
+            .server
+            .status(&id)
+            .await
+            .map_err(|error| host_error("server status", error))?;
+        serde_json::to_value(status)
+            .map_err(|_| CapabilityDispatchError::Failed("host response encoding"))
     }
 }
 
@@ -254,6 +357,15 @@ fn market_scope(
         .ok_or(CapabilityDispatchError::InvalidRequest("market resource id"))
 }
 
+fn server_scope(
+    scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+) -> Result<&str, CapabilityDispatchError> {
+    let scope = scope.ok_or(CapabilityDispatchError::InvalidRequest("server scope"))?;
+    (scope.kind == ScopeKind::ServerInstance)
+        .then_some(scope.value.as_str())
+        .ok_or(CapabilityDispatchError::InvalidRequest("server scope kind"))
+}
+
 fn market_error(operation: &'static str, error: MarketError) -> CapabilityDispatchError {
     tracing::warn!(
         target: "sealantern.application.plugin",
@@ -269,6 +381,16 @@ fn market_error(operation: &'static str, error: MarketError) -> CapabilityDispat
     }
 }
 
+fn host_error(operation: &'static str, error: impl std::fmt::Display) -> CapabilityDispatchError {
+    tracing::warn!(
+        target: "sealantern.application.plugin",
+        operation,
+        error = %error,
+        "plugin host read capability failed"
+    );
+    CapabilityDispatchError::Failed("host read request failed")
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -278,6 +400,27 @@ mod tests {
 
     struct FakeMarket {
         searches: AtomicUsize,
+    }
+
+    struct FakeReadHost;
+
+    #[async_trait]
+    impl PluginReadHost for FakeReadHost {
+        async fn system_facts(&self) -> Result<Value, CapabilityDispatchError> {
+            Ok(serde_json::json!({"os": "test"}))
+        }
+
+        async fn installed_plugins(&self) -> Result<Value, CapabilityDispatchError> {
+            Ok(Value::Array(vec![]))
+        }
+
+        async fn instances(&self) -> Result<Value, CapabilityDispatchError> {
+            Ok(Value::Array(vec![]))
+        }
+
+        async fn server_status(&self, instance_id: &str) -> Result<Value, CapabilityDispatchError> {
+            Ok(serde_json::json!({"instanceId": instance_id, "state": "stopped"}))
+        }
     }
 
     #[async_trait]
@@ -361,5 +504,38 @@ mod tests {
                 sealantern_core::app_plugin::PolicyDenialReason::CapabilityNotDeclared
             ))
         ));
+    }
+
+    #[tokio::test]
+    async fn server_status_uses_scoped_persistent_grant_and_read_host() {
+        let root = tempfile::tempdir().unwrap();
+        let policy = Arc::new(
+            PluginPolicyStore::open(root.path().join("state.sqlite"))
+                .await
+                .unwrap(),
+        );
+        let scope = ScopeBinding::new(ScopeKind::ServerInstance, "server-a").unwrap();
+        policy.set_enabled("example.plugin", true).await.unwrap();
+        policy
+            .grant_persistent("example.plugin", "server.status.read", Some(&scope))
+            .await
+            .unwrap();
+        let dispatcher = CoreCapabilityDispatcher::new(
+            policy,
+            Arc::new(FakeMarket { searches: AtomicUsize::new(0) }),
+        )
+        .with_read_host(Arc::new(FakeReadHost));
+        let invocation = CapabilityInvocation {
+            principal: ExecutionPrincipal::Plugin("example.plugin".to_string()),
+            trust_source: TrustSource::UntrustedLocal,
+            capability: CapabilityId::new("server.status.read").unwrap(),
+            scope: Some(scope),
+            declared: true,
+            payload: Value::Null,
+            approval_token: None,
+            request_id: "request-3".to_string(),
+        };
+
+        assert_eq!(dispatcher.invoke(invocation).await.unwrap()["instanceId"], "server-a");
     }
 }

--- a/application/src/plugin/mod.rs
+++ b/application/src/plugin/mod.rs
@@ -4,6 +4,9 @@ mod dispatcher;
 mod policy;
 mod service;
 
-pub use dispatcher::{CoreCapabilityDispatcher, DefaultMarketGateway, MarketGateway};
+pub use dispatcher::{
+    ApplicationPluginReadHost, CoreCapabilityDispatcher, DefaultMarketGateway, MarketGateway,
+    PluginReadHost,
+};
 pub use policy::{AuditEntry, PluginPolicyError, PluginPolicyStore, SessionApproval, SessionGrant};
 pub use service::{CorePluginService, PluginService, PluginServiceError};

--- a/application/src/plugin/service.rs
+++ b/application/src/plugin/service.rs
@@ -5,7 +5,10 @@ use async_trait::async_trait;
 use sealantern_extra::app_plugin::{AsyncPluginManager, PluginInfo, PluginManagerConfig};
 use sealantern_infra::platform::get_app_data_dir;
 
-use super::{CoreCapabilityDispatcher, DefaultMarketGateway, PluginPolicyError, PluginPolicyStore};
+use super::{
+    CoreCapabilityDispatcher, DefaultMarketGateway, PluginPolicyError, PluginPolicyStore,
+    PluginReadHost,
+};
 
 /// 应用插件生命周期的宿主入口。
 #[async_trait]
@@ -71,10 +74,25 @@ impl CorePluginService {
         data_dir: impl Into<PathBuf>,
         state_path: impl Into<PathBuf>,
     ) -> Result<Self, PluginServiceError> {
+        Self::open_with_read_host(plugins_dir, data_dir, state_path, None).await
+    }
+
+    /// 使用明确的只读宿主能力构造服务。
+    pub async fn open_with_read_host(
+        plugins_dir: impl Into<PathBuf>,
+        data_dir: impl Into<PathBuf>,
+        state_path: impl Into<PathBuf>,
+        read_host: Option<Arc<dyn PluginReadHost>>,
+    ) -> Result<Self, PluginServiceError> {
         let policy = Arc::new(PluginPolicyStore::open(state_path).await?);
         let market =
             Arc::new(DefaultMarketGateway::new().map_err(PluginServiceError::Initialization)?);
-        let dispatcher = Arc::new(CoreCapabilityDispatcher::new(policy.clone(), market));
+        let dispatcher = CoreCapabilityDispatcher::new(policy.clone(), market);
+        let dispatcher = match read_host {
+            Some(host) => dispatcher.with_read_host(host),
+            None => dispatcher,
+        };
+        let dispatcher = Arc::new(dispatcher);
         Ok(Self {
             runtime: AsyncPluginManager::new(
                 PluginManagerConfig::new(plugins_dir, data_dir).with_dispatcher(dispatcher),

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::error::InstanceError;
-use crate::plugin::{CorePluginService, PluginServiceError};
+use crate::plugin::{ApplicationPluginReadHost, CorePluginService, PluginServiceError};
 use crate::service::{
     CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreServerService,
     CoreSettingsService, CoreSystemService, CoreUpdateCheckService, ProxyMonitoringService,
@@ -240,9 +240,22 @@ impl AppServices {
 
     /// 获取应用插件服务；首次调用才打开策略数据库，避免阻塞常规启动路径。
     pub async fn plugin(&self) -> Result<&Arc<CorePluginService>, PluginServiceError> {
+        let system = self.inner.system.clone();
+        let instance = self.inner.instance.clone();
+        let server = self.inner.server.clone();
         self.inner
             .plugin
-            .get_or_try_init(|| async { CorePluginService::open_default().await.map(Arc::new) })
+            .get_or_try_init(move || async move {
+                let root = sealantern_infra::platform::get_app_data_dir().join("plugins");
+                CorePluginService::open_with_read_host(
+                    &root,
+                    root.join("data"),
+                    root.join("plugin-state.sqlite"),
+                    Some(Arc::new(ApplicationPluginReadHost::new(system, instance, server))),
+                )
+                .await
+                .map(Arc::new)
+            })
             .await
     }
 


### PR DESCRIPTION
提供系统、实例和服务器状态的受控只读能力。

## Summary by Sourcery

为插件添加受策略保护的主机读取能力，允许以受控方式访问系统、实例和服务器状态数据。

新功能：
- 通过新的调度路径，为系统信息、已安装插件、实例和服务器状态引入插件主机读取能力。
- 提供应用级的 `PluginReadHost` 适配器，以只读方式向插件暴露现有的系统、实例和服务器服务。

增强内容：
- 扩展 `CoreCapabilityDispatcher` 和 `CorePluginService`，在构建插件运行时时可选地接入只读主机适配器。
- 更新应用服务装配方式，使插件服务在初始化时使用由核心服务支持的只读主机。

测试：
- 添加测试，验证服务器状态读取使用了作用域持久授权（scoped persistent grants）以及已配置的主机读取实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a policy-protected host read capability for plugins, allowing controlled access to system, instance, and server status data.

New Features:
- Introduce plugin host read capabilities for system facts, installed plugins, instances, and server status via a new dispatcher path.
- Provide an application-level PluginReadHost adapter that exposes existing system, instance, and server services to plugins in a read-only manner.

Enhancements:
- Extend CoreCapabilityDispatcher and CorePluginService to optionally wire in a read-only host adapter when constructing the plugin runtime.
- Update application service wiring so the plugin service is initialized with a read-only host backed by core services.

Tests:
- Add tests verifying server status read uses scoped persistent grants and the configured read host implementation.

</details>