### PR TITLE
feat(plugin): 增加范围限定的文件读取

### DIFF
--- a/application/src/plugin/dispatcher.rs
+++ b/application/src/plugin/dispatcher.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -191,6 +192,7 @@ impl CoreCapabilityDispatcher {
         &self,
         capability_id: &str,
         scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+        payload: &Value,
     ) -> Result<Value, CapabilityDispatchError> {
         let host = self
             .host
@@ -203,6 +205,13 @@ impl CoreCapabilityDispatcher {
             "server.status.read" => {
                 let id = server_scope(scope)?;
                 host.server_status(id).await
+            }
+            "server.file.metadata"
+            | "server.file.read"
+            | "plugin.bundle.metadata"
+            | "plugin.bundle.read" => {
+                let path = read_path(payload)?;
+                host.scoped_file(capability_id, scope, &path).await
             }
             "server.metrics.read" | "server.metadata.read" | "server.config.redacted" => Err(
                 CapabilityDispatchError::Unavailable("server read capability is not implemented"),
@@ -255,7 +264,7 @@ impl CapabilityDispatcher for CoreCapabilityDispatcher {
                     .await
             }
             capability => {
-                self.dispatch_read_host(capability, invocation.scope.as_ref())
+                self.dispatch_read_host(capability, invocation.scope.as_ref(), &invocation.payload)
                     .await
             }
         }
@@ -269,6 +278,12 @@ pub trait PluginReadHost: Send + Sync {
     async fn installed_plugins(&self) -> Result<Value, CapabilityDispatchError>;
     async fn instances(&self) -> Result<Value, CapabilityDispatchError>;
     async fn server_status(&self, instance_id: &str) -> Result<Value, CapabilityDispatchError>;
+    async fn scoped_file(
+        &self,
+        capability_id: &str,
+        scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+        relative_path: &Path,
+    ) -> Result<Value, CapabilityDispatchError>;
 }
 
 /// 基于既有应用服务的只读宿主适配器。
@@ -276,6 +291,7 @@ pub struct ApplicationPluginReadHost {
     system: Arc<dyn SystemService>,
     instance: Arc<dyn InstanceService>,
     server: Arc<dyn ServerService>,
+    plugin_root: PathBuf,
 }
 
 impl ApplicationPluginReadHost {
@@ -283,8 +299,14 @@ impl ApplicationPluginReadHost {
         system: Arc<dyn SystemService>,
         instance: Arc<dyn InstanceService>,
         server: Arc<dyn ServerService>,
+        plugin_root: impl Into<PathBuf>,
     ) -> Self {
-        Self { system, instance, server }
+        Self {
+            system,
+            instance,
+            server,
+            plugin_root: plugin_root.into(),
+        }
     }
 }
 
@@ -325,6 +347,82 @@ impl PluginReadHost for ApplicationPluginReadHost {
         serde_json::to_value(status)
             .map_err(|_| CapabilityDispatchError::Failed("host response encoding"))
     }
+
+    async fn scoped_file(
+        &self,
+        capability_id: &str,
+        scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+        relative_path: &Path,
+    ) -> Result<Value, CapabilityDispatchError> {
+        let scope = scope.ok_or(CapabilityDispatchError::InvalidRequest("file scope"))?;
+        let root = match scope.kind {
+            ScopeKind::ServerInstance => {
+                let id = sealantern_core::instance::InstanceId::new(&scope.value)
+                    .map_err(|_| CapabilityDispatchError::InvalidRequest("server instance id"))?;
+                self.instance
+                    .find(&id)
+                    .await
+                    .map_err(|error| host_error("instance lookup", error))?
+                    .ok_or(CapabilityDispatchError::Unavailable("server instance not found"))?
+                    .directory
+            }
+            ScopeKind::PluginBundle => self.plugin_root.join(&scope.value),
+            _ => return Err(CapabilityDispatchError::InvalidRequest("file scope kind")),
+        };
+        read_scoped_file(capability_id, root, relative_path).await
+    }
+}
+
+async fn read_scoped_file(
+    capability_id: &str,
+    root: PathBuf,
+    relative_path: &Path,
+) -> Result<Value, CapabilityDispatchError> {
+    let root = tokio::fs::canonicalize(&root)
+        .await
+        .map_err(|_| CapabilityDispatchError::Unavailable("file scope root unavailable"))?;
+    let path = root.join(relative_path);
+    let resolved = tokio::fs::canonicalize(&path)
+        .await
+        .map_err(|_| CapabilityDispatchError::Unavailable("scoped file unavailable"))?;
+    if !resolved.starts_with(&root) {
+        return Err(CapabilityDispatchError::InvalidRequest("scoped file escapes root"));
+    }
+    let metadata = tokio::fs::metadata(&resolved)
+        .await
+        .map_err(|_| CapabilityDispatchError::Unavailable("scoped file metadata unavailable"))?;
+    if capability_id.ends_with("metadata") {
+        return Ok(serde_json::json!({
+            "path": relative_path,
+            "isFile": metadata.is_file(),
+            "isDirectory": metadata.is_dir(),
+            "length": metadata.len(),
+        }));
+    }
+    if !metadata.is_file() || metadata.len() > 1024 * 1024 {
+        return Err(CapabilityDispatchError::Unavailable("scoped file exceeds read limit"));
+    }
+    let content = tokio::fs::read_to_string(&resolved)
+        .await
+        .map_err(|_| CapabilityDispatchError::Failed("scoped file read failed"))?;
+    Ok(serde_json::json!({ "path": relative_path, "content": content }))
+}
+
+fn read_path(payload: &Value) -> Result<PathBuf, CapabilityDispatchError> {
+    let path = payload
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or(CapabilityDispatchError::InvalidRequest("scoped file path"))?;
+    let path = Path::new(path);
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(CapabilityDispatchError::InvalidRequest("scoped file path"));
+    }
+    Ok(path.to_owned())
 }
 
 #[derive(Deserialize)]
