### PR TITLE
feat(network): 同步持久化代理运行时

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5223,6 +5223,7 @@ dependencies = [
  "sealantern-extra",
  "sealantern-infra",
  "sealantern-interface",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 async-trait = "0.1.91"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "sync", "fs", "time"] }
 tracing = "0.1"
+serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 sealantern-core = { path = "../crates/core" }

--- a/application/src/error/settings.rs
+++ b/application/src/error/settings.rs
@@ -3,6 +3,8 @@
 use std::fmt;
 
 use sealantern_extra::config::SettingsError as ExtraSettingsError;
+use sealantern_infra::net::{NetError, NetworkCommitError};
+use sealantern_infra::platform::SystemProxyReadError;
 use sealantern_interface::error::SettingsServiceError;
 
 /// 设置服务主错误类型。
@@ -26,6 +28,11 @@ pub enum SettingsError {
         /// 底层来源错误。
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    /// 持久化代理设置与进程网络运行时同步失败。
+    NetworkSyncFailed {
+        /// 不包含代理凭据的底层失败。
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 impl fmt::Display for SettingsError {
@@ -40,6 +47,9 @@ impl fmt::Display for SettingsError {
             Self::OperationFailed { source } => {
                 write!(formatter, "settings operation failed: {source}")
             }
+            Self::NetworkSyncFailed { source } => {
+                write!(formatter, "settings network synchronization failed: {source}")
+            }
         }
     }
 }
@@ -49,8 +59,28 @@ impl std::error::Error for SettingsError {
         match self {
             Self::InvalidInput { source } => Some(source),
             Self::StorageFailed { source } => Some(source),
-            Self::OperationFailed { source } => Some(source.as_ref()),
+            Self::OperationFailed { source } | Self::NetworkSyncFailed { source } => {
+                Some(source.as_ref())
+            }
         }
+    }
+}
+
+impl From<NetError> for SettingsError {
+    fn from(source: NetError) -> Self {
+        Self::NetworkSyncFailed { source: Box::new(source) }
+    }
+}
+
+impl From<NetworkCommitError> for SettingsError {
+    fn from(source: NetworkCommitError) -> Self {
+        Self::NetworkSyncFailed { source: Box::new(source) }
+    }
+}
+
+impl From<SystemProxyReadError> for SettingsError {
+    fn from(source: SystemProxyReadError) -> Self {
+        Self::NetworkSyncFailed { source: Box::new(source) }
     }
 }
 
@@ -72,6 +102,7 @@ impl From<SettingsError> for SettingsServiceError {
             SettingsError::InvalidInput { .. } => Self::InvalidInput,
             SettingsError::StorageFailed { .. } => Self::StorageFailed,
             SettingsError::OperationFailed { .. } => Self::OperationFailed,
+            SettingsError::NetworkSyncFailed { .. } => Self::Unavailable,
         }
     }
 }

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -7,6 +7,7 @@
 mod cron;
 mod download;
 mod instance;
+mod network_settings;
 mod server;
 mod settings;
 mod system;

