### PR TITLE
feat(plugin): 增加防 SSRF 的 allowlist 网络

### DIFF
--- a/application/src/plugin/dispatcher.rs
+++ b/application/src/plugin/dispatcher.rs
@@ -11,6 +11,10 @@ use sealantern_core::app_plugin::{
 use sealantern_extra::market::{
     Fetcher, MarketError, MarketSource, ResourceInfo, SearchResult, Version,
 };
+use sealantern_infra::net::{
+    NetworkOrigin, PluginHttpMethod, PluginNetworkAddressPolicy, PluginNetworkExecutor,
+    PluginNetworkLimits, PluginNetworkRequest, PluginNetworkScope,
+};
 use sealantern_interface::{InstanceService, ServerService, SystemService};
 use serde::Deserialize;
 use serde_json::Value;
@@ -19,6 +23,7 @@ use tokio::sync::Mutex;
 use super::PluginPolicyStore;
 
 const MARKET_PAGE_SIZE_LIMIT: u32 = 100;
+const MAX_PLUGIN_NETWORK_IN_FLIGHT: usize = 8;
 const RATE_WINDOW: Duration = Duration::from_secs(60);
 
 /// 只读市场能力的宿主端口。
@@ -85,6 +90,7 @@ pub struct CoreCapabilityDispatcher {
     policy: Arc<PluginPolicyStore>,
     market: Arc<dyn MarketGateway>,
     host: Option<Arc<dyn PluginReadHost>>,
+    network: PluginNetworkExecutor,
     calls: Mutex<HashMap<(String, String), VecDeque<Instant>>>,
 }
 
@@ -94,6 +100,11 @@ impl CoreCapabilityDispatcher {
             policy,
             market,
             host: None,
+            network: PluginNetworkExecutor::new(
+                MAX_PLUGIN_NETWORK_IN_FLIGHT,
+                PluginNetworkLimits::default(),
+            )
+            .expect("default plugin network limits must be valid"),
             calls: Mutex::new(HashMap::new()),
         }
     }
@@ -236,6 +247,46 @@ impl CoreCapabilityDispatcher {
             )),
         }
     }
+
+    async fn dispatch_network(
+        &self,
+        scope: Option<&sealantern_core::app_plugin::ScopeBinding>,
+        payload: &Value,
+    ) -> Result<Value, CapabilityDispatchError> {
+        let scope = scope.ok_or(CapabilityDispatchError::InvalidRequest("network origin scope"))?;
+        if scope.kind != ScopeKind::NetworkOrigin {
+            return Err(CapabilityDispatchError::InvalidRequest("network origin scope kind"));
+        }
+        let request: NetworkRequest = serde_json::from_value(payload.clone())
+            .map_err(|_| CapabilityDispatchError::InvalidRequest("network request payload"))?;
+        if request.method != "GET" {
+            return Err(CapabilityDispatchError::InvalidRequest("plugin network method"));
+        }
+        let origin = NetworkOrigin::parse(&scope.value)
+            .map_err(|_| CapabilityDispatchError::InvalidRequest("network origin scope value"))?;
+        let scope = PluginNetworkScope::new(origin, PluginNetworkAddressPolicy::PublicOnly)
+            .map_err(|_| CapabilityDispatchError::InvalidRequest("network origin scope value"))?;
+        let execution = self
+            .network
+            .execute(PluginNetworkRequest::new(PluginHttpMethod::Get, request.url), scope)
+            .await
+            .map_err(|error| {
+                tracing::warn!(
+                    target: "sealantern.application.plugin",
+                    error = %error,
+                    "plugin allowlisted network request failed"
+                );
+                CapabilityDispatchError::Failed("plugin network request failed")
+            })?;
+        let response = execution.response;
+        let body = String::from_utf8(response.body.to_vec())
+            .map_err(|_| CapabilityDispatchError::Failed("plugin network response is not UTF-8"))?;
+        Ok(serde_json::json!({
+            "status": response.status,
+            "contentType": response.content_type,
+            "body": body,
+        }))
+    }
 }
 
 #[async_trait]
@@ -294,6 +345,10 @@ impl CapabilityDispatcher for CoreCapabilityDispatcher {
         match invocation.capability.as_str() {
             capability @ ("market.search" | "market.resource.read" | "market.versions.read") => {
                 self.dispatch_market(capability, invocation.scope.as_ref(), &invocation.payload)
+                    .await
+            }
+            "network.request.public_allowlisted" => {
+                self.dispatch_network(invocation.scope.as_ref(), &invocation.payload)
                     .await
             }
             capability => {
@@ -511,6 +566,13 @@ struct MarketSearchRequest {
     query: String,
     page: Option<u32>,
     page_size: Option<u32>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct NetworkRequest {
+    method: String,
+    url: String,
 }
 
 fn market_scope(

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1", features = [
     "rt",
     "rt-multi-thread",
     "macros",
+    "net",
     "sync",
     "time",
 ] }


### PR DESCRIPTION
提供精确 origin、DNS 地址过滤和响应限制的插件网络能力。

## Summary by Sourcery

为插件引入基于 HTTPS 来源允许列表的受限出站网络能力，以减轻 SSRF 风险。

新特性：
- 添加一个插件网络能力入口点（`network.request.public_allowlisted`），并接入核心能力调度器。
- 为插件提供专用的 `PluginNetworkClient`，强制执行 HTTPS 来源允许列表，并限制仅返回大小受控的文本响应。

增强内容：
- 将新的插件网络客户端集成到应用层，使网络请求能够根据插件范围元数据进行校验。
- 扩展基础设施网络模块的导出内容，包含插件网络客户端，并启用 Tokio net 对 DNS 解析的支持。

测试：
- 添加单元测试，验证 HTTPS 来源校验、重定向目标约束，以及拒绝插件网络请求中指向私有或本地 IP 地址的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a restricted outbound network capability for plugins based on an HTTPS origin allowlist to mitigate SSRF risks.

New Features:
- Add a plugin network capability entry point (`network.request.public_allowlisted`) wired into the core capability dispatcher.
- Provide a dedicated `PluginNetworkClient` for plugins that enforces HTTPS origin allowlisting and size-limited text responses.

Enhancements:
- Integrate the new plugin network client into the application layer so network requests are validated against plugin scope metadata.
- Extend infra networking module exports to include the plugin network client and enable Tokio net support for DNS resolution.

Tests:
- Add unit tests verifying HTTPS origin validation, redirect target constraints, and rejection of private or local IP addresses for plugin network requests.

</details>