### PR TITLE
feat(java): expose detection and validation service

### DIFF
--- a/application/src/service/java.rs
+++ b/application/src/service/java.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+use sealantern_extra::java::{
+    detect_java_installations_with_diagnostics, validate_java, JavaDetectionReport,
+};
+use sealantern_extra::models::JavaInfo;
+use sealantern_interface::{JavaService, JavaServiceError};
+
+#[derive(Debug, Default)]
+pub struct CoreJavaService;
+#[async_trait]
+impl JavaService for CoreJavaService {
+    async fn detect(&self) -> Result<JavaDetectionReport, JavaServiceError> {
+        tokio::task::spawn_blocking(detect_java_installations_with_diagnostics)
+            .await
+            .map_err(|_| JavaServiceError::OperationFailed)
+    }
+    async fn validate(&self, path: String) -> Result<JavaInfo, JavaServiceError> {
+        tokio::task::spawn_blocking(move || validate_java(&path))
+            .await
+            .map_err(|_| JavaServiceError::OperationFailed)?
+            .map_err(|_| JavaServiceError::InvalidInput)
+    }
+}

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -7,6 +7,7 @@
 mod cron;
 mod download;
 mod instance;
+mod java;
 mod network_settings;
 mod provisioning;
 mod proxy_monitoring;
@@ -18,6 +19,7 @@ mod update;
 pub use cron::CoreCronTaskService;
 pub use download::CoreDownloadService;
 pub use instance::CoreInstanceService;