--- a/application/src/service/network_settings.rs
+++ b/application/src/service/network_settings.rs
@@ -1,0 +1,176 @@
+//! 持久化代理设置与进程级网络运行时之间的同步边界。
+
+use sealantern_infra::net::proxy::{ProxyMode, ProxySettings};
+use sealantern_infra::net::{
+    commit_prepared_proxy_update, prepare_proxy_settings, NetworkCommitError,
+    PreparedNetworkUpdate, SystemProxySnapshot,
+};
+use sealantern_infra::platform::current_system_proxy;
+
+use crate::error::SettingsError;
+
+const MAX_COMMIT_ATTEMPTS: usize = 3;
+
+pub(super) trait PreparedProxyUpdate: Send {
+    fn commit(self: Box<Self>) -> Result<(), NetworkCommitError>;
+}
+
+pub(super) trait NetworkSettingsRuntime: Send + Sync {
+    fn prepare(
+        &self,
+        settings: ProxySettings,
+    ) -> Result<Box<dyn PreparedProxyUpdate>, SettingsError>;
+}
+
+#[derive(Default)]
+pub(super) struct GlobalNetworkSettingsRuntime;
+
+struct GlobalPreparedProxyUpdate(PreparedNetworkUpdate);
+
+impl PreparedProxyUpdate for GlobalPreparedProxyUpdate {
+    fn commit(self: Box<Self>) -> Result<(), NetworkCommitError> {
+        commit_prepared_proxy_update(self.0).map(|_| ())
+    }
+}
+
+impl NetworkSettingsRuntime for GlobalNetworkSettingsRuntime {
+    fn prepare(
+        &self,
+        settings: ProxySettings,
+    ) -> Result<Box<dyn PreparedProxyUpdate>, SettingsError> {
+        let system_proxy = match &settings.mode {
+            ProxyMode::Adaptive | ProxyMode::Preserve => current_system_proxy()?,
+            ProxyMode::Manual { .. } | ProxyMode::Disabled => SystemProxySnapshot::direct(),
+        };
+        let prepared = prepare_proxy_settings(settings, system_proxy)?;
+        Ok(Box::new(GlobalPreparedProxyUpdate(prepared)))
+    }
+}
+
+/// 提交持久化前准备的候选；revision 冲突时基于已持久化设置有界重试。
+pub(super) fn commit_persisted_proxy(
+    runtime: &dyn NetworkSettingsRuntime,
+    mut prepared: Box<dyn PreparedProxyUpdate>,
+    persisted: ProxySettings,
+) -> Result<(), SettingsError> {
+    for attempt in 0..MAX_COMMIT_ATTEMPTS {
+        match prepared.commit() {
+            Ok(()) => return Ok(()),
+            Err(error @ NetworkCommitError::RuntimeUnavailable) => return Err(error.into()),
+            Err(error @ NetworkCommitError::Conflict { .. }) => {
+                if attempt + 1 == MAX_COMMIT_ATTEMPTS {
+                    return Err(error.into());
+                }
+                prepared = runtime.prepare(persisted.clone())?;
+            }
+        }
+    }
+    unreachable!("提交尝试次数至少为一")
+}
+
+#[cfg(test)]
+pub(super) struct NoopNetworkSettingsRuntime;
+
+#[cfg(test)]
+struct NoopPreparedProxyUpdate;
+
+#[cfg(test)]
+impl PreparedProxyUpdate for NoopPreparedProxyUpdate {
+    fn commit(self: Box<Self>) -> Result<(), NetworkCommitError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl NetworkSettingsRuntime for NoopNetworkSettingsRuntime {
+    fn prepare(
+        &self,
+        _settings: ProxySettings,
+    ) -> Result<Box<dyn PreparedProxyUpdate>, SettingsError> {
+        Ok(Box::new(NoopPreparedProxyUpdate))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use sealantern_infra::net::proxy::ProxySettings;
+
+    use super::*;
+
+    struct FakePrepared {
+        outcomes: Arc<Mutex<VecDeque<Result<(), NetworkCommitError>>>>,
+    }
+
+    impl PreparedProxyUpdate for FakePrepared {
+        fn commit(self: Box<Self>) -> Result<(), NetworkCommitError> {
+            self.outcomes
+                .lock()
+                .expect("测试提交结果锁不应污染")
+                .pop_front()
+                .expect("测试应提供提交结果")
+        }
+    }
+
+    struct FakeRuntime {
+        prepare_count: Arc<Mutex<usize>>,
+        outcomes: Arc<Mutex<VecDeque<Result<(), NetworkCommitError>>>>,
+    }
+
+    impl NetworkSettingsRuntime for FakeRuntime {
+        fn prepare(
+            &self,
+            _settings: ProxySettings,
+        ) -> Result<Box<dyn PreparedProxyUpdate>, SettingsError> {
+            *self.prepare_count.lock().expect("测试准备计数锁不应污染") += 1;
+            Ok(Box::new(FakePrepared { outcomes: self.outcomes.clone() }))
+        }
+    }
+
+    #[test]
+    fn commit_reprepares_after_revision_conflict() {
+        let prepare_count = Arc::new(Mutex::new(0));
+        let outcomes = Arc::new(Mutex::new(VecDeque::from([
+            Err(NetworkCommitError::Conflict { expected_revision: 1, actual_revision: 2 }),
+            Ok(()),
+        ])));
+        let runtime = FakeRuntime {
+            prepare_count: prepare_count.clone(),
+            outcomes: outcomes.clone(),
+        };
+        let initial = runtime
+            .prepare(ProxySettings::default())
+            .expect("初次准备应成功");
+
+        commit_persisted_proxy(&runtime, initial, ProxySettings::default())
+            .expect("冲突后应重新准备并提交");
+
+        assert_eq!(*prepare_count.lock().expect("测试准备计数锁不应污染"), 2);
+        assert!(outcomes.lock().expect("测试提交结果锁不应污染").is_empty());
+    }
+
+    #[test]
+    fn commit_stops_after_bounded_conflicts() {
+        let prepare_count = Arc::new(Mutex::new(0));
+        let outcomes = Arc::new(Mutex::new(VecDeque::from([
+            Err(NetworkCommitError::Conflict { expected_revision: 1, actual_revision: 2 }),
+            Err(NetworkCommitError::Conflict { expected_revision: 2, actual_revision: 3 }),
+            Err(NetworkCommitError::Conflict { expected_revision: 3, actual_revision: 4 }),
+        ])));
+        let runtime = FakeRuntime {
+            prepare_count: prepare_count.clone(),
+            outcomes,
+        };
+        let initial = runtime
+            .prepare(ProxySettings::default())
+            .expect("初次准备应成功");
+
+        assert!(matches!(
+            commit_persisted_proxy(&runtime, initial, ProxySettings::default()),
+            Err(SettingsError::NetworkSyncFailed { .. })
+        ));
+        assert_eq!(*prepare_count.lock().expect("测试准备计数锁不应污染"), 3);
+    }
+}

--- a/application/src/service/settings.rs
+++ b/application/src/service/settings.rs
@@ -7,6 +7,9 @@
 //! [`SettingsService`] 时统一转为接口契约错误 [`SettingsServiceError`]。
 
 use async_trait::async_trait;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use sealantern_extra::config::SettingsManager;
 use sealantern_extra::models::{
     AppSettings, PartialAppSettings, UpdateResult, DEFAULT_ACRYLIC_BLUR_LEVEL,
@@ -17,36 +20,138 @@ use sealantern_interface::settings::{
 use sealantern_interface::{SettingsService, SettingsServiceError};
 
 use crate::error::SettingsError;
+use crate::service::network_settings::{
+    commit_persisted_proxy, GlobalNetworkSettingsRuntime, NetworkSettingsRuntime,
+    PreparedProxyUpdate,
+};
 
 /// 基于 `extra` 配置管理的设置服务实现。
 pub struct CoreSettingsService {
     /// 惰性加载的唯一设置管理器；首次真实配置操作时初始化。
     manager: tokio::sync::OnceCell<tokio::sync::Mutex<SettingsManager>>,
+    /// 持久化代理设置只向网络运行时初始化一次；失败后允许重试。
+    network_initialized: tokio::sync::OnceCell<()>,
+    /// 持久化成功但运行时提交失败时，下一次操作先修复同步。
+    network_desynchronized: AtomicBool,
+    network_runtime: Arc<dyn NetworkSettingsRuntime>,
 }
 
 impl CoreSettingsService {
     /// 创建使用默认配置位置的惰性设置服务。
     pub fn new() -> Self {
-        Self { manager: tokio::sync::OnceCell::new() }
+        Self {
+            manager: tokio::sync::OnceCell::new(),
+            network_initialized: tokio::sync::OnceCell::new(),
+            network_desynchronized: AtomicBool::new(false),
+            network_runtime: Arc::new(GlobalNetworkSettingsRuntime),
+        }
     }
 
     /// 使用既有设置管理器构造服务，供测试和受控注入使用。
     pub fn with_manager(manager: SettingsManager) -> Self {
         Self {
             manager: tokio::sync::OnceCell::new_with(Some(tokio::sync::Mutex::new(manager))),
+            network_initialized: tokio::sync::OnceCell::new(),
+            network_desynchronized: AtomicBool::new(false),
+            network_runtime: Arc::new(GlobalNetworkSettingsRuntime),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_manager_and_runtime(
+        manager: SettingsManager,
+        network_runtime: Arc<dyn NetworkSettingsRuntime>,
+    ) -> Self {
+        Self {
+            manager: tokio::sync::OnceCell::new_with(Some(tokio::sync::Mutex::new(manager))),
+            network_initialized: tokio::sync::OnceCell::new(),
+            network_desynchronized: AtomicBool::new(false),
+            network_runtime,
         }
     }
 
     /// 获取设置管理器；并发首次调用只执行一次初始化，失败后允许重试。
     async fn manager(&self) -> Result<&tokio::sync::Mutex<SettingsManager>, SettingsError> {
-        self.manager
+        let manager = self
+            .manager
             .get_or_try_init(|| async {
                 SettingsManager::load_default()
                     .await
                     .map(tokio::sync::Mutex::new)
                     .map_err(SettingsError::from)
             })
-            .await
+            .await?;
+        self.network_initialized
+            .get_or_try_init(|| async {
+                let proxy = manager.lock().await.get().proxy.clone();
+                let prepared = self.network_runtime.prepare(proxy.clone())?;
+                commit_persisted_proxy(self.network_runtime.as_ref(), prepared, proxy)?;
+                Ok::<(), SettingsError>(())
+            })
+            .await?;
+        Ok(manager)
+    }
+
+    /// 加载持久化设置并同步代理运行时，供网络消费者建立启动屏障。
+    pub async fn initialize(&self) -> Result<(), SettingsServiceError> {
+        let manager = self.manager().await.map_err(Self::contract_error)?;
+        let manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)
+    }
+
+    fn repair_network_if_needed(&self, settings: &AppSettings) -> Result<(), SettingsError> {
+        if !self.network_desynchronized.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let proxy = settings.proxy.clone();
+        let prepared = self.network_runtime.prepare(proxy.clone())?;
+        commit_persisted_proxy(self.network_runtime.as_ref(), prepared, proxy)?;
+        self.network_desynchronized.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn prepare_proxy_change(
+        &self,
+        current: &AppSettings,
+        candidate: &AppSettings,
+    ) -> Result<Option<Box<dyn PreparedProxyUpdate>>, SettingsError> {
+        if current.proxy == candidate.proxy {
+            return Ok(None);
+        }
+        self.network_runtime
+            .prepare(candidate.proxy.clone())
+            .map(Some)
+    }
+
+    fn commit_proxy_change(
+        &self,
+        prepared: Option<Box<dyn PreparedProxyUpdate>>,
+        result: &UpdateResult,
+    ) -> Result<(), SettingsError> {
+        if !result
+            .changed_groups
+            .contains(&sealantern_extra::models::SettingsGroup::Network)
+        {
+            return Ok(());
+        }
+        let prepared = prepared.ok_or_else(|| SettingsError::OperationFailed {
+            source: Box::new(std::io::Error::other("网络设置发生未准备的并发变更")),
+        })?;
+        self.commit_prepared_persisted_proxy(prepared, result.settings.proxy.clone())
+    }
+
+    fn commit_prepared_persisted_proxy(
+        &self,
+        prepared: Box<dyn PreparedProxyUpdate>,
+        persisted: sealantern_infra::net::proxy::ProxySettings,
+    ) -> Result<(), SettingsError> {
+        self.network_desynchronized.store(true, Ordering::Release);
+        let result = commit_persisted_proxy(self.network_runtime.as_ref(), prepared, persisted);
+        if result.is_ok() {
+            self.network_desynchronized.store(false, Ordering::Release);
+        }
+        result
     }
 
     /// 将应用层设置错误记录并收敛为宿主契约错误。
@@ -102,18 +207,32 @@ impl SettingsService for CoreSettingsService {
     async fn get(&self) -> Result<AppSettings, SettingsServiceError> {
         let manager = self.manager().await.map_err(Self::contract_error)?;
         let manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)?;
         Ok(manager.get().clone())
     }
 
     async fn update(&self, settings: AppSettings) -> Result<UpdateResult, SettingsServiceError> {
         let manager = self.manager().await.map_err(Self::contract_error)?;
-        manager
-            .lock()
-            .await
+        settings
+            .validate()
+            .map_err(sealantern_extra::config::SettingsError::from)
+            .map_err(SettingsError::from)
+            .map_err(Self::contract_error)?;
+        let mut manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)?;
+        let prepared = self
+            .prepare_proxy_change(manager.get(), &settings)
+            .map_err(Self::contract_error)?;
+        let result = manager
             .update(settings)
             .await
             .map_err(SettingsError::from)
-            .map_err(Self::contract_error)
+            .map_err(Self::contract_error)?;
+        self.commit_proxy_change(prepared, &result)
+            .map_err(Self::contract_error)?;
+        Ok(result)
     }
 
     async fn update_partial(
@@ -121,31 +240,60 @@ impl SettingsService for CoreSettingsService {
         partial: PartialAppSettings,
     ) -> Result<UpdateResult, SettingsServiceError> {
         let manager = self.manager().await.map_err(Self::contract_error)?;
-        manager
-            .lock()
-            .await
+        let mut manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)?;
+        let prepared = match partial.proxy.as_ref() {
+            Some(proxy) => Some(
+                self.network_runtime
+                    .prepare(proxy.clone())
+                    .map_err(Self::contract_error)?,
+            ),
+            _ => None,
+        };
+        let result = manager
             .update_partial(partial)
             .await
             .map_err(SettingsError::from)
-            .map_err(Self::contract_error)
+            .map_err(Self::contract_error)?;
+        self.commit_proxy_change(prepared, &result)
+            .map_err(Self::contract_error)?;
+        Ok(result)
     }
 
     async fn reset(&self) -> Result<AppSettings, SettingsServiceError> {
         let manager = self.manager().await.map_err(Self::contract_error)?;
-        manager
-            .lock()
-            .await
+        let mut manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)?;
+        let default = AppSettings::default();
+        let prepared = self
+            .prepare_proxy_change(manager.get(), &default)
+            .map_err(Self::contract_error)?;
+        let previous_proxy = manager.get().proxy.clone();
+        let settings = manager
             .reset()
             .await
             .map_err(SettingsError::from)
-            .map_err(Self::contract_error)
+            .map_err(Self::contract_error)?;
+        if settings.proxy != previous_proxy {
+            let prepared = prepared.ok_or_else(|| {
+                Self::contract_error(SettingsError::OperationFailed {
+                    source: Box::new(std::io::Error::other("网络设置发生未准备的重置")),
+                })
+            })?;
+            self.commit_prepared_persisted_proxy(prepared, settings.proxy.clone())
+                .map_err(Self::contract_error)?;
+        }
+        Ok(settings)
     }
 
     async fn export_json(&self) -> Result<String, SettingsServiceError> {
         let manager = self.manager().await.map_err(Self::contract_error)?;
+        let manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)?;
         manager
-            .lock()
-            .await
             .export_json()
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)
@@ -153,13 +301,33 @@ impl SettingsService for CoreSettingsService {
 
     async fn import_json(&self, json: &str) -> Result<UpdateResult, SettingsServiceError> {
         let manager = self.manager().await.map_err(Self::contract_error)?;
-        manager
-            .lock()
-            .await
+        let candidate: AppSettings = serde_json::from_str(json).map_err(|error| {
+            Self::contract_error(SettingsError::InvalidInput {
+                source: sealantern_extra::config::SettingsError::invalid_input(
+                    "json",
+                    error.to_string(),
+                ),
+            })
+        })?;
+        candidate
+            .validate()
+            .map_err(sealantern_extra::config::SettingsError::from)
+            .map_err(SettingsError::from)
+            .map_err(Self::contract_error)?;
+        let mut manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())
+            .map_err(Self::contract_error)?;
+        let prepared = self
+            .prepare_proxy_change(manager.get(), &candidate)
+            .map_err(Self::contract_error)?;
+        let result = manager
             .import_json(json)
             .await
             .map_err(SettingsError::from)
-            .map_err(Self::contract_error)
+            .map_err(Self::contract_error)?;
+        self.commit_proxy_change(prepared, &result)
+            .map_err(Self::contract_error)?;
+        Ok(result)
     }
 }
 
@@ -576,8 +744,110 @@ fn build_developer_group() -> SettingsGroupInfo {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex as StdMutex;
+
     use super::*;
     use sealantern_extra::models::SettingsGroup;
+    use sealantern_infra::net::proxy::{ProxyMode, ProxySettings};
+    use sealantern_infra::net::NetworkCommitError;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum NetworkEvent {
+        Prepare(ProxySettings),
+        Commit,
+    }
+
+    struct RecordingPrepared {
+        events: Arc<StdMutex<Vec<NetworkEvent>>>,
+        outcome: Result<(), NetworkCommitError>,
+    }
+
+    impl PreparedProxyUpdate for RecordingPrepared {
+        fn commit(self: Box<Self>) -> Result<(), NetworkCommitError> {
+            self.events
+                .lock()
+                .expect("测试事件锁不应污染")
+                .push(NetworkEvent::Commit);
+            self.outcome
+        }
+    }
+
+    struct RecordingRuntime {
+        events: Arc<StdMutex<Vec<NetworkEvent>>>,
+        prepare_results: StdMutex<VecDeque<Result<(), &'static str>>>,
+        commit_results: StdMutex<VecDeque<Result<(), NetworkCommitError>>>,
+    }
+
+    impl RecordingRuntime {
+        fn successful() -> (Arc<Self>, Arc<StdMutex<Vec<NetworkEvent>>>) {
+            let events = Arc::new(StdMutex::new(Vec::new()));
+            (
+                Arc::new(Self {
+                    events: events.clone(),
+                    prepare_results: StdMutex::new(VecDeque::new()),
+                    commit_results: StdMutex::new(VecDeque::new()),
+                }),
+                events,
+            )
+        }
+
+        fn fail_next_prepare(&self) {
+            self.prepare_results
+                .lock()
+                .expect("测试准备结果锁不应污染")
+                .push_back(Err("synthetic prepare failure"));
+        }
+
+        fn push_commit_result(&self, result: Result<(), NetworkCommitError>) {
+            self.commit_results
+                .lock()
+                .expect("测试提交结果锁不应污染")
+                .push_back(result);
+        }
+    }
+
+    impl NetworkSettingsRuntime for RecordingRuntime {
+        fn prepare(
+            &self,
+            settings: ProxySettings,
+        ) -> Result<Box<dyn PreparedProxyUpdate>, SettingsError> {
+            self.events
+                .lock()
+                .expect("测试事件锁不应污染")
+                .push(NetworkEvent::Prepare(settings));
+            if let Some(Err(message)) = self
+                .prepare_results
+                .lock()
+                .expect("测试准备结果锁不应污染")
+                .pop_front()
+            {
+                return Err(SettingsError::OperationFailed {
+                    source: Box::new(std::io::Error::other(message)),
+                });
+            }
+            Ok(Box::new(RecordingPrepared {
+                events: self.events.clone(),
+                outcome: self
+                    .commit_results
+                    .lock()
+                    .expect("测试提交结果锁不应污染")
+                    .pop_front()
+                    .unwrap_or(Ok(())),
+            }))
+        }
+    }
+
+    async fn recording_service(
+        path: &std::path::Path,
+    ) -> (CoreSettingsService, Arc<RecordingRuntime>, Arc<StdMutex<Vec<NetworkEvent>>>) {
+        let manager = SettingsManager::load(path).await.expect("设置管理器应加载");
+        let (runtime, events) = RecordingRuntime::successful();
+        let service = CoreSettingsService::with_manager_and_runtime(manager, runtime.clone());
+        service.get().await.expect("首次代理同步应成功");
+        events.lock().expect("测试事件锁不应污染").clear();
+        (service, runtime, events)
+    }
 
     #[tokio::test]
     async fn overview_does_not_initialize_settings_manager() {
@@ -600,7 +870,10 @@ mod tests {
         let manager = SettingsManager::load(&path)
             .await
             .expect("settings manager should load");
-        let service = CoreSettingsService::with_manager(manager);
+        let service = CoreSettingsService::with_manager_and_runtime(
+            manager,
+            Arc::new(crate::service::network_settings::NoopNetworkSettingsRuntime),
+        );
 
         let initial = service
             .get()
@@ -657,5 +930,150 @@ mod tests {
             .expect("persisted settings should reload");
         assert_eq!(reloaded.get().theme, "dark");
         assert_eq!(reloaded.get().default_port, 25566);
+    }
+
+    #[tokio::test]
+    async fn proxy_update_prepares_before_persisting_and_commits_after_success() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let (service, _runtime, events) = recording_service(&path).await;
+        let mut settings = service.get().await.expect("设置应可读取");
+        settings.proxy = ProxySettings { mode: ProxyMode::Disabled };
+
+        let result = service.update(settings).await.expect("代理设置更新应成功");
+
+        assert!(result.changed_groups.contains(&SettingsGroup::Network));
+        assert_eq!(
+            *events.lock().expect("测试事件锁不应污染"),
+            vec![
+                NetworkEvent::Prepare(ProxySettings { mode: ProxyMode::Disabled }),
+                NetworkEvent::Commit,
+            ]
+        );
+        let persisted = SettingsManager::load(&path)
+            .await
+            .expect("持久化设置应可重载");
+        assert_eq!(persisted.get().proxy.mode, ProxyMode::Disabled);
+    }
+
+    #[tokio::test]
+    async fn proxy_prepare_failure_does_not_persist_settings() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let (service, runtime, events) = recording_service(&path).await;
+        runtime.fail_next_prepare();
+        let mut settings = service.get().await.expect("设置应可读取");
+        settings.proxy = ProxySettings { mode: ProxyMode::Disabled };
+
+        assert!(matches!(
+            service.update(settings).await,
+            Err(SettingsServiceError::OperationFailed)
+        ));
+
+        assert_eq!(events.lock().expect("测试事件锁不应污染").len(), 1);
+        let persisted = SettingsManager::load(&path).await.expect("原设置应可重载");
+        assert_eq!(persisted.get().proxy, ProxySettings::default());
+    }
+
+    #[tokio::test]
+    async fn persistence_failure_does_not_commit_prepared_proxy() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let (service, _runtime, events) = recording_service(&path).await;
+        std::fs::remove_file(&path).expect("测试设置文件应可删除");
+        std::fs::create_dir(&path).expect("测试设置路径应可替换为目录");
+        let mut settings = service.get().await.expect("内存设置应可读取");
+        settings.proxy = ProxySettings { mode: ProxyMode::Disabled };
+
+        assert!(matches!(
+            service.update(settings).await,
+            Err(SettingsServiceError::StorageFailed)
+        ));
+
+        assert_eq!(
+            *events.lock().expect("测试事件锁不应污染"),
+            vec![NetworkEvent::Prepare(ProxySettings { mode: ProxyMode::Disabled })]
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_reset_and_import_synchronize_proxy_changes() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let (service, _runtime, events) = recording_service(&path).await;
+
+        service
+            .update_partial(PartialAppSettings {
+                proxy: Some(ProxySettings { mode: ProxyMode::Disabled }),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("部分代理更新应成功");
+        assert_eq!(events.lock().expect("测试事件锁不应污染").len(), 2);
+
+        events.lock().expect("测试事件锁不应污染").clear();
+        service.reset().await.expect("重置应成功");
+        assert_eq!(events.lock().expect("测试事件锁不应污染").len(), 2);
+
+        events.lock().expect("测试事件锁不应污染").clear();
+        let mut imported = service.get().await.expect("设置应可读取");
+        imported.proxy = ProxySettings { mode: ProxyMode::Disabled };
+        let json = serde_json::to_string(&imported).expect("测试设置应可序列化");
+        service.import_json(&json).await.expect("导入应成功");
+        assert_eq!(events.lock().expect("测试事件锁不应污染").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn network_settings_initialize_only_once_for_all_settings_operations() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let manager = SettingsManager::load(&path)
+            .await
+            .expect("设置管理器应加载");
+        let (runtime, events) = RecordingRuntime::successful();
+        let service = CoreSettingsService::with_manager_and_runtime(manager, runtime);
+
+        service.initialize().await.expect("显式初始化应成功");
+        service.get().await.expect("后续读取应成功");
+        service.initialize().await.expect("重复初始化应成功");
+
+        assert_eq!(
+            *events.lock().expect("测试事件锁不应污染"),
+            vec![NetworkEvent::Prepare(ProxySettings::default()), NetworkEvent::Commit,]
+        );
+    }
+
+    #[tokio::test]
+    async fn later_operation_repairs_runtime_after_persisted_commit_conflicts() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let (service, runtime, events) = recording_service(&path).await;
+        for revision in 1..=3 {
+            runtime.push_commit_result(Err(NetworkCommitError::Conflict {
+                expected_revision: revision,
+                actual_revision: revision + 1,
+            }));
+        }
+        let mut settings = service.get().await.expect("设置应可读取");
+        settings.proxy = ProxySettings { mode: ProxyMode::Disabled };
+
+        assert!(matches!(service.update(settings).await, Err(SettingsServiceError::Unavailable)));
+        let persisted = SettingsManager::load(&path)
+            .await
+            .expect("已持久化设置应可重载");
+        assert_eq!(persisted.get().proxy.mode, ProxyMode::Disabled);
+
+        let repaired = service.get().await.expect("后续读取应先修复运行时同步");
+        assert_eq!(repaired.proxy.mode, ProxyMode::Disabled);
+        assert!(!service.network_desynchronized.load(Ordering::Acquire));
+        assert_eq!(
+            events
+                .lock()
+                .expect("测试事件锁不应污染")
+                .iter()
+                .filter(|event| matches!(event, NetworkEvent::Commit))
+                .count(),
+            4
+        );
     }
 }

--- a/application/src/service/settings.rs
+++ b/application/src/service/settings.rs
@@ -94,10 +94,19 @@ impl CoreSettingsService {
 
     /// 加载持久化设置并同步代理运行时，供网络消费者建立启动屏障。
     pub async fn initialize(&self) -> Result<(), SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
-        let manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        self.lock_synchronized_manager()
+            .await
+            .map(|_| ())
             .map_err(Self::contract_error)
+    }
+
+    async fn lock_synchronized_manager(
+        &self,
+    ) -> Result<tokio::sync::MutexGuard<'_, SettingsManager>, SettingsError> {
+        let manager = self.manager().await?;
+        let manager = manager.lock().await;
+        self.repair_network_if_needed(manager.get())?;
+        Ok(manager)
     }
 
     fn repair_network_if_needed(&self, settings: &AppSettings) -> Result<(), SettingsError> {
@@ -127,18 +136,20 @@ impl CoreSettingsService {
     fn commit_proxy_change(
         &self,
         prepared: Option<Box<dyn PreparedProxyUpdate>>,
-        result: &UpdateResult,
+        previous: &sealantern_infra::net::proxy::ProxySettings,
+        persisted: &sealantern_infra::net::proxy::ProxySettings,
     ) -> Result<(), SettingsError> {
-        if !result
-            .changed_groups
-            .contains(&sealantern_extra::models::SettingsGroup::Network)
-        {
+        if previous == persisted {
             return Ok(());
         }
-        let prepared = prepared.ok_or_else(|| SettingsError::OperationFailed {
-            source: Box::new(std::io::Error::other("网络设置发生未准备的并发变更")),
-        })?;
-        self.commit_prepared_persisted_proxy(prepared, result.settings.proxy.clone())
+        // 部分更新会在配置锁内重读磁盘。若其他进程刚修改了代理，本次调用即使
+        // 没携带 proxy，也可能观察到真实的 Network 变更；此时应按最终持久化值
+        // 重新准备，而不是把正常的跨进程合并误报为内部不变量错误。
+        let prepared = match prepared {
+            Some(prepared) => prepared,
+            None => self.network_runtime.prepare(persisted.clone())?,
+        };
+        self.commit_prepared_persisted_proxy(prepared, persisted.clone())
     }
 
     fn commit_prepared_persisted_proxy(
@@ -205,23 +216,24 @@ impl SettingsService for CoreSettingsService {
     }
 
     async fn get(&self) -> Result<AppSettings, SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
-        let manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        let manager = self
+            .lock_synchronized_manager()
+            .await
             .map_err(Self::contract_error)?;
         Ok(manager.get().clone())
     }
 
     async fn update(&self, settings: AppSettings) -> Result<UpdateResult, SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
         settings
             .validate()
             .map_err(sealantern_extra::config::SettingsError::from)
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)?;
-        let mut manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        let mut manager = self
+            .lock_synchronized_manager()
+            .await
             .map_err(Self::contract_error)?;
+        let previous_proxy = manager.get().proxy.clone();
         let prepared = self
             .prepare_proxy_change(manager.get(), &settings)
             .map_err(Self::contract_error)?;
@@ -230,7 +242,7 @@ impl SettingsService for CoreSettingsService {
             .await
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)?;
-        self.commit_proxy_change(prepared, &result)
+        self.commit_proxy_change(prepared, &previous_proxy, &result.settings.proxy)
             .map_err(Self::contract_error)?;
         Ok(result)
     }
@@ -239,10 +251,11 @@ impl SettingsService for CoreSettingsService {
         &self,
         partial: PartialAppSettings,
     ) -> Result<UpdateResult, SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
-        let mut manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        let mut manager = self
+            .lock_synchronized_manager()
+            .await
             .map_err(Self::contract_error)?;
+        let previous_proxy = manager.get().proxy.clone();
         let prepared = match partial.proxy.as_ref() {
             Some(proxy) => Some(
                 self.network_runtime
@@ -256,15 +269,15 @@ impl SettingsService for CoreSettingsService {
             .await
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)?;
-        self.commit_proxy_change(prepared, &result)
+        self.commit_proxy_change(prepared, &previous_proxy, &result.settings.proxy)
             .map_err(Self::contract_error)?;
         Ok(result)
     }
 
     async fn reset(&self) -> Result<AppSettings, SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
-        let mut manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        let mut manager = self
+            .lock_synchronized_manager()
+            .await
             .map_err(Self::contract_error)?;
         let default = AppSettings::default();
         let prepared = self
@@ -277,11 +290,13 @@ impl SettingsService for CoreSettingsService {
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)?;
         if settings.proxy != previous_proxy {
-            let prepared = prepared.ok_or_else(|| {
-                Self::contract_error(SettingsError::OperationFailed {
-                    source: Box::new(std::io::Error::other("网络设置发生未准备的重置")),
-                })
-            })?;
+            let prepared = match prepared {
+                Some(prepared) => prepared,
+                None => self
+                    .network_runtime
+                    .prepare(settings.proxy.clone())
+                    .map_err(Self::contract_error)?,
+            };
             self.commit_prepared_persisted_proxy(prepared, settings.proxy.clone())
                 .map_err(Self::contract_error)?;
         }
@@ -289,9 +304,9 @@ impl SettingsService for CoreSettingsService {
     }
 
     async fn export_json(&self) -> Result<String, SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
-        let manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        let manager = self
+            .lock_synchronized_manager()
+            .await
             .map_err(Self::contract_error)?;
         manager
             .export_json()
@@ -300,7 +315,6 @@ impl SettingsService for CoreSettingsService {
     }
 
     async fn import_json(&self, json: &str) -> Result<UpdateResult, SettingsServiceError> {
-        let manager = self.manager().await.map_err(Self::contract_error)?;
         let candidate: AppSettings = serde_json::from_str(json).map_err(|error| {
             Self::contract_error(SettingsError::InvalidInput {
                 source: sealantern_extra::config::SettingsError::invalid_input(
@@ -314,9 +328,11 @@ impl SettingsService for CoreSettingsService {
             .map_err(sealantern_extra::config::SettingsError::from)
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)?;
-        let mut manager = manager.lock().await;
-        self.repair_network_if_needed(manager.get())
+        let mut manager = self
+            .lock_synchronized_manager()
+            .await
             .map_err(Self::contract_error)?;
+        let previous_proxy = manager.get().proxy.clone();
         let prepared = self
             .prepare_proxy_change(manager.get(), &candidate)
             .map_err(Self::contract_error)?;
@@ -325,7 +341,7 @@ impl SettingsService for CoreSettingsService {
             .await
             .map_err(SettingsError::from)
             .map_err(Self::contract_error)?;
-        self.commit_proxy_change(prepared, &result)
+        self.commit_proxy_change(prepared, &previous_proxy, &result.settings.proxy)
             .map_err(Self::contract_error)?;
         Ok(result)
     }
@@ -1074,6 +1090,41 @@ mod tests {
                 .filter(|event| matches!(event, NetworkEvent::Commit))
                 .count(),
             4
+        );
+    }
+
+    #[tokio::test]
+    async fn non_network_partial_update_adopts_and_applies_external_proxy_change() {
+        let root = tempfile::tempdir().expect("临时目录应创建");
+        let path = root.path().join("settings.json");
+        let (service, _runtime, events) = recording_service(&path).await;
+        let mut external = SettingsManager::load(&path)
+            .await
+            .expect("外部设置管理器应加载");
+        external
+            .update_partial(PartialAppSettings {
+                proxy: Some(ProxySettings { mode: ProxyMode::Disabled }),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("外部代理更新应持久化");
+
+        let result = service
+            .update_partial(PartialAppSettings {
+                default_port: Some(25566),
+                ..PartialAppSettings::default()
+            })
+            .await
+            .expect("非网络部分更新应合并外部代理并同步运行时");
+
+        assert_eq!(result.settings.proxy.mode, ProxyMode::Disabled);
+        assert_eq!(result.settings.default_port, 25566);
+        assert_eq!(
+            *events.lock().expect("测试事件锁不应污染"),
+            vec![
+                NetworkEvent::Prepare(ProxySettings { mode: ProxyMode::Disabled }),
+                NetworkEvent::Commit,
+            ]
         );
     }
 }

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -163,6 +163,13 @@ impl AppServices {
         &self.inner.settings
     }
 
+    /// 加载持久化设置并同步全局网络运行时。
+    pub async fn initialize_network_settings(
+        &self,
+    ) -> Result<(), sealantern_interface::SettingsServiceError> {
+        self.inner.settings.initialize().await
+    }
+
     /// 便捷访问入口：一步拿到设置信息服务的共享句柄（惰性初始化 + 可替换）。
     pub async fn settings_service() -> Result<Arc<CoreSettingsService>, InstanceError> {
         Ok(Self::get().await?.settings().clone())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,6 +64,10 @@ pub async fn main() {
             std::process::exit(1);
         }
     };
+    if let Err(error) = services.initialize_network_settings().await {
+        tracing::error!(error = %error, "failed to initialize persisted network settings");
+        std::process::exit(1);
+    }
 
     // 构建 Vite 配置并（在 dev 模式下）拉起 dev server。
     // 手柄必须在此持有，drop 时会终止 vite 子进程。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod adapter;
 pub mod desktop;
 pub mod observability;
 
+use sealantern_application::services::AppServices;
 use tauri::Manager;
 
 use adapter::tauri::commands::compat::download_compat::{
@@ -116,6 +117,23 @@ pub fn run() {
             validate_server_path
         ])
         .setup(|app| {
+            tauri::async_runtime::block_on(async {
+                let services = AppServices::get().await.map_err(|error| {
+                    std::io::Error::other(format!(
+                        "failed to assemble application services: {error}"
+                    ))
+                })?;
+                services
+                    .initialize_network_settings()
+                    .await
+                    .map_err(|error| {
+                        std::io::Error::other(format!(
+                            "failed to initialize persisted network settings: {error}"
+                        ))
+                    })?;
+                Ok::<(), std::io::Error>(())
+            })?;
+
             // 前端提供自定义标题栏；macOS 仍使用 Overlay 承载系统交通灯。
             #[cfg(not(target_os = "macos"))]
             if let Some(window) = app.get_webview_window("main") {


### PR DESCRIPTION
## 概述

将持久化的 `AppSettings.proxy` 与进程级全局网络运行时连接起来，使代理策略在应用启动、全量更新、部分更新、重置和导入时真实生效。

## 主要变更

- 新增应用层 `NetworkSettingsRuntime` 边界，将设置事务与 infra 全局网络运行时解耦并支持确定性测试。
- 首次加载设置时读取持久化代理，预构建并提交全局网络运行时状态。
- `CoreSettingsService::initialize` 和 `AppServices::initialize_network_settings` 提供显式启动屏障。
- server 在构建路由前完成代理初始化；Tauri 在 `setup` 阶段完成代理初始化，失败则中止启动。
- `update`、`update_partial`、`reset` 和 `import_json` 均接入代理运行时同步。
- 非网络设置变更不触发代理客户端重建。
- `Manual` 和 `Disabled` 模式不读取无关的系统代理；`Adaptive` 与 `Preserve` 使用当前平台快照。
- `lock_synchronized_manager` 统一管理 manager 初始化、mutex 获取和待同步状态修复，避免各入口重复或遗漏同步步骤。

## 事务与恢复语义

代理变更按以下顺序执行：

```text
校验候选设置
→ 读取必要的系统代理快照
→ prepare_proxy_settings（预构建候选，不修改运行时）
→ 持久化设置
→ commit_prepared_proxy_update
```

- prepare 失败：不写配置文件，也不修改当前运行时。
- 持久化失败：丢弃候选，不提交运行时。
- commit revision 冲突：基于已经持久化的代理设置重新 prepare，最多尝试 3 次。
- commit 冲突耗尽：返回 `Unavailable`，保留设置已持久化的事实，并标记运行时待同步。
- 后续任意真实设置操作会在持有 settings mutex 时先修复待同步状态，避免磁盘与运行时永久分叉。
- 网络同步错误在 application 保留底层 source，跨接口收敛为不携带敏感信息的 `SettingsServiceError::Unavailable`。

## 跨进程配置合并

`SettingsManager::update_partial` 会在配置锁内重读磁盘，因此其他进程可能在当前服务的内存快照之外修改代理。同步判断使用“操作前服务内存代理”与“操作后真实持久化代理”比较，而不是只依赖当前请求是否携带 `proxy` 或 `changed_groups`。

如果一次非网络部分更新合并了外部代理变化，本层会按照最终持久化代理补做 prepare/commit。这属于正常跨进程合并，不会被误报为“未准备的内部不变量错误”。

## 并发边界

- 设置管理器仍使用原有 mutex 串行化同一服务实例的写入。
- 运行时修复检查位于 settings mutex 临界区内，避免等待锁之前误判同步状态。
- 首次代理同步由独立 `OnceCell` 保证并发只执行一次；失败不会缓存成功状态，后续可重试。
- infra 的 revision 校验继续防止系统代理变化或其他运行时写入覆盖候选状态。

## 验证

- `cargo test -p sealantern-application --locked`：30 项通过。
- 覆盖首次初始化、只初始化一次、全量更新、部分更新、重置、导入、prepare 失败、持久化失败、冲突重试、冲突后的后续自愈，以及非网络部分更新合并外部代理变化。
- `cargo clippy -p sealantern-application -p sealantern-server -p sealantern --all-targets --locked -- -D warnings`：通过。
- `cargo fmt --all -- --check`：通过。
- `cargo check -p sealantern-server --locked`：通过。
- `cargo check -p sealantern --locked`：通过。

## Stack

- GitHub Stack：#922
- 位置：第 6 层
- 依赖：#937 `feat(network): 提供插件安全出站客户端`
