### PR TITLE
feat(catalog): expose server download catalog

### DIFF
--- a/application/src/service/catalog.rs
+++ b/application/src/service/catalog.rs
@@ -1,0 +1,29 @@
+use async_trait::async_trait;
+use sealantern_extra::download_link::{LinkManager, TypeDownloadLinks};
+use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
+#[derive(Debug, Default)]
+pub struct CoreServerCatalogService;
+#[async_trait]
+impl ServerCatalogService for CoreServerCatalogService {
+    async fn server_types(&self) -> Result<Vec<String>, ServerCatalogServiceError> {
+        LinkManager::get_server_types()
+            .await
+            .map_err(|_| ServerCatalogServiceError::OperationFailed)
+    }
+    async fn versions(
+        &self,
+        server_type: String,
+    ) -> Result<Vec<String>, ServerCatalogServiceError> {
+        LinkManager::get_versions_by_type(&server_type)
+            .await
+            .map_err(|_| ServerCatalogServiceError::NotFound)
+    }
+    async fn details(
+        &self,
+        server_type: String,
+    ) -> Result<TypeDownloadLinks, ServerCatalogServiceError> {
+        LinkManager::get_type_by_name(&server_type)
+            .await
+            .map_err(|_| ServerCatalogServiceError::NotFound)
+    }
+}

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -4,6 +4,7 @@
 //! [`CoreServerService`]、[`CoreDownloadService`]、[`CoreCronTaskService`]），实现
 //! `interface` 的能力端口，由 `services` 装配层组装进全局容器。
 
+mod catalog;
 mod cron;
 mod download;
 mod instance;
@@ -16,6 +17,7 @@ mod settings;
 mod system;
 mod update;
 
+pub use catalog::CoreServerCatalogService;
 pub use cron::CoreCronTaskService;
 pub use download::CoreDownloadService;
 pub use instance::CoreInstanceService;

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -18,8 +18,8 @@ use crate::error::InstanceError;
 use crate::plugin::{ApplicationPluginReadHost, CorePluginService, PluginServiceError};
 use crate::service::{
     CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreJavaService,
-    CoreProvisioningService, CoreServerService, CoreSettingsService, CoreSystemService,
-    CoreUpdateCheckService, ProxyMonitoringService,
+    CoreProvisioningService, CoreServerCatalogService, CoreServerService, CoreSettingsService,
+    CoreSystemService, CoreUpdateCheckService, ProxyMonitoringService,
 };
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
@@ -40,6 +40,7 @@ pub struct AppServicesInner {
     /// 服务器实例记录管理服务。
     pub instance: Arc<CoreInstanceService>,
     pub java: Arc<CoreJavaService>,
+    pub catalog: Arc<CoreServerCatalogService>,
     /// 服务端检查与供给计划服务。
     pub provisioning: Arc<CoreProvisioningService>,
     /// 服务器进程管理服务。
@@ -77,6 +78,7 @@ impl AppServices {
                 server,
                 instance,
                 java: Arc::new(CoreJavaService),
+                catalog: Arc::new(CoreServerCatalogService),
                 provisioning: Arc::new(CoreProvisioningService),
                 settings: Arc::new(CoreSettingsService::new()),
                 proxy_monitoring: Arc::new(ProxyMonitoringService::new()),
@@ -156,6 +158,9 @@ impl AppServices {
     }
     pub fn java(&self) -> &Arc<CoreJavaService> {
         &self.inner.java
+    }
+    pub fn catalog(&self) -> &Arc<CoreServerCatalogService> {
+        &self.inner.catalog
     }
 
     /// 访问服务端检查与供给计划服务。

--- a/crates/extra/src/models/download_link.rs
+++ b/crates/extra/src/models/download_link.rs
@@ -4,10 +4,9 @@ use serde::{Deserialize, Serialize};
 
 /// 单个下载链接。
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct DownloadLink {
     pub version: String,
-    #[serde(alias = "file_name")]
     pub file_name: String,
     pub url: String,
 }
@@ -66,7 +65,7 @@ mod tests {
     use super::DownloadLink;
 
     #[test]
-    fn download_link_uses_frontend_field_names() {
+    fn download_link_uses_snake_case_field_names() {
         let value = serde_json::to_value(DownloadLink::new(
             "1.21.1".to_string(),
             "server.jar".to_string(),
@@ -74,21 +73,7 @@ mod tests {
         ))
         .expect("download link should serialize");
 
-        assert_eq!(value["fileName"], "server.jar");
-        assert!(value.get("file_name").is_none());
-    }
-
-    #[test]
-    fn download_link_accepts_legacy_snake_case_field() {
-        let link: DownloadLink = serde_json::from_str(
-            r#"{
-                "version":"1.21.1",
-                "file_name":"server.jar",
-                "url":"https://example.invalid/server.jar"
-            }"#,
-        )
-        .expect("legacy download link should deserialize");
-
-        assert_eq!(link.file_name, "server.jar");
+        assert_eq!(value["file_name"], "server.jar");
+        assert!(value.get("fileName").is_none());
     }
 }

--- a/crates/interface/src/catalog/mod.rs
+++ b/crates/interface/src/catalog/mod.rs
@@ -1,0 +1,2 @@
+pub mod service;
+pub use service::ServerCatalogService;

--- a/crates/interface/src/catalog/service.rs
+++ b/crates/interface/src/catalog/service.rs
@@ -1,0 +1,13 @@
+use crate::error::ServerCatalogServiceError;
+use async_trait::async_trait;
+use sealantern_extra::download_link::TypeDownloadLinks;
+#[async_trait]
+pub trait ServerCatalogService: Send + Sync {
+    async fn server_types(&self) -> Result<Vec<String>, ServerCatalogServiceError>;
+    async fn versions(&self, server_type: String)
+        -> Result<Vec<String>, ServerCatalogServiceError>;
+    async fn details(
+        &self,
+        server_type: String,
+    ) -> Result<TypeDownloadLinks, ServerCatalogServiceError>;
+}

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -267,6 +267,22 @@ impl std::fmt::Display for JavaServiceError {
 }
 impl std::error::Error for JavaServiceError {}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerCatalogServiceError {
+    NotFound,
+    OperationFailed,
+}
+impl std::fmt::Display for ServerCatalogServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::NotFound => "server catalog entry not found",
+            Self::OperationFailed => "server catalog operation failed",
+        })
+    }
+}
+impl std::error::Error for ServerCatalogServiceError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,6 +308,10 @@ mod tests {
                 "\"inspection_failed\"",
             ),
             (serde_json::to_string(&JavaServiceError::InvalidInput), "\"invalid_input\""),