+pub use java::CoreJavaService;
 pub use provisioning::CoreProvisioningService;
 pub use proxy_monitoring::ProxyMonitoringService;
 pub use server::CoreServerService;

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -17,9 +17,9 @@ use std::sync::Arc;
 use crate::error::InstanceError;
 use crate::plugin::{ApplicationPluginReadHost, CorePluginService, PluginServiceError};
 use crate::service::{
-    CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreProvisioningService,
-    CoreServerService, CoreSettingsService, CoreSystemService, CoreUpdateCheckService,
-    ProxyMonitoringService,
+    CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreJavaService,
+    CoreProvisioningService, CoreServerService, CoreSettingsService, CoreSystemService,
+    CoreUpdateCheckService, ProxyMonitoringService,
 };
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
@@ -39,6 +39,7 @@ pub struct AppServicesInner {
     pub download: Arc<CoreDownloadService>,
     /// 服务器实例记录管理服务。
     pub instance: Arc<CoreInstanceService>,
+    pub java: Arc<CoreJavaService>,
     /// 服务端检查与供给计划服务。
     pub provisioning: Arc<CoreProvisioningService>,
     /// 服务器进程管理服务。
@@ -75,6 +76,7 @@ impl AppServices {
                 cron: Arc::new(CoreCronTaskService::new(server.clone())),
                 server,
                 instance,
+                java: Arc::new(CoreJavaService),
                 provisioning: Arc::new(CoreProvisioningService),
                 settings: Arc::new(CoreSettingsService::new()),
                 proxy_monitoring: Arc::new(ProxyMonitoringService::new()),
@@ -151,6 +153,9 @@ impl AppServices {
     /// 访问实例管理服务（`Arc` 共享句柄，clone 廉价）。
     pub fn instance(&self) -> &Arc<CoreInstanceService> {
         &self.inner.instance
+    }
+    pub fn java(&self) -> &Arc<CoreJavaService> {
+        &self.inner.java
     }
 
     /// 访问服务端检查与供给计划服务。

--- a/crates/extra/src/java/discovery.rs
+++ b/crates/extra/src/java/discovery.rs
@@ -32,7 +32,8 @@ impl JavaSearchSource {
 }
 
 /// Java 自动检测结果；成功安装和非致命错误同时保留。
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct JavaDetectionReport {
     pub installations: Vec<JavaInfo>,
     pub errors: Vec<JavaDiscoveryError>,

--- a/crates/extra/src/java/error.rs
+++ b/crates/extra/src/java/error.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
 /// Java 自动检测中单个来源或候选产生的非致命错误。
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct JavaDiscoveryError {
     pub source: String,
     pub message: String,

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -251,6 +251,22 @@ impl std::fmt::Display for ProvisioningServiceError {
 
 impl std::error::Error for ProvisioningServiceError {}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JavaServiceError {
+    InvalidInput,
+    OperationFailed,
+}
+impl std::fmt::Display for JavaServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::InvalidInput => "invalid Java installation",
+            Self::OperationFailed => "Java operation failed",
+        })
+    }
+}
+impl std::error::Error for JavaServiceError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,6 +291,7 @@ mod tests {
                 serde_json::to_string(&ProvisioningServiceError::InspectionFailed),
                 "\"inspection_failed\"",
             ),
+            (serde_json::to_string(&JavaServiceError::InvalidInput), "\"invalid_input\""),
         ];
 
         for (serialized, expected) in cases {

--- a/crates/interface/src/java/mod.rs
+++ b/crates/interface/src/java/mod.rs
@@ -1,0 +1,2 @@
+pub mod service;
+pub use service::JavaService;

--- a/crates/interface/src/java/service.rs
+++ b/crates/interface/src/java/service.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use sealantern_extra::java::JavaDetectionReport;
+use sealantern_extra::models::JavaInfo;
+
+use crate::error::JavaServiceError;
+
+#[async_trait]
+pub trait JavaService: Send + Sync {
+    async fn detect(&self) -> Result<JavaDetectionReport, JavaServiceError>;
+    async fn validate(&self, path: String) -> Result<JavaInfo, JavaServiceError>;
+}

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -13,6 +13,7 @@ pub mod download;
 pub mod error;
 /// 服务器实例记录相关模型与服务端口。
 pub mod instance;
+pub mod java;
 /// 服务端检查与实例供给计划相关服务端口。
 pub mod provisioning;
 /// 服务器进程管理相关模型与服务端口。
@@ -34,6 +35,7 @@ pub use error::CronTaskServiceError;
 pub use error::DownloadServiceError;
 /// 服务器实例管理错误枚举。
 pub use error::InstanceServiceError;
+pub use error::JavaServiceError;
 /// 服务端检查与实例供给计划失败类别。
 pub use error::ProvisioningServiceError;
 /// 服务器进程管理错误枚举。
@@ -46,6 +48,7 @@ pub use error::SystemServiceError;
 pub use error::UpdateCheckServiceError;
 /// 服务器实例记录管理服务端口。
 pub use instance::InstanceService;
+pub use java::JavaService;
 /// 服务端检查与实例供给计划服务端口。
 pub use provisioning::ProvisioningService;
 /// 服务器进程管理服务端口。

--- a/src-tauri/src/adapter/tauri/commands/java.rs
+++ b/src-tauri/src/adapter/tauri/commands/java.rs
@@ -1,0 +1,23 @@
+use sealantern_application::services::AppServices;
+use sealantern_extra::java::JavaDetectionReport;
+use sealantern_extra::models::JavaInfo;
+use sealantern_interface::{JavaService, JavaServiceError};
+
+#[tauri::command]
+pub async fn java_detect() -> Result<JavaDetectionReport, JavaServiceError> {
+    AppServices::get()
+        .await
+        .map_err(|_| JavaServiceError::OperationFailed)?
+        .java()
+        .detect()
+        .await
+}
+#[tauri::command]
+pub async fn java_validate(path: String) -> Result<JavaInfo, JavaServiceError> {
+    AppServices::get()
+        .await
+        .map_err(|_| JavaServiceError::OperationFailed)?
+        .java()
+        .validate(path)
+        .await
+}

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod cron;
 pub mod download;
 pub mod instance;
+pub mod java;
 pub mod plugin;
 pub mod provisioning;
 pub mod server;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use adapter::tauri::commands::instance::{
     create_instance, delete_instance, get_instance, list_instances, rename_instance,
     update_instance_path,
 };
+use adapter::tauri::commands::java::{java_detect, java_validate};
 use adapter::tauri::commands::plugin::{
     plugin_v2_audit, plugin_v2_disable, plugin_v2_discover, plugin_v2_enable, plugin_v2_load,
     plugin_v2_plugins, plugin_v2_unload,
@@ -83,6 +84,8 @@ pub fn run() {
             list_instances,
             rename_instance,
             update_instance_path,
+            java_detect,
+            java_validate,
             force_stop_server,
             restart_server,
             send_server_command,


### PR DESCRIPTION
接入既有 Java 检测与路径校验能力。

## Summary by Sourcery

通过核心应用和 Tauri 命令暴露一个 Java 服务，用于检测和验证 Java 安装，并提供完善的错误建模以及检测诊断信息的序列化。

New Features:
- 引入 `JavaService` 接口，提供用于 Java 安装的异步 `detect` 和 `validate` 操作。
- 在应用层添加 `CoreJavaService` 实现，并将其接入全局的 `AppServices` 容器。
- 暴露 `java_detect` 和 `java_validate` Tauri 命令，使其委托给 Java 服务供 UI/API 使用。

Enhancements:
- 添加 `JavaServiceError` 枚举，用于规范化与 Java 相关的故障模式，并将其集成到接口导出中。
- 使 `JavaDetectionReport` 和 `JavaDiscoveryError` 可序列化，并使用 `snake_case` 字段，以便通过接口提供结构化诊断信息。
- 扩展接口和服务模块的导出内容，以包含新的 Java 服务及错误类型。

Tests:
- 添加针对 `JavaServiceError` 各种取值的序列化测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a Java service through the core application and Tauri commands for Java installation detection and validation, with proper error modeling and serialization of detection diagnostics.

New Features:
- Introduce a JavaService interface with async detect and validate operations for Java installations.
- Add CoreJavaService implementation in the application layer and wire it into the global AppServices container.
- Expose java_detect and java_validate Tauri commands that delegate to the Java service for UI/API use.

Enhancements:
- Add JavaServiceError enum to standardize Java-related failure modes and integrate it into the interface exports.
- Make JavaDetectionReport and JavaDiscoveryError serializable with snake_case fields for structured diagnostics over the interface.
- Extend interface and service module exports to include the new Java service and error types.

Tests:
- Add serialization test coverage for JavaServiceError values.

</details>