### PR TITLE
feat(network): 提供插件安全出站客户端

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5272,9 +5272,11 @@ name = "sealantern-infra"
 version = "1.2.0"
 dependencies = [
  "atomicwrites",
+ "bytes",
  "cap-std",
  "dirs 5.0.1",
  "futures",
+ "ipnet",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -13,13 +13,16 @@ blocking = ["reqwest/blocking"]
 
 [dependencies]
 atomicwrites = "0.4"
+bytes = "1"
 cap-std = "4"
+ipnet = "2"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 tracing = "0.1"
 tokio = { version = "1", features = [
     "fs",
     "io-util",
+    "net",
     "rt",
     "rt-multi-thread",
     "macros",

--- a/crates/infra/src/net/mod.rs
+++ b/crates/infra/src/net/mod.rs
@@ -9,9 +9,10 @@ pub use client::{ClientConfig, NetClient, RemoteFileInfo, RetryPolicy, TimeoutPo
 pub use error::NetError;
 pub use plugin::{
     AllowedNetworkTarget, NetworkOrigin, PluginHttpMethod, PluginNetworkAddressPolicy,
-    PluginNetworkClient, PluginNetworkError, PluginNetworkExecution, PluginNetworkExecutor,
-    PluginNetworkLimits, PluginNetworkRequest, PluginNetworkResponse, PluginNetworkScope,
-    PluginNetworkTrace, PluginTransportErrorKind, PluginTransportStage, ResolvedNetworkTarget,
+    PluginNetworkClient, PluginNetworkCredentials, PluginNetworkError, PluginNetworkExecution,
+    PluginNetworkExecutor, PluginNetworkLimits, PluginNetworkRequest, PluginNetworkResponse,
+    PluginNetworkScope, PluginNetworkTrace, PluginRequestHeaders, PluginTransportErrorKind,
+    PluginTransportStage, ResolvedNetworkTarget,
 };
 pub use proxy::{
     EffectiveProxy, ProxyConfigError, ProxyController, ProxyMode, ProxyMonitor, ProxySettings,

--- a/crates/infra/src/net/mod.rs
+++ b/crates/infra/src/net/mod.rs
@@ -11,7 +11,7 @@ pub use plugin::{
     AllowedNetworkTarget, NetworkOrigin, PluginHttpMethod, PluginNetworkAddressPolicy,
     PluginNetworkClient, PluginNetworkError, PluginNetworkExecution, PluginNetworkExecutor,
     PluginNetworkLimits, PluginNetworkRequest, PluginNetworkResponse, PluginNetworkScope,
-    PluginNetworkTrace, ResolvedNetworkTarget,
+    PluginNetworkTrace, PluginTransportErrorKind, PluginTransportStage, ResolvedNetworkTarget,
 };
 pub use proxy::{
     EffectiveProxy, ProxyConfigError, ProxyController, ProxyMode, ProxyMonitor, ProxySettings,

--- a/crates/infra/src/net/mod.rs
+++ b/crates/infra/src/net/mod.rs
@@ -1,11 +1,18 @@
 pub mod client;
 pub mod error;
+mod plugin;
 pub mod proxy;
 pub mod request;
 mod runtime;
 
 pub use client::{ClientConfig, NetClient, RemoteFileInfo, RetryPolicy, TimeoutPolicy};
 pub use error::NetError;
+pub use plugin::{
+    AllowedNetworkTarget, NetworkOrigin, PluginHttpMethod, PluginNetworkAddressPolicy,
+    PluginNetworkClient, PluginNetworkError, PluginNetworkExecution, PluginNetworkExecutor,
+    PluginNetworkLimits, PluginNetworkRequest, PluginNetworkResponse, PluginNetworkScope,
+    PluginNetworkTrace, ResolvedNetworkTarget,
+};
 pub use proxy::{
     EffectiveProxy, ProxyConfigError, ProxyController, ProxyMode, ProxyMonitor, ProxySettings,
     ProxyUpdate, SystemProxyProvider, SystemProxySnapshot,

--- a/crates/infra/src/net/plugin/executor.rs
+++ b/crates/infra/src/net/plugin/executor.rs
@@ -14,10 +14,11 @@ use url::{Host, Url};
 use super::{
     canonical_ip, AllowedNetworkTarget, PluginHttpMethod, PluginNetworkAddressPolicy,
     PluginNetworkError, PluginNetworkExecution, PluginNetworkLimits, PluginNetworkRequest,
-    PluginNetworkResponse, PluginNetworkScope, PluginNetworkTrace, ResolvedNetworkTarget,
+    PluginNetworkResponse, PluginNetworkScope, PluginNetworkTrace, PluginTransportErrorKind,
+    PluginTransportStage, ResolvedNetworkTarget,
 };
 
-const MAX_DNS_ADDRESSES: usize = 32;
+pub(super) const MAX_DNS_ADDRESSES: usize = 32;
 
 pub(super) trait PluginDnsResolver: Send + Sync {
     fn resolve<'a>(
@@ -36,7 +37,7 @@ impl PluginDnsResolver for SystemPluginDnsResolver {
         Box::pin(async move {
             tokio::net::lookup_host((host, 0))
                 .await
-                .map_err(|_| PluginNetworkError::DnsResolutionFailed)
+                .map_err(|error| PluginNetworkError::DnsResolutionFailed(error.kind()))
                 .map(|addresses| {
                     addresses
                         .map(|address| canonical_ip(address.ip()))
@@ -213,7 +214,7 @@ async fn execute_request(
             .headers(request.headers.clone())
             .send()
             .await
-            .map_err(transport_error)?;
+            .map_err(|error| transport_error(PluginTransportStage::RequestSend, error))?;
 
         if is_redirect(response.status()) {
             if redirects >= limits.max_redirects {
@@ -290,7 +291,7 @@ fn build_pinned_client(
     }
     builder
         .build()
-        .map_err(|_| PluginNetworkError::TransportFailed)
+        .map_err(|error| transport_error(PluginTransportStage::ClientBuild, error))
 }
 
 fn validate_limits(limits: PluginNetworkLimits) -> Result<(), PluginNetworkError> {
@@ -485,7 +486,8 @@ async fn read_bounded_body(
     let mut stream = response.bytes_stream();
     let mut body = Vec::with_capacity(max_bytes.min(16 * 1024));
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(transport_error)?;
+        let chunk =
+            chunk.map_err(|error| transport_error(PluginTransportStage::ResponseBody, error))?;
         let next_len = body
             .len()
             .checked_add(chunk.len())
@@ -498,10 +500,21 @@ async fn read_bounded_body(
     Ok(Bytes::from(body))
 }
 
-fn transport_error(error: reqwest::Error) -> PluginNetworkError {
+fn transport_error(stage: PluginTransportStage, error: reqwest::Error) -> PluginNetworkError {
     if error.is_timeout() {
         PluginNetworkError::Timeout
     } else {
-        PluginNetworkError::TransportFailed
+        let kind = if error.is_connect() {
+            PluginTransportErrorKind::Connect
+        } else if error.is_decode() {
+            PluginTransportErrorKind::Decode
+        } else if error.is_body() {
+            PluginTransportErrorKind::Body
+        } else if error.is_request() {
+            PluginTransportErrorKind::Request
+        } else {
+            PluginTransportErrorKind::Other
+        };
+        PluginNetworkError::TransportFailed { stage, kind }
     }
 }

--- a/crates/infra/src/net/plugin/executor.rs
+++ b/crates/infra/src/net/plugin/executor.rs
@@ -4,9 +4,7 @@ use std::time::Instant;
 
 use bytes::Bytes;
 use futures::StreamExt;
-use reqwest::header::{
-    HeaderMap, HeaderName, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, LOCATION,
-};
+use reqwest::header::{HeaderMap, CONTENT_LENGTH, CONTENT_TYPE, LOCATION};
 use reqwest::{Method, StatusCode};
 use tokio::sync::Semaphore;
 use url::{Host, Url};
@@ -15,7 +13,7 @@ use super::{
     canonical_ip, AllowedNetworkTarget, PluginHttpMethod, PluginNetworkAddressPolicy,
     PluginNetworkError, PluginNetworkExecution, PluginNetworkLimits, PluginNetworkRequest,
     PluginNetworkResponse, PluginNetworkScope, PluginNetworkTrace, PluginTransportErrorKind,
-    PluginTransportStage, ResolvedNetworkTarget,
+    PluginTransportStage, ResolvedNetworkTarget, MAX_HEADER_BYTES, MAX_REQUEST_HEADERS,
 };
 
 pub(super) const MAX_DNS_ADDRESSES: usize = 32;
@@ -71,7 +69,7 @@ impl PluginNetworkClient {
         limits: PluginNetworkLimits,
     ) -> Result<PluginNetworkExecution, PluginNetworkError> {
         validate_limits(limits)?;
-        validate_headers(&request.headers, &scope.address_policy)?;
+        validate_request_headers(&request, &scope.address_policy)?;
         let started = Instant::now();
         tokio::time::timeout(
             limits.total_timeout,
@@ -191,6 +189,7 @@ async fn execute_request(
     started: Instant,
 ) -> Result<PluginNetworkExecution, PluginNetworkError> {
     let mut target = parse_target(&request.url, &scope)?;
+    let headers = request_headers(&request);
     let mut redirects = 0u8;
     let mut resolved_targets = Vec::new();
 
@@ -211,7 +210,7 @@ async fn execute_request(
         let client = build_pinned_client(&target, &addresses, &scope.address_policy, limits)?;
         let response = client
             .request(method(request.method), target.clone())
-            .headers(request.headers.clone())
+            .headers(headers.clone())
             .send()
             .await
             .map_err(|error| transport_error(PluginTransportStage::RequestSend, error))?;
@@ -330,37 +329,29 @@ fn validate_target(target: &Url, scope: &PluginNetworkScope) -> Result<(), Plugi
     Ok(())
 }
 
-pub(super) fn validate_headers(
-    headers: &HeaderMap,
+pub(super) fn validate_request_headers(
+    request: &PluginNetworkRequest,
     policy: &PluginNetworkAddressPolicy,
 ) -> Result<(), PluginNetworkError> {
-    const FORBIDDEN: &[&str] = &[
-        "host",
-        "proxy-authorization",
-        "connection",
-        "upgrade",
-        "transfer-encoding",
-        "te",
-        "trailer",
-        "forwarded",
-        "x-forwarded-for",
-        "x-forwarded-host",
-        "x-forwarded-proto",
-        "x-real-ip",
-    ];
-    for name in headers.keys() {
-        if FORBIDDEN.iter().any(|forbidden| name == *forbidden)
-            || (matches!(policy, PluginNetworkAddressPolicy::PublicOnly)
-                && is_credential_header(name))
-        {
-            return Err(PluginNetworkError::ForbiddenHeader(name.to_string()));
-        }
+    if matches!(policy, PluginNetworkAddressPolicy::PublicOnly) && !request.credentials.is_empty() {
+        return Err(PluginNetworkError::CredentialsNotAllowed);
+    }
+    let header_count = request.headers.values.len() + request.credentials.values.len();
+    let header_bytes = request
+        .headers
+        .bytes
+        .checked_add(request.credentials.bytes)
+        .ok_or(PluginNetworkError::RequestHeadersTooLarge)?;
+    if header_count > MAX_REQUEST_HEADERS || header_bytes > MAX_HEADER_BYTES {
+        return Err(PluginNetworkError::RequestHeadersTooLarge);
     }
     Ok(())
 }
 
-fn is_credential_header(name: &HeaderName) -> bool {
-    name == AUTHORIZATION || name == COOKIE
+fn request_headers(request: &PluginNetworkRequest) -> HeaderMap {
+    let mut headers = request.headers.values.clone();
+    headers.extend(request.credentials.values.clone());
+    headers
 }
 
 fn method(method: PluginHttpMethod) -> Method {

--- a/crates/infra/src/net/plugin/executor.rs
+++ b/crates/infra/src/net/plugin/executor.rs
@@ -1,0 +1,507 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use reqwest::header::{
+    HeaderMap, HeaderName, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE, LOCATION,
+};
+use reqwest::{Method, StatusCode};
+use tokio::sync::Semaphore;
+use url::{Host, Url};
+
+use super::{
+    canonical_ip, AllowedNetworkTarget, PluginHttpMethod, PluginNetworkAddressPolicy,
+    PluginNetworkError, PluginNetworkExecution, PluginNetworkLimits, PluginNetworkRequest,
+    PluginNetworkResponse, PluginNetworkScope, PluginNetworkTrace, ResolvedNetworkTarget,
+};
+
+const MAX_DNS_ADDRESSES: usize = 32;
+
+pub(super) trait PluginDnsResolver: Send + Sync {
+    fn resolve<'a>(
+        &'a self,
+        host: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<Vec<IpAddr>, PluginNetworkError>>;
+}
+
+struct SystemPluginDnsResolver;
+
+impl PluginDnsResolver for SystemPluginDnsResolver {
+    fn resolve<'a>(
+        &'a self,
+        host: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<Vec<IpAddr>, PluginNetworkError>> {
+        Box::pin(async move {
+            tokio::net::lookup_host((host, 0))
+                .await
+                .map_err(|_| PluginNetworkError::DnsResolutionFailed)
+                .map(|addresses| {
+                    addresses
+                        .map(|address| canonical_ip(address.ip()))
+                        .collect()
+                })
+        })
+    }
+}
+
+/// 插件专用安全客户端。
+///
+/// 该客户端不会暴露底层 `reqwest::Client` 或请求构建器。每次连接都会先解析并
+/// 校验全部地址，再把连接固定到该批地址；重定向的每一跳都会重复此过程。
+#[derive(Clone)]
+pub struct PluginNetworkClient {
+    resolver: Arc<dyn PluginDnsResolver>,
+}
+
+impl PluginNetworkClient {
+    pub fn new() -> Self {
+        Self {
+            resolver: Arc::new(SystemPluginDnsResolver),
+        }
+    }
+
+    /// 使用调用方已经批准的精确作用域和硬限制执行请求。
+    pub async fn execute(
+        &self,
+        request: PluginNetworkRequest,
+        scope: PluginNetworkScope,
+        limits: PluginNetworkLimits,
+    ) -> Result<PluginNetworkExecution, PluginNetworkError> {
+        validate_limits(limits)?;
+        validate_headers(&request.headers, &scope.address_policy)?;
+        let started = Instant::now();
+        tokio::time::timeout(
+            limits.total_timeout,
+            self.execute_inner(request, scope, limits, started),
+        )
+        .await
+        .map_err(|_| PluginNetworkError::Timeout)?
+    }
+
+    async fn execute_inner(
+        &self,
+        request: PluginNetworkRequest,
+        scope: PluginNetworkScope,
+        limits: PluginNetworkLimits,
+        started: Instant,
+    ) -> Result<PluginNetworkExecution, PluginNetworkError> {
+        execute_request(self, request, scope, limits, started).await
+    }
+
+    pub(super) async fn resolve_and_validate(
+        &self,
+        target: &Url,
+        policy: &PluginNetworkAddressPolicy,
+    ) -> Result<Vec<IpAddr>, PluginNetworkError> {
+        let mut addresses = match target.host().ok_or(PluginNetworkError::InvalidUrl)? {
+            Host::Ipv4(address) => vec![IpAddr::V4(address)],
+            Host::Ipv6(address) => vec![canonical_ip(IpAddr::V6(address))],
+            Host::Domain(host) => self.resolver.resolve(host).await?,
+        };
+        addresses.iter_mut().for_each(|address| {
+            *address = canonical_ip(*address);
+        });
+        addresses.sort_unstable();
+        addresses.dedup();
+        if addresses.is_empty() {
+            return Err(PluginNetworkError::EmptyDnsResult);
+        }
+        if addresses.len() > MAX_DNS_ADDRESSES {
+            return Err(PluginNetworkError::TooManyDnsAddresses);
+        }
+        for address in &addresses {
+            validate_address(*address, policy)?;
+        }
+        Ok(addresses)
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_resolver(resolver: Arc<dyn PluginDnsResolver>) -> Self {
+        Self { resolver }
+    }
+}
+
+impl Default for PluginNetworkClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 带进程级插件网络并发上限的受约束执行器。
+pub struct PluginNetworkExecutor {
+    client: PluginNetworkClient,
+    in_flight: Semaphore,
+    limits: PluginNetworkLimits,
+}
+
+impl PluginNetworkExecutor {
+    pub fn new(
+        max_in_flight: usize,
+        limits: PluginNetworkLimits,
+    ) -> Result<Self, PluginNetworkError> {
+        if max_in_flight == 0 {
+            return Err(PluginNetworkError::InvalidConfiguration);
+        }
+        validate_limits(limits)?;
+        Ok(Self {
+            client: PluginNetworkClient::new(),
+            in_flight: Semaphore::new(max_in_flight),
+            limits,
+        })
+    }
+
+    /// 使用指定安全客户端构造执行器，便于宿主统一管理客户端实例。
+    pub fn with_client(
+        client: PluginNetworkClient,
+        max_in_flight: usize,
+        limits: PluginNetworkLimits,
+    ) -> Result<Self, PluginNetworkError> {
+        if max_in_flight == 0 {
+            return Err(PluginNetworkError::InvalidConfiguration);
+        }
+        validate_limits(limits)?;
+        Ok(Self {
+            client,
+            in_flight: Semaphore::new(max_in_flight),
+            limits,
+        })
+    }
+
+    pub async fn execute(
+        &self,
+        request: PluginNetworkRequest,
+        scope: PluginNetworkScope,
+    ) -> Result<PluginNetworkExecution, PluginNetworkError> {
+        let _permit = self
+            .in_flight
+            .try_acquire()
+            .map_err(|_| PluginNetworkError::ConcurrencyLimitExceeded)?;
+        self.client.execute(request, scope, self.limits).await
+    }
+}
+
+async fn execute_request(
+    client: &PluginNetworkClient,
+    request: PluginNetworkRequest,
+    scope: PluginNetworkScope,
+    limits: PluginNetworkLimits,
+    started: Instant,
+) -> Result<PluginNetworkExecution, PluginNetworkError> {
+    let mut target = parse_target(&request.url, &scope)?;
+    let mut redirects = 0u8;
+    let mut resolved_targets = Vec::new();
+
+    loop {
+        let addresses = client
+            .resolve_and_validate(&target, &scope.address_policy)
+            .await?;
+        let host = target.host_str().ok_or(PluginNetworkError::InvalidUrl)?;
+        let port = target
+            .port_or_known_default()
+            .ok_or(PluginNetworkError::InvalidUrl)?;
+        resolved_targets.push(ResolvedNetworkTarget {
+            host: host.trim_end_matches('.').to_ascii_lowercase(),
+            port,
+            addresses: addresses.clone(),
+        });
+
+        let client = build_pinned_client(&target, &addresses, &scope.address_policy, limits)?;
+        let response = client
+            .request(method(request.method), target.clone())
+            .headers(request.headers.clone())
+            .send()
+            .await
+            .map_err(transport_error)?;
+
+        if is_redirect(response.status()) {
+            if redirects >= limits.max_redirects {
+                return Err(PluginNetworkError::RedirectLimitExceeded);
+            }
+            let location = response
+                .headers()
+                .get(LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or(PluginNetworkError::RedirectMissingLocation)?;
+            target = target
+                .join(location)
+                .map_err(|_| PluginNetworkError::RedirectMissingLocation)?;
+            validate_target(&target, &scope)?;
+            redirects += 1;
+            continue;
+        }
+
+        if declared_body_too_large(response.headers(), limits.max_response_bytes) {
+            return Err(PluginNetworkError::ResponseTooLarge);
+        }
+        let status = response.status().as_u16();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let body = read_bounded_body(response, limits.max_response_bytes).await?;
+        let bytes_received = body.len();
+
+        return Ok(PluginNetworkExecution {
+            response: PluginNetworkResponse {
+                status,
+                final_origin: scope.origin,
+                content_type,
+                body,
+            },
+            trace: PluginNetworkTrace {
+                duration: started.elapsed(),
+                redirects_followed: redirects,
+                resolved_targets,
+                bytes_received,
+            },
+        });
+    }
+}
+
+fn build_pinned_client(
+    target: &Url,
+    addresses: &[IpAddr],
+    policy: &PluginNetworkAddressPolicy,
+    limits: PluginNetworkLimits,
+) -> Result<reqwest::Client, PluginNetworkError> {
+    let host = target.host_str().ok_or(PluginNetworkError::InvalidUrl)?;
+    let port = target
+        .port_or_known_default()
+        .ok_or(PluginNetworkError::InvalidUrl)?;
+    let mut builder = reqwest::Client::builder()
+        .no_proxy()
+        .redirect(reqwest::redirect::Policy::none())
+        .pool_max_idle_per_host(0)
+        .connect_timeout(limits.connect_timeout)
+        .read_timeout(limits.read_timeout);
+    if matches!(policy, PluginNetworkAddressPolicy::PublicOnly) {
+        builder = builder.https_only(true);
+    }
+    if matches!(target.host(), Some(Host::Domain(_))) {
+        let pinned = addresses
+            .iter()
+            .copied()
+            .map(|address| SocketAddr::new(address, port))
+            .collect::<Vec<_>>();
+        builder = builder.resolve_to_addrs(host, &pinned);
+    }
+    builder
+        .build()
+        .map_err(|_| PluginNetworkError::TransportFailed)
+}
+
+fn validate_limits(limits: PluginNetworkLimits) -> Result<(), PluginNetworkError> {
+    if limits.max_response_bytes == 0
+        || limits.total_timeout.is_zero()
+        || limits.connect_timeout.is_zero()
+        || limits.read_timeout.is_zero()
+    {
+        Err(PluginNetworkError::InvalidConfiguration)
+    } else {
+        Ok(())
+    }
+}
+
+pub(super) fn parse_target(
+    value: &str,
+    scope: &PluginNetworkScope,
+) -> Result<Url, PluginNetworkError> {
+    let target = Url::parse(value).map_err(|_| PluginNetworkError::InvalidUrl)?;
+    validate_target(&target, scope)?;
+    Ok(target)
+}
+
+fn validate_target(target: &Url, scope: &PluginNetworkScope) -> Result<(), PluginNetworkError> {
+    if !target.username().is_empty() || target.password().is_some() {
+        return Err(PluginNetworkError::CredentialsNotAllowed);
+    }
+    if !scope.origin.matches(target) {
+        return Err(PluginNetworkError::OriginMismatch);
+    }
+    if matches!(scope.address_policy, PluginNetworkAddressPolicy::PublicOnly)
+        && target.scheme() != "https"
+    {
+        return Err(PluginNetworkError::SchemeNotAllowed);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_headers(
+    headers: &HeaderMap,
+    policy: &PluginNetworkAddressPolicy,
+) -> Result<(), PluginNetworkError> {
+    const FORBIDDEN: &[&str] = &[
+        "host",
+        "proxy-authorization",
+        "connection",
+        "upgrade",
+        "transfer-encoding",
+        "te",
+        "trailer",
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-real-ip",
+    ];
+    for name in headers.keys() {
+        if FORBIDDEN.iter().any(|forbidden| name == *forbidden)
+            || (matches!(policy, PluginNetworkAddressPolicy::PublicOnly)
+                && is_credential_header(name))
+        {
+            return Err(PluginNetworkError::ForbiddenHeader(name.to_string()));
+        }
+    }
+    Ok(())
+}
+
+fn is_credential_header(name: &HeaderName) -> bool {
+    name == AUTHORIZATION || name == COOKIE
+}
+
+fn method(method: PluginHttpMethod) -> Method {
+    match method {
+        PluginHttpMethod::Get => Method::GET,
+        PluginHttpMethod::Head => Method::HEAD,
+    }
+}
+
+pub(super) fn validate_address(
+    address: IpAddr,
+    policy: &PluginNetworkAddressPolicy,
+) -> Result<(), PluginNetworkError> {
+    let address = canonical_ip(address);
+    let allowed = match policy {
+        PluginNetworkAddressPolicy::PublicOnly => is_public_ip(address),
+        PluginNetworkAddressPolicy::AuthenticatedOrPrivate { allowed_targets } => {
+            !is_always_forbidden(address)
+                && allowed_targets
+                    .iter()
+                    .any(|target: &AllowedNetworkTarget| target.contains(address))
+        }
+    };
+    if allowed {
+        Ok(())
+    } else {
+        Err(PluginNetworkError::AddressNotAllowed(address))
+    }
+}
+
+pub(super) fn is_public_ip(address: IpAddr) -> bool {
+    match canonical_ip(address) {
+        IpAddr::V4(address) => is_public_ipv4(address),
+        IpAddr::V6(address) => is_public_ipv6(address),
+    }
+}
+
+fn is_public_ipv4(address: Ipv4Addr) -> bool {
+    let address = u32::from(address);
+    ![
+        (0x0000_0000, 8),
+        (0x0a00_0000, 8),
+        (0x6440_0000, 10),
+        (0x7f00_0000, 8),
+        (0xa9fe_0000, 16),
+        (0xac10_0000, 12),
+        (0xc000_0000, 24),
+        (0xc000_0200, 24),
+        (0xc0a8_0000, 16),
+        (0xc612_0000, 15),
+        (0xc633_6400, 24),
+        (0xcb00_7100, 24),
+        (0xe000_0000, 4),
+        (0xf000_0000, 4),
+    ]
+    .iter()
+    .any(|(network, prefix)| ipv4_in_network(address, *network, *prefix))
+}
+
+fn ipv4_in_network(address: u32, network: u32, prefix: u8) -> bool {
+    let mask = u32::MAX << (32 - prefix);
+    address & mask == network & mask
+}
+
+fn is_public_ipv6(address: Ipv6Addr) -> bool {
+    let address = u128::from(address);
+    // 公网模式保守地只接受全局单播 2000::/3，并排除特殊用途过渡/文档网段。
+    ipv6_in_network(address, 0x2000_0000_0000_0000_0000_0000_0000_0000, 3)
+        && ![
+            (0x2001_0db8_0000_0000_0000_0000_0000_0000, 32),
+            (0x2002_0000_0000_0000_0000_0000_0000_0000, 16),
+        ]
+        .iter()
+        .any(|(network, prefix)| ipv6_in_network(address, *network, *prefix))
+}
+
+fn ipv6_in_network(address: u128, network: u128, prefix: u8) -> bool {
+    let mask = u128::MAX << (128 - prefix);
+    address & mask == network & mask
+}
+
+fn is_always_forbidden(address: IpAddr) -> bool {
+    match canonical_ip(address) {
+        IpAddr::V4(address) => {
+            address.is_unspecified()
+                || address.is_loopback()
+                || address.is_link_local()
+                || address.is_multicast()
+                || address.is_broadcast()
+        }
+        IpAddr::V6(address) => {
+            address.is_unspecified()
+                || address.is_loopback()
+                || address.is_unicast_link_local()
+                || address.is_multicast()
+        }
+    }
+}
+
+pub(super) fn is_redirect(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::MOVED_PERMANENTLY
+            | StatusCode::FOUND
+            | StatusCode::SEE_OTHER
+            | StatusCode::TEMPORARY_REDIRECT
+            | StatusCode::PERMANENT_REDIRECT
+    )
+}
+
+pub(super) fn declared_body_too_large(headers: &HeaderMap, max_bytes: usize) -> bool {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .is_some_and(|length| length > max_bytes)
+}
+
+async fn read_bounded_body(
+    response: reqwest::Response,
+    max_bytes: usize,
+) -> Result<Bytes, PluginNetworkError> {
+    let mut stream = response.bytes_stream();
+    let mut body = Vec::with_capacity(max_bytes.min(16 * 1024));
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(transport_error)?;
+        let next_len = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or(PluginNetworkError::ResponseTooLarge)?;
+        if next_len > max_bytes {
+            return Err(PluginNetworkError::ResponseTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(Bytes::from(body))
+}
+
+fn transport_error(error: reqwest::Error) -> PluginNetworkError {
+    if error.is_timeout() {
+        PluginNetworkError::Timeout
+    } else {
+        PluginNetworkError::TransportFailed
+    }
+}

--- a/crates/infra/src/net/plugin/mod.rs
+++ b/crates/infra/src/net/plugin/mod.rs
@@ -1,0 +1,239 @@
+//! 插件受约束出站网络执行。
+//!
+//! 上层负责插件身份、能力声明、审批与策略审计；本模块只负责确保实际网络连接
+//! 不超出已经批准的 origin、地址范围和资源限制。
+
+mod executor;
+
+use std::fmt;
+use std::net::IpAddr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use ipnet::IpNet;
+use reqwest::header::HeaderMap;
+use url::{Host, Url};
+
+pub use executor::{PluginNetworkClient, PluginNetworkExecutor};
+
+/// 规范化后的精确 HTTP(S) origin。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NetworkOrigin {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl NetworkOrigin {
+    pub fn parse(value: &str) -> Result<Self, PluginNetworkError> {
+        let url = Url::parse(value).map_err(|_| PluginNetworkError::InvalidOrigin)?;
+        if !matches!(url.scheme(), "http" | "https")
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.path() != "/"
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(PluginNetworkError::InvalidOrigin);
+        }
+
+        let host = normalized_url_host(&url).ok_or(PluginNetworkError::InvalidOrigin)?;
+        let port = url
+            .port_or_known_default()
+            .ok_or(PluginNetworkError::InvalidOrigin)?;
+        Ok(Self {
+            scheme: url.scheme().to_owned(),
+            host,
+            port,
+        })
+    }
+
+    pub fn scheme(&self) -> &str {
+        &self.scheme
+    }
+
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub const fn port(&self) -> u16 {
+        self.port
+    }
+
+    fn matches(&self, url: &Url) -> bool {
+        url.scheme() == self.scheme
+            && normalized_url_host(url).as_deref() == Some(self.host.as_str())
+            && url.port_or_known_default() == Some(self.port)
+    }
+}
+
+/// 上层为私有网络能力明确批准的目标。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllowedNetworkTarget {
+    Exact(IpAddr),
+    Network(IpNet),
+}
+
+impl AllowedNetworkTarget {
+    fn contains(&self, address: IpAddr) -> bool {
+        let address = canonical_ip(address);
+        match self {
+            Self::Exact(expected) => canonical_ip(*expected) == address,
+            Self::Network(network) => network.contains(&address),
+        }
+    }
+}
+
+/// 已由上层能力策略选定的地址访问类别。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginNetworkAddressPolicy {
+    /// 仅允许 HTTPS 公网单播地址，且不允许认证请求头。
+    PublicOnly,
+    /// 仅允许显式列出的地址或网段；回环、链路本地等地址仍始终拒绝。
+    AuthenticatedOrPrivate {
+        allowed_targets: Vec<AllowedNetworkTarget>,
+    },
+}
+
+/// 已获批准的精确网络执行作用域。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginNetworkScope {
+    pub origin: NetworkOrigin,
+    pub address_policy: PluginNetworkAddressPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginHttpMethod {
+    Get,
+    Head,
+}
+
+/// 声明式请求。插件无法通过该类型取得底层 HTTP 客户端或 socket。
+#[derive(Debug, Clone)]
+pub struct PluginNetworkRequest {
+    pub method: PluginHttpMethod,
+    pub url: String,
+    pub headers: HeaderMap,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PluginNetworkLimits {
+    pub total_timeout: Duration,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub max_response_bytes: usize,
+    pub max_redirects: u8,
+}
+
+impl Default for PluginNetworkLimits {
+    fn default() -> Self {
+        Self {
+            total_timeout: Duration::from_secs(15),
+            connect_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(10),
+            max_response_bytes: 1024 * 1024,
+            max_redirects: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedNetworkTarget {
+    pub host: String,
+    pub port: u16,
+    pub addresses: Vec<IpAddr>,
+}
+
+/// 不包含 URL 查询串、凭据、请求头和响应体的执行轨迹。
+#[derive(Debug, Clone)]
+pub struct PluginNetworkTrace {
+    pub duration: Duration,
+    pub redirects_followed: u8,
+    pub resolved_targets: Vec<ResolvedNetworkTarget>,
+    pub bytes_received: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PluginNetworkResponse {
+    pub status: u16,
+    pub final_origin: NetworkOrigin,
+    pub content_type: Option<String>,
+    pub body: Bytes,
+}
+
+#[derive(Debug, Clone)]
+pub struct PluginNetworkExecution {
+    pub response: PluginNetworkResponse,
+    pub trace: PluginNetworkTrace,
+}
+
+/// 网络执行失败分类；插件策略拒绝理由仍由上层定义。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginNetworkError {
+    InvalidConfiguration,
+    InvalidOrigin,
+    InvalidUrl,
+    OriginMismatch,
+    SchemeNotAllowed,
+    CredentialsNotAllowed,
+    ForbiddenHeader(String),
+    AddressNotAllowed(IpAddr),
+    EmptyDnsResult,
+    TooManyDnsAddresses,
+    DnsResolutionFailed,
+    RedirectMissingLocation,
+    RedirectLimitExceeded,
+    ResponseTooLarge,
+    ConcurrencyLimitExceeded,
+    Timeout,
+    TransportFailed,
+}
+
+impl fmt::Display for PluginNetworkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfiguration => formatter.write_str("插件网络执行器配置无效"),
+            Self::InvalidOrigin => formatter.write_str("插件网络 origin 无效"),
+            Self::InvalidUrl => formatter.write_str("插件网络 URL 无效"),
+            Self::OriginMismatch => formatter.write_str("插件网络目标超出已批准 origin"),
+            Self::SchemeNotAllowed => formatter.write_str("插件网络协议不受允许"),
+            Self::CredentialsNotAllowed => formatter.write_str("插件网络 URL 不允许携带凭据"),
+            Self::ForbiddenHeader(name) => write!(formatter, "插件网络请求头不受允许: {name}"),
+            Self::AddressNotAllowed(address) => {
+                write!(formatter, "插件网络目标地址不受允许: {address}")
+            }
+            Self::EmptyDnsResult => formatter.write_str("插件网络 DNS 未返回地址"),
+            Self::TooManyDnsAddresses => formatter.write_str("插件网络 DNS 返回地址过多"),
+            Self::DnsResolutionFailed => formatter.write_str("插件网络 DNS 解析失败"),
+            Self::RedirectMissingLocation => formatter.write_str("插件网络重定向缺少有效 Location"),
+            Self::RedirectLimitExceeded => formatter.write_str("插件网络重定向次数超限"),
+            Self::ResponseTooLarge => formatter.write_str("插件网络响应体超限"),
+            Self::ConcurrencyLimitExceeded => formatter.write_str("插件网络并发已达上限"),
+            Self::Timeout => formatter.write_str("插件网络请求超时"),
+            Self::TransportFailed => formatter.write_str("插件网络传输失败"),
+        }
+    }
+}
+
+impl std::error::Error for PluginNetworkError {}
+
+fn normalized_url_host(url: &Url) -> Option<String> {
+    match url.host()? {
+        Host::Domain(host) => Some(host.trim_end_matches('.').to_ascii_lowercase()),
+        Host::Ipv4(address) => Some(address.to_string()),
+        Host::Ipv6(address) => Some(address.to_string()),
+    }
+}
+
+fn canonical_ip(address: IpAddr) -> IpAddr {
+    match address {
+        IpAddr::V6(address) => address
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(address)),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/infra/src/net/plugin/mod.rs
+++ b/crates/infra/src/net/plugin/mod.rs
@@ -98,8 +98,33 @@ pub enum PluginNetworkAddressPolicy {
 /// 已获批准的精确网络执行作用域。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginNetworkScope {
-    pub origin: NetworkOrigin,
-    pub address_policy: PluginNetworkAddressPolicy,
+    origin: NetworkOrigin,
+    address_policy: PluginNetworkAddressPolicy,
+}
+
+impl PluginNetworkScope {
+    /// 构造已经通过上层策略审批的执行作用域。
+    ///
+    /// 公网能力在构造阶段即要求 HTTPS，避免将错误配置延迟到请求执行时发现。
+    pub fn new(
+        origin: NetworkOrigin,
+        address_policy: PluginNetworkAddressPolicy,
+    ) -> Result<Self, PluginNetworkError> {
+        if matches!(address_policy, PluginNetworkAddressPolicy::PublicOnly)
+            && origin.scheme() != "https"
+        {
+            return Err(PluginNetworkError::SchemeNotAllowed);
+        }
+        Ok(Self { origin, address_policy })
+    }
+
+    pub fn origin(&self) -> &NetworkOrigin {
+        &self.origin
+    }
+
+    pub fn address_policy(&self) -> &PluginNetworkAddressPolicy {
+        &self.address_policy
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -167,6 +192,24 @@ pub struct PluginNetworkExecution {
     pub trace: PluginNetworkTrace,
 }
 
+/// 传输失败发生的阶段，不包含 URL 或请求数据。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginTransportStage {
+    ClientBuild,
+    RequestSend,
+    ResponseBody,
+}
+
+/// 从 `reqwest::Error` 提取的脱敏失败类别。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginTransportErrorKind {
+    Connect,
+    Decode,
+    Body,
+    Request,
+    Other,
+}
+
 /// 网络执行失败分类；插件策略拒绝理由仍由上层定义。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PluginNetworkError {
@@ -180,13 +223,16 @@ pub enum PluginNetworkError {
     AddressNotAllowed(IpAddr),
     EmptyDnsResult,
     TooManyDnsAddresses,
-    DnsResolutionFailed,
+    DnsResolutionFailed(std::io::ErrorKind),
     RedirectMissingLocation,
     RedirectLimitExceeded,
     ResponseTooLarge,
     ConcurrencyLimitExceeded,
     Timeout,
-    TransportFailed,
+    TransportFailed {
+        stage: PluginTransportStage,
+        kind: PluginTransportErrorKind,
+    },
 }
 
 impl fmt::Display for PluginNetworkError {
@@ -204,13 +250,17 @@ impl fmt::Display for PluginNetworkError {
             }
             Self::EmptyDnsResult => formatter.write_str("插件网络 DNS 未返回地址"),
             Self::TooManyDnsAddresses => formatter.write_str("插件网络 DNS 返回地址过多"),
-            Self::DnsResolutionFailed => formatter.write_str("插件网络 DNS 解析失败"),
+            Self::DnsResolutionFailed(kind) => {
+                write!(formatter, "插件网络 DNS 解析失败: {kind:?}")
+            }
             Self::RedirectMissingLocation => formatter.write_str("插件网络重定向缺少有效 Location"),
             Self::RedirectLimitExceeded => formatter.write_str("插件网络重定向次数超限"),
             Self::ResponseTooLarge => formatter.write_str("插件网络响应体超限"),
             Self::ConcurrencyLimitExceeded => formatter.write_str("插件网络并发已达上限"),
             Self::Timeout => formatter.write_str("插件网络请求超时"),
-            Self::TransportFailed => formatter.write_str("插件网络传输失败"),
+            Self::TransportFailed { stage, kind } => {
+                write!(formatter, "插件网络传输失败: {stage:?}/{kind:?}")
+            }
         }
     }
 }

--- a/crates/infra/src/net/plugin/mod.rs
+++ b/crates/infra/src/net/plugin/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use ipnet::IpNet;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use url::{Host, Url};
 
 pub use executor::{PluginNetworkClient, PluginNetworkExecutor};
@@ -133,12 +133,114 @@ pub enum PluginHttpMethod {
     Head,
 }
 
-/// 声明式请求。插件无法通过该类型取得底层 HTTP 客户端或 socket。
+const MAX_REQUEST_HEADERS: usize = 32;
+const MAX_HEADER_NAME_BYTES: usize = 64;
+const MAX_HEADER_VALUE_BYTES: usize = 4096;
+const MAX_HEADER_BYTES: usize = 16 * 1024;
+
+/// 经过名称白名单和资源限制校验的普通请求头。
+#[derive(Debug, Clone, Default)]
+pub struct PluginRequestHeaders {
+    values: HeaderMap,
+    bytes: usize,
+}
+
+impl PluginRequestHeaders {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, name: &str, value: &str) -> Result<(), PluginNetworkError> {
+        let name = parse_header_name(name)?;
+        if !is_allowed_regular_header(&name) {
+            return Err(PluginNetworkError::ForbiddenHeader(name.to_string()));
+        }
+        let value = parse_header_value(value)?;
+        insert_bounded_header(&mut self.values, &mut self.bytes, name, value)
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+/// 仅由宿主凭据注入层构造的敏感请求头。
+///
+/// `Debug` 输出不会包含凭据名称或内容。
+#[derive(Clone, Default)]
+pub struct PluginNetworkCredentials {
+    values: HeaderMap,
+    bytes: usize,
+}
+
+impl fmt::Debug for PluginNetworkCredentials {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PluginNetworkCredentials")
+            .field("header_count", &self.values.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PluginNetworkCredentials {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, name: &str, value: &str) -> Result<(), PluginNetworkError> {
+        let name = parse_header_name(name)?;
+        if !is_allowed_credential_header(&name) {
+            return Err(PluginNetworkError::ForbiddenHeader(name.to_string()));
+        }
+        let value = parse_header_value(value)?;
+        insert_bounded_header(&mut self.values, &mut self.bytes, name, value)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+/// 声明式请求。插件无法通过该类型取得底层 HTTP 客户端、HeaderMap 或 socket。
 #[derive(Debug, Clone)]
 pub struct PluginNetworkRequest {
-    pub method: PluginHttpMethod,
-    pub url: String,
-    pub headers: HeaderMap,
+    method: PluginHttpMethod,
+    url: String,
+    headers: PluginRequestHeaders,
+    credentials: PluginNetworkCredentials,
+}
+
+impl PluginNetworkRequest {
+    pub fn new(method: PluginHttpMethod, url: impl Into<String>) -> Self {
+        Self {
+            method,
+            url: url.into(),
+            headers: PluginRequestHeaders::new(),
+            credentials: PluginNetworkCredentials::new(),
+        }
+    }
+
+    pub fn with_headers(mut self, headers: PluginRequestHeaders) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    pub fn with_credentials(mut self, credentials: PluginNetworkCredentials) -> Self {
+        self.credentials = credentials;
+        self
+    }
+
+    pub fn method(&self) -> PluginHttpMethod {
+        self.method
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -220,6 +322,9 @@ pub enum PluginNetworkError {
     SchemeNotAllowed,
     CredentialsNotAllowed,
     ForbiddenHeader(String),
+    InvalidHeaderName,
+    InvalidHeaderValue,
+    RequestHeadersTooLarge,
     AddressNotAllowed(IpAddr),
     EmptyDnsResult,
     TooManyDnsAddresses,
@@ -245,6 +350,9 @@ impl fmt::Display for PluginNetworkError {
             Self::SchemeNotAllowed => formatter.write_str("插件网络协议不受允许"),
             Self::CredentialsNotAllowed => formatter.write_str("插件网络 URL 不允许携带凭据"),
             Self::ForbiddenHeader(name) => write!(formatter, "插件网络请求头不受允许: {name}"),
+            Self::InvalidHeaderName => formatter.write_str("插件网络请求头名称无效"),
+            Self::InvalidHeaderValue => formatter.write_str("插件网络请求头值无效"),
+            Self::RequestHeadersTooLarge => formatter.write_str("插件网络请求头超出资源限制"),
             Self::AddressNotAllowed(address) => {
                 write!(formatter, "插件网络目标地址不受允许: {address}")
             }
@@ -266,6 +374,63 @@ impl fmt::Display for PluginNetworkError {
 }
 
 impl std::error::Error for PluginNetworkError {}
+
+fn parse_header_name(value: &str) -> Result<HeaderName, PluginNetworkError> {
+    if value.is_empty() || value.len() > MAX_HEADER_NAME_BYTES {
+        return Err(PluginNetworkError::InvalidHeaderName);
+    }
+    HeaderName::from_bytes(value.as_bytes()).map_err(|_| PluginNetworkError::InvalidHeaderName)
+}
+
+fn parse_header_value(value: &str) -> Result<HeaderValue, PluginNetworkError> {
+    if value.len() > MAX_HEADER_VALUE_BYTES {
+        return Err(PluginNetworkError::RequestHeadersTooLarge);
+    }
+    HeaderValue::from_str(value).map_err(|_| PluginNetworkError::InvalidHeaderValue)
+}
+
+fn insert_bounded_header(
+    headers: &mut HeaderMap,
+    bytes: &mut usize,
+    name: HeaderName,
+    value: HeaderValue,
+) -> Result<(), PluginNetworkError> {
+    let old_bytes = headers
+        .get(&name)
+        .map_or(0, |old| name.as_str().len() + old.as_bytes().len());
+    let new_bytes = name.as_str().len() + value.as_bytes().len();
+    let next_bytes = bytes
+        .checked_sub(old_bytes)
+        .and_then(|current| current.checked_add(new_bytes))
+        .ok_or(PluginNetworkError::RequestHeadersTooLarge)?;
+    let adds_name = !headers.contains_key(&name);
+    if (adds_name && headers.len() >= MAX_REQUEST_HEADERS) || next_bytes > MAX_HEADER_BYTES {
+        return Err(PluginNetworkError::RequestHeadersTooLarge);
+    }
+    headers.insert(name, value);
+    *bytes = next_bytes;
+    Ok(())
+}
+
+fn is_allowed_regular_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "accept"
+            | "accept-language"
+            | "cache-control"
+            | "content-type"
+            | "if-match"
+            | "if-modified-since"
+            | "if-none-match"
+            | "if-unmodified-since"
+            | "pragma"
+            | "range"
+    )
+}
+
+fn is_allowed_credential_header(name: &HeaderName) -> bool {
+    matches!(name.as_str(), "authorization" | "cookie" | "x-api-key")
+}
 
 fn normalized_url_host(url: &Url) -> Option<String> {
     match url.host()? {

--- a/crates/infra/src/net/plugin/tests.rs
+++ b/crates/infra/src/net/plugin/tests.rs
@@ -1,0 +1,191 @@
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, HOST};
+use reqwest::StatusCode;
+use url::Url;
+
+use super::executor::{
+    declared_body_too_large, is_public_ip, is_redirect, parse_target, validate_address,
+    validate_headers, PluginDnsResolver,
+};
+use super::{
+    AllowedNetworkTarget, NetworkOrigin, PluginNetworkAddressPolicy, PluginNetworkClient,
+    PluginNetworkError, PluginNetworkExecutor, PluginNetworkLimits, PluginNetworkScope,
+};
+
+struct FixedResolver(Vec<IpAddr>);
+
+impl PluginDnsResolver for FixedResolver {
+    fn resolve<'a>(
+        &'a self,
+        _host: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<IpAddr>, PluginNetworkError>> {
+        Box::pin(async { Ok(self.0.clone()) })
+    }
+}
+
+fn public_scope(origin: &str) -> PluginNetworkScope {
+    PluginNetworkScope {
+        origin: NetworkOrigin::parse(origin).expect("测试 origin 应有效"),
+        address_policy: PluginNetworkAddressPolicy::PublicOnly,
+    }
+}
+
+#[test]
+fn origin_is_normalized_and_rejects_non_origin_components() {
+    let origin = NetworkOrigin::parse("https://EXAMPLE.com:443").expect("origin 应有效");
+    assert_eq!(origin.scheme(), "https");
+    assert_eq!(origin.host(), "example.com");
+    assert_eq!(origin.port(), 443);
+
+    for invalid in [
+        "ftp://example.com",
+        "https://example.com/path",
+        "https://user:secret@example.com",
+        "https://example.com?token=secret",
+        "https://example.com#fragment",
+    ] {
+        assert_eq!(
+            NetworkOrigin::parse(invalid),
+            Err(PluginNetworkError::InvalidOrigin),
+            "{invalid}"
+        );
+    }
+}
+
+#[test]
+fn target_must_stay_inside_exact_origin() {
+    let scope = public_scope("https://api.example.com");
+    assert!(parse_target("https://api.example.com/v1?q=ok", &scope).is_ok());
+    assert!(parse_target("https://api.example.com:444/v1", &scope).is_err());
+    assert!(parse_target("https://other.example.com/v1", &scope).is_err());
+    assert!(parse_target("http://api.example.com/v1", &scope).is_err());
+    assert!(parse_target("https://user@api.example.com/v1", &scope).is_err());
+}
+
+#[test]
+fn public_policy_rejects_special_use_and_mapped_addresses() {
+    for address in [
+        "0.1.2.3",
+        "10.0.0.1",
+        "100.64.0.1",
+        "127.0.0.1",
+        "169.254.169.254",
+        "172.16.0.1",
+        "192.0.2.1",
+        "192.168.1.1",
+        "198.18.0.1",
+        "198.51.100.1",
+        "203.0.113.1",
+        "224.0.0.1",
+        "::1",
+        "fc00::1",
+        "fe80::1",
+        "::ffff:127.0.0.1",
+        "64:ff9b::7f00:1",
+        "2001:db8::1",
+    ] {
+        let address: IpAddr = address.parse().expect("测试 IP 应有效");
+        assert!(!is_public_ip(address), "{address}");
+    }
+    assert!(is_public_ip("8.8.8.8".parse().expect("测试 IP 应有效")));
+    assert!(is_public_ip("2606:4700:4700::1111".parse().expect("测试 IP 应有效")));
+}
+
+#[test]
+fn private_policy_requires_explicit_target_and_keeps_hard_denials() {
+    let policy = PluginNetworkAddressPolicy::AuthenticatedOrPrivate {
+        allowed_targets: vec![AllowedNetworkTarget::Network(
+            "192.168.1.0/24".parse().expect("测试网段应有效"),
+        )],
+    };
+    assert!(validate_address("192.168.1.20".parse().expect("测试 IP 应有效"), &policy).is_ok());
+    assert!(validate_address("192.168.2.20".parse().expect("测试 IP 应有效"), &policy).is_err());
+
+    let loopback_policy = PluginNetworkAddressPolicy::AuthenticatedOrPrivate {
+        allowed_targets: vec![AllowedNetworkTarget::Network(
+            "127.0.0.0/8".parse().expect("测试网段应有效"),
+        )],
+    };
+    assert!(
+        validate_address("127.0.0.1".parse().expect("测试 IP 应有效"), &loopback_policy).is_err()
+    );
+}
+
+#[test]
+fn public_requests_reject_credentials_and_transport_headers() {
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
+    assert!(validate_headers(&headers, &PluginNetworkAddressPolicy::PublicOnly).is_err());
+
+    let mut headers = HeaderMap::new();
+    headers.insert(HOST, HeaderValue::from_static("internal.example"));
+    let private =
+        PluginNetworkAddressPolicy::AuthenticatedOrPrivate { allowed_targets: Vec::new() };
+    assert!(validate_headers(&headers, &private).is_err());
+}
+
+#[test]
+fn only_http_redirect_statuses_are_followed() {
+    for status in [301, 302, 303, 307, 308] {
+        assert!(is_redirect(StatusCode::from_u16(status).expect("测试状态码应有效")));
+    }
+    assert!(!is_redirect(StatusCode::NOT_MODIFIED));
+    assert!(!is_redirect(StatusCode::MULTIPLE_CHOICES));
+}
+
+#[test]
+fn declared_response_size_is_checked_before_streaming() {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_LENGTH, HeaderValue::from_static("1025"));
+    assert!(declared_body_too_large(&headers, 1024));
+    assert!(!declared_body_too_large(&headers, 1025));
+}
+
+#[test]
+fn executor_rejects_zero_resource_limits() {
+    let limits = PluginNetworkLimits {
+        max_response_bytes: 0,
+        ..PluginNetworkLimits::default()
+    };
+    assert!(matches!(
+        PluginNetworkExecutor::new(1, limits),
+        Err(PluginNetworkError::InvalidConfiguration)
+    ));
+    assert!(matches!(
+        PluginNetworkExecutor::new(0, PluginNetworkLimits::default()),
+        Err(PluginNetworkError::InvalidConfiguration)
+    ));
+}
+
+#[test]
+fn exact_private_target_accepts_ipv4_mapped_equivalent() {
+    let policy = PluginNetworkAddressPolicy::AuthenticatedOrPrivate {
+        allowed_targets: vec![AllowedNetworkTarget::Exact(
+            "192.168.1.20".parse().expect("测试 IP 应有效"),
+        )],
+    };
+    assert!(
+        validate_address("::ffff:192.168.1.20".parse().expect("测试 IP 应有效"), &policy).is_ok()
+    );
+}
+
+#[tokio::test]
+async fn client_rejects_dns_answer_when_any_address_is_private() {
+    let client = PluginNetworkClient::with_resolver(Arc::new(FixedResolver(vec![
+        "8.8.8.8".parse().expect("测试 IP 应有效"),
+        "192.168.1.20".parse().expect("测试 IP 应有效"),
+    ])));
+    let target = Url::parse("https://api.example.com/data").expect("测试 URL 应有效");
+
+    assert_eq!(
+        client
+            .resolve_and_validate(&target, &PluginNetworkAddressPolicy::PublicOnly)
+            .await,
+        Err(PluginNetworkError::AddressNotAllowed(
+            "192.168.1.20".parse().expect("测试 IP 应有效")
+        ))
+    );
+}

--- a/crates/infra/src/net/plugin/tests.rs
+++ b/crates/infra/src/net/plugin/tests.rs
@@ -1,4 +1,5 @@
-use std::net::IpAddr;
+use std::io::ErrorKind;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
@@ -8,7 +9,7 @@ use url::Url;
 
 use super::executor::{
     declared_body_too_large, is_public_ip, is_redirect, parse_target, validate_address,
-    validate_headers, PluginDnsResolver,
+    validate_headers, PluginDnsResolver, MAX_DNS_ADDRESSES,
 };
 use super::{
     AllowedNetworkTarget, NetworkOrigin, PluginNetworkAddressPolicy, PluginNetworkClient,
@@ -16,6 +17,8 @@ use super::{
 };
 
 struct FixedResolver(Vec<IpAddr>);
+
+struct ErrorResolver;
 
 impl PluginDnsResolver for FixedResolver {
     fn resolve<'a>(
@@ -26,11 +29,23 @@ impl PluginDnsResolver for FixedResolver {
     }
 }
 
-fn public_scope(origin: &str) -> PluginNetworkScope {
-    PluginNetworkScope {
-        origin: NetworkOrigin::parse(origin).expect("测试 origin 应有效"),
-        address_policy: PluginNetworkAddressPolicy::PublicOnly,
+impl PluginDnsResolver for ErrorResolver {
+    fn resolve<'a>(
+        &'a self,
+        _host: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<IpAddr>, PluginNetworkError>> {
+        Box::pin(async {
+            Err(PluginNetworkError::DnsResolutionFailed(ErrorKind::ConnectionAborted))
+        })
     }
+}
+
+fn public_scope(origin: &str) -> PluginNetworkScope {
+    PluginNetworkScope::new(
+        NetworkOrigin::parse(origin).expect("测试 origin 应有效"),
+        PluginNetworkAddressPolicy::PublicOnly,
+    )
+    .expect("测试作用域应有效")
 }
 
 #[test]
@@ -66,6 +81,17 @@ fn target_must_stay_inside_exact_origin() {
 }
 
 #[test]
+fn public_scope_rejects_http_origin_during_construction() {
+    assert_eq!(
+        PluginNetworkScope::new(
+            NetworkOrigin::parse("http://api.example.com").expect("HTTP origin 本身应可解析"),
+            PluginNetworkAddressPolicy::PublicOnly,
+        ),
+        Err(PluginNetworkError::SchemeNotAllowed)
+    );
+}
+
+#[test]
 fn public_policy_rejects_special_use_and_mapped_addresses() {
     for address in [
         "0.1.2.3",
@@ -92,6 +118,35 @@ fn public_policy_rejects_special_use_and_mapped_addresses() {
     }
     assert!(is_public_ip("8.8.8.8".parse().expect("测试 IP 应有效")));
     assert!(is_public_ip("2606:4700:4700::1111".parse().expect("测试 IP 应有效")));
+}
+
+#[test]
+fn public_policy_accepts_addresses_adjacent_to_excluded_networks() {
+    for address in [
+        "9.255.255.255",
+        "11.0.0.0",
+        "100.63.255.255",
+        "100.128.0.0",
+        "126.255.255.255",
+        "128.0.0.0",
+        "169.253.255.255",
+        "169.255.0.0",
+        "172.15.255.255",
+        "172.32.0.0",
+        "192.0.1.255",
+        "192.0.3.0",
+        "198.17.255.255",
+        "198.20.0.0",
+        "198.51.99.255",
+        "198.51.101.0",
+        "203.0.112.255",
+        "203.0.114.0",
+        "2001:db7:ffff:ffff:ffff:ffff:ffff:ffff",
+        "2001:db9::",
+    ] {
+        let address: IpAddr = address.parse().expect("测试 IP 应有效");
+        assert!(is_public_ip(address), "{address}");
+    }
 }
 
 #[test]
@@ -187,5 +242,47 @@ async fn client_rejects_dns_answer_when_any_address_is_private() {
         Err(PluginNetworkError::AddressNotAllowed(
             "192.168.1.20".parse().expect("测试 IP 应有效")
         ))
+    );
+}
+
+#[tokio::test]
+async fn client_rejects_empty_dns_answer() {
+    let client = PluginNetworkClient::with_resolver(Arc::new(FixedResolver(Vec::new())));
+    let target = Url::parse("https://api.example.com/data").expect("测试 URL 应有效");
+
+    assert_eq!(
+        client
+            .resolve_and_validate(&target, &PluginNetworkAddressPolicy::PublicOnly)
+            .await,
+        Err(PluginNetworkError::EmptyDnsResult)
+    );
+}
+
+#[tokio::test]
+async fn client_rejects_too_many_dns_addresses_before_address_validation() {
+    let addresses = (1..=(MAX_DNS_ADDRESSES + 1))
+        .map(|suffix| IpAddr::V4(Ipv4Addr::new(9, 9, 0, suffix as u8)))
+        .collect();
+    let client = PluginNetworkClient::with_resolver(Arc::new(FixedResolver(addresses)));
+    let target = Url::parse("https://api.example.com/data").expect("测试 URL 应有效");
+
+    assert_eq!(
+        client
+            .resolve_and_validate(&target, &PluginNetworkAddressPolicy::PublicOnly)
+            .await,
+        Err(PluginNetworkError::TooManyDnsAddresses)
+    );
+}
+
+#[tokio::test]
+async fn client_propagates_dns_resolution_error_kind() {
+    let client = PluginNetworkClient::with_resolver(Arc::new(ErrorResolver));
+    let target = Url::parse("https://api.example.com/data").expect("测试 URL 应有效");
+
+    assert_eq!(
+        client
+            .resolve_and_validate(&target, &PluginNetworkAddressPolicy::PublicOnly)
+            .await,
+        Err(PluginNetworkError::DnsResolutionFailed(ErrorKind::ConnectionAborted))
     );
 }

--- a/crates/infra/src/net/plugin/tests.rs
+++ b/crates/infra/src/net/plugin/tests.rs
@@ -3,17 +3,18 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, HOST};
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_LENGTH};
 use reqwest::StatusCode;
 use url::Url;
 
 use super::executor::{
     declared_body_too_large, is_public_ip, is_redirect, parse_target, validate_address,
-    validate_headers, PluginDnsResolver, MAX_DNS_ADDRESSES,
+    validate_request_headers, PluginDnsResolver, MAX_DNS_ADDRESSES,
 };
 use super::{
-    AllowedNetworkTarget, NetworkOrigin, PluginNetworkAddressPolicy, PluginNetworkClient,
-    PluginNetworkError, PluginNetworkExecutor, PluginNetworkLimits, PluginNetworkScope,
+    AllowedNetworkTarget, NetworkOrigin, PluginHttpMethod, PluginNetworkAddressPolicy,
+    PluginNetworkClient, PluginNetworkCredentials, PluginNetworkError, PluginNetworkExecutor,
+    PluginNetworkLimits, PluginNetworkRequest, PluginNetworkScope, PluginRequestHeaders,
 };
 
 struct FixedResolver(Vec<IpAddr>);
@@ -170,16 +171,60 @@ fn private_policy_requires_explicit_target_and_keeps_hard_denials() {
 }
 
 #[test]
-fn public_requests_reject_credentials_and_transport_headers() {
-    let mut headers = HeaderMap::new();
-    headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
-    assert!(validate_headers(&headers, &PluginNetworkAddressPolicy::PublicOnly).is_err());
+fn regular_headers_use_an_explicit_allowlist() {
+    let mut headers = PluginRequestHeaders::new();
+    assert!(headers.insert("accept", "application/json").is_ok());
+    assert_eq!(headers.len(), 1);
+    assert_eq!(
+        headers.insert("host", "internal.example"),
+        Err(PluginNetworkError::ForbiddenHeader("host".to_owned()))
+    );
+    assert_eq!(
+        headers.insert("authorization", "Bearer secret"),
+        Err(PluginNetworkError::ForbiddenHeader("authorization".to_owned()))
+    );
+}
 
-    let mut headers = HeaderMap::new();
-    headers.insert(HOST, HeaderValue::from_static("internal.example"));
-    let private =
-        PluginNetworkAddressPolicy::AuthenticatedOrPrivate { allowed_targets: Vec::new() };
-    assert!(validate_headers(&headers, &private).is_err());
+#[test]
+fn credentials_accept_only_explicit_sensitive_headers_and_redact_debug_output() {
+    let mut credentials = PluginNetworkCredentials::new();
+    assert!(credentials.insert("authorization", "Bearer secret").is_ok());
+    assert!(credentials.insert("x-api-key", "secret-key").is_ok());
+    assert_eq!(
+        credentials.insert("x-forwarded-for", "127.0.0.1"),
+        Err(PluginNetworkError::ForbiddenHeader("x-forwarded-for".to_owned()))
+    );
+    let debug = format!("{credentials:?}");
+    assert!(!debug.contains("secret"));
+    assert!(!debug.contains("authorization"));
+}
+
+#[test]
+fn request_headers_enforce_value_and_total_limits() {
+    let mut headers = PluginRequestHeaders::new();
+    assert_eq!(
+        headers.insert("accept", &"a".repeat(4097)),
+        Err(PluginNetworkError::RequestHeadersTooLarge)
+    );
+    assert_eq!(
+        headers.insert("accept", "line\r\nbreak"),
+        Err(PluginNetworkError::InvalidHeaderValue)
+    );
+}
+
+#[test]
+fn public_request_rejects_dedicated_credentials_before_transport() {
+    let mut credentials = PluginNetworkCredentials::new();
+    credentials
+        .insert("authorization", "Bearer secret")
+        .expect("测试凭据应有效");
+    let request = PluginNetworkRequest::new(PluginHttpMethod::Get, "https://api.example.com")
+        .with_credentials(credentials);
+
+    assert_eq!(
+        validate_request_headers(&request, &PluginNetworkAddressPolicy::PublicOnly),
+        Err(PluginNetworkError::CredentialsNotAllowed)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概述

为插件运行时提供独立的安全出站网络客户端与受约束执行器。上层仍负责插件能力声明、审批、信任与审计策略；本层只负责确保实际网络连接不超出已批准的 origin、地址范围和资源限制。

## 主要变更

- 新增 `PluginNetworkClient`，提供真实 HTTP(S) 出站访问能力，不暴露底层 `reqwest::Client`、请求构建器或 socket。
- 新增 `PluginNetworkExecutor`，提供进程级并发限制和统一执行限制。
- 新增强类型 `NetworkOrigin`，规范化并校验 scheme、host 与 port，拒绝凭据及非 origin 组件。
- 支持 `PublicOnly` 和 `AuthenticatedOrPrivate` 两类地址策略。
- 私网访问必须匹配上层显式批准的 IP 或 CIDR；回环、链路本地、组播等地址保持硬拒绝。
- DNS 返回的全部 A/AAAA 地址均需通过策略校验，任一地址违规即拒绝请求。
- 规范化 IPv4-mapped IPv6，避免通过映射地址绕过 IPv4 策略。
- 使用 `resolve_to_addrs` 将实际连接固定到已验证地址，避免 DNS 预检后再次解析导致的重绑定或 TOCTOU。
- 保留原始域名用于 TLS SNI、证书校验和 HTTP Host。
- 强制直连并禁用自动代理；公网模式仅允许 HTTPS。
- 禁用自动重定向，对 301、302、303、307、308 逐跳重新执行 origin、DNS 与 IP 校验。
- 限制总超时、连接超时、读取超时、重定向次数、响应体大小与并发数。
- 响应体按流式分块读取并实施硬上限，避免先完整聚合后检查。
- 返回不包含请求凭据、查询参数或响应正文的结构化执行轨迹。
- `PluginNetworkScope::new` 在构造阶段拒绝 `PublicOnly` 与 HTTP origin 的错误组合。
- DNS 与传输错误保留脱敏的错误类别及执行阶段，提升可观测性而不泄露请求 URL。

## 请求头安全边界

- 公开请求模型不再暴露 `HeaderMap`，改用字段私有的 `PluginRequestHeaders` 与 `PluginNetworkCredentials`。
- 普通请求头采用明确白名单，仅允许内容协商、条件请求、缓存控制和 Range 等安全用途。
- `Authorization`、`Cookie` 和 `X-API-Key` 只能通过专用凭据容器注入。
- `Host`、hop-by-hop、代理和转发类请求头不能通过公开 API 构造。
- 请求头名称长度、单值长度、数量和总字节数均有硬限制。
- `PublicOnly` 作用域携带任何专用凭据都会在 DNS 和网络传输前被拒绝。
- 凭据容器的 `Debug` 输出只显示数量，不输出凭据名称或内容。

## 安全边界

本 PR 不负责：

- 插件身份与 capability 声明；
- 用户审批和 session grant；
- 插件信任判断；
- 插件级限流及审计持久化；
- 启用 `network.request.authenticated_private`。

这些决策仍由 `core/application/plugin-runtime` 完成，并将已批准的精确作用域传给本层执行。

## 验证

- `cargo test -p sealantern-infra --all-features --locked net::plugin`：18 项通过。
- `cargo test -p sealantern-infra --all-features --locked`：此前 145 项通过。
- `cargo check -p sealantern-infra --all-features --locked`：通过。
- `cargo clippy -p sealantern-infra --all-targets --all-features --locked -- -D warnings`：通过。

## Stack

- GitHub Stack：#922
- 位置：第 5 层
- 依赖：#936 `refactor(network): 支持代理更新预提交`