+            (
+                serde_json::to_string(&ServerCatalogServiceError::OperationFailed),
+                "\"operation_failed\"",
+            ),
         ];
 
         for (serialized, expected) in cases {

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod catalog;
 /// 服务器定时任务相关模型与服务端口。
 pub mod cron;
 /// 下载任务管理相关模型与服务端口。
@@ -25,6 +26,7 @@ pub mod system;
 /// 应用更新检查相关模型与服务端口。
 pub mod update;
 
+pub use catalog::ServerCatalogService;
 /// 服务器定时任务服务端口。
 pub use cron::CronTaskService;
 /// 下载任务管理服务端口。
@@ -38,6 +40,7 @@ pub use error::InstanceServiceError;
 pub use error::JavaServiceError;
 /// 服务端检查与实例供给计划失败类别。
 pub use error::ProvisioningServiceError;
+pub use error::ServerCatalogServiceError;
 /// 服务器进程管理错误枚举。
 pub use error::ServerServiceError;
 /// 设置信息服务错误枚举。

--- a/src-tauri/src/adapter/tauri/commands/catalog.rs
+++ b/src-tauri/src/adapter/tauri/commands/catalog.rs
@@ -1,0 +1,34 @@
+use sealantern_application::services::AppServices;
+use sealantern_extra::download_link::TypeDownloadLinks;
+use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
+#[tauri::command]
+pub async fn catalog_server_types() -> Result<Vec<String>, ServerCatalogServiceError> {
+    AppServices::get()
+        .await
+        .map_err(|_| ServerCatalogServiceError::OperationFailed)?
+        .catalog()
+        .server_types()
+        .await
+}
+#[tauri::command]
+pub async fn catalog_versions(
+    server_type: String,
+) -> Result<Vec<String>, ServerCatalogServiceError> {
+    AppServices::get()
+        .await
+        .map_err(|_| ServerCatalogServiceError::OperationFailed)?
+        .catalog()
+        .versions(server_type)
+        .await
+}
+#[tauri::command]
+pub async fn catalog_details(
+    server_type: String,
+) -> Result<TypeDownloadLinks, ServerCatalogServiceError> {
+    AppServices::get()
+        .await
+        .map_err(|_| ServerCatalogServiceError::OperationFailed)?
+        .catalog()
+        .details(server_type)
+        .await
+}

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalog;
 pub mod cron;
 pub mod download;
 pub mod instance;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod observability;
 use sealantern_application::services::AppServices;
 use tauri::Manager;
 
+use adapter::tauri::commands::catalog::{catalog_details, catalog_server_types, catalog_versions};
 use adapter::tauri::commands::cron::{
     create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
     update_cron_task,
@@ -73,6 +74,9 @@ pub fn run() {
             run_cron_task,
             set_cron_task_enabled,
             update_cron_task,
+            catalog_details,
+            catalog_server_types,
+            catalog_versions,
             //系统资源能力（由adapter/tauri/commands接入application）
             get_directory_usage,
             get_process_usage,


### PR DESCRIPTION
接入既有服务端下载目录查询能力。

## Summary by Sourcery

在整个应用程序和 Tauri 接口中暴露一个服务器下载目录服务（server download catalog service），该服务由现有的链接管理功能提供支持，并将下载链接的序列化方式统一为使用 snake_case 字段名。

New Features:
- 添加服务器目录服务接口，用于查询可用的服务器类型、版本以及下载详情。
- 将核心服务器目录服务接入全局应用服务容器和 Tauri 命令。

Enhancements:
- 将下载链接的 JSON 序列化统一标准化为 snake_case，并相应更新测试。
- 为服务器目录操作引入专用错误类型，并使用 snake_case 的 JSON 表示。

Tests:
- 扩展错误序列化测试，以覆盖新的服务器目录错误类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a server download catalog service across the application and Tauri interface, backed by existing link management, and align download link serialization with snake_case field names.

New Features:
- Add a server catalog service interface to query available server types, versions, and download details.
- Wire the core server catalog service into the global application services container and Tauri commands.

Enhancements:
- Standardize download link JSON serialization to snake_case and update tests accordingly.
- Introduce a dedicated error type for server catalog operations with snake_case JSON representation.

Tests:
- Extend error serialization tests to cover the new server catalog error type.

</details>