@@ -420,6 +518,15 @@ mod tests {
 
         async fn server_status(&self, instance_id: &str) -> Result<Value, CapabilityDispatchError> {
             Ok(serde_json::json!({"instanceId": instance_id, "state": "stopped"}))
+        }
+
+        async fn scoped_file(
+            &self,
+            _: &str,
+            _: Option<&sealantern_core::app_plugin::ScopeBinding>,
+            _: &Path,
+        ) -> Result<Value, CapabilityDispatchError> {
+            Err(CapabilityDispatchError::Unavailable("not used"))
         }
     }
 
@@ -537,5 +644,31 @@ mod tests {
         };
 
         assert_eq!(dispatcher.invoke(invocation).await.unwrap()["instanceId"], "server-a");
+    }
+
+    #[tokio::test]
+    async fn scoped_file_read_is_bounded_and_rejects_parent_paths() {
+        let root = tempfile::tempdir().unwrap();
+        tokio::fs::write(root.path().join("config.txt"), "safe content")
+            .await
+            .unwrap();
+        let result =
+            read_scoped_file("plugin.bundle.read", root.path().to_owned(), Path::new("config.txt"))
+                .await
+                .unwrap();
+        assert_eq!(result["content"], "safe content");
+        assert!(matches!(
+            read_path(&serde_json::json!({"path":"../config.txt"})),
+            Err(CapabilityDispatchError::InvalidRequest("scoped file path"))
+        ));
+
+        tokio::fs::write(root.path().join("large.txt"), vec![b'x'; 1024 * 1024 + 1])
+            .await
+            .unwrap();
+        assert!(matches!(
+            read_scoped_file("plugin.bundle.read", root.path().to_owned(), Path::new("large.txt"))
+                .await,
+            Err(CapabilityDispatchError::Unavailable("scoped file exceeds read limit"))
+        ));
     }
 }

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -251,7 +251,7 @@ impl AppServices {
                     &root,
                     root.join("data"),
                     root.join("plugin-state.sqlite"),
-                    Some(Arc::new(ApplicationPluginReadHost::new(system, instance, server))),
+                    Some(Arc::new(ApplicationPluginReadHost::new(system, instance, server, &root))),
                 )
                 .await
                 .map(Arc::new)


### PR DESCRIPTION
提供受作用域、路径边界和大小限制保护的文件读取。

## Summary by Sourcery

为插件和服务器实例引入带作用域和边界限制的文件读取能力。

New Features:
- 为服务器和插件包文件添加在定义作用域内运行的读取能力。
- 在插件读取主机上暴露带作用域的文件访问方法，以支持元数据和内容的获取。

Enhancements:
- 在解析和读取带作用域的文件时强制执行路径边界限制、防止访问父目录，以及文件大小限制。
- 扩展应用服务的装配，将插件根目录提供给插件读取主机。

Tests:
- 添加测试，以验证带作用域的文件读取遵守大小限制，并拒绝试图逃逸出允许目录的路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce scoped, bounded file read capabilities for plugins and server instances.

New Features:
- Add read capabilities for server and plugin bundle files that operate within a defined scope.
- Expose a scoped file access method on the plugin read host to support metadata and content retrieval.

Enhancements:
- Enforce path boundary, non-parent, and size limits when resolving and reading scoped files.
- Extend application services wiring to provide plugin read hosts with the plugin root directory.

Tests:
- Add tests verifying scoped file reads respect size limits and reject paths that escape the allowed directory.

</details>