### PR TITLE
feat(update): expose installation service

### DIFF
--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -16,6 +16,7 @@ mod server;
 mod settings;
 mod system;
 mod update;
+mod update_install;
 
 pub use catalog::CoreServerCatalogService;
 pub use cron::CoreCronTaskService;
@@ -28,3 +29,4 @@ pub use server::CoreServerService;
 pub use settings::CoreSettingsService;
 pub use system::CoreSystemService;
 pub use update::CoreUpdateCheckService;
+pub use update_install::CoreUpdateInstallService;

--- a/application/src/service/update_install.rs
+++ b/application/src/service/update_install.rs
@@ -1,0 +1,61 @@
+use async_trait::async_trait;
+use sealantern_extra::update::{
+    check_pending_update, clear_pending_update, download_update_file_without_events,
+    get_pending_update_file, get_update_cache_dir, write_pending_update, PendingUpdate,
+};
+use sealantern_interface::{UpdateInstallService, UpdateInstallServiceError};
+
+#[derive(Debug, Default)]
+pub struct CoreUpdateInstallService;
+
+#[async_trait]
+impl UpdateInstallService for CoreUpdateInstallService {
+    async fn download(
+        &self,
+        url: String,
+        expected_hash: Option<String>,
+        version: String,
+    ) -> Result<String, UpdateInstallServiceError> {
+        if version.trim().is_empty() {
+            return Err(UpdateInstallServiceError::InvalidInput);
+        }
+        let path = download_update_file_without_events(url, expected_hash, get_update_cache_dir())
+            .await
+            .map_err(|_| UpdateInstallServiceError::OperationFailed)?;
+        write_pending_update(&get_pending_update_file(), &path, version)
+            .map_err(|_| UpdateInstallServiceError::OperationFailed)?;
+        Ok(path)
+    }
+    async fn pending(&self) -> Result<Option<PendingUpdate>, UpdateInstallServiceError> {
+        check_pending_update()
+            .await
+            .map_err(|_| UpdateInstallServiceError::OperationFailed)
+    }
+    async fn clear_pending(&self) -> Result<(), UpdateInstallServiceError> {
+        clear_pending_update()
+            .await
+            .map_err(|_| UpdateInstallServiceError::OperationFailed)
+    }
+    async fn install(
+        &self,
+        file_path: String,
+        arguments: Vec<String>,
+    ) -> Result<(), UpdateInstallServiceError> {
+        #[cfg(target_os = "windows")]
+        {
+            let refs = arguments.iter().map(String::as_str).collect::<Vec<_>>();
+            sealantern_extra::update::spawn_elevated_windows_process(
+                &file_path,
+                &refs,
+                Some(&file_path),
+                get_pending_update_file().to_str(),
+            )
+            .map_err(|_| UpdateInstallServiceError::OperationFailed)
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = (file_path, arguments);
+            Err(UpdateInstallServiceError::Unsupported)
+        }
+    }
+}

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -19,7 +19,7 @@ use crate::plugin::{ApplicationPluginReadHost, CorePluginService, PluginServiceE
 use crate::service::{
     CoreCronTaskService, CoreDownloadService, CoreInstanceService, CoreJavaService,
     CoreProvisioningService, CoreServerCatalogService, CoreServerService, CoreSettingsService,
-    CoreSystemService, CoreUpdateCheckService, ProxyMonitoringService,
+    CoreSystemService, CoreUpdateCheckService, CoreUpdateInstallService, ProxyMonitoringService,
 };
 
 /// 真正的全局服务容器（进程级单例，内部为异步锁 + 可配置）。
@@ -55,6 +55,7 @@ pub struct AppServicesInner {
     pub system: Arc<CoreSystemService>,
     /// 应用更新检查服务。
     pub update: Arc<CoreUpdateCheckService>,
+    pub update_install: Arc<CoreUpdateInstallService>,
     /// 惰性初始化的应用插件服务。
     plugin: tokio::sync::OnceCell<Arc<CorePluginService>>,
 }
@@ -84,6 +85,7 @@ impl AppServices {
                 proxy_monitoring: Arc::new(ProxyMonitoringService::new()),
                 system: Arc::new(CoreSystemService),
                 update: Arc::new(CoreUpdateCheckService::new()),
+                update_install: Arc::new(CoreUpdateInstallService),
                 plugin: tokio::sync::OnceCell::new(),
             }),
         }
@@ -248,6 +250,9 @@ impl AppServices {
     /// 访问应用更新检查服务（`Arc` 共享句柄，clone 廉价）。
     pub fn update(&self) -> &Arc<CoreUpdateCheckService> {
         &self.inner.update
+    }
+    pub fn update_install(&self) -> &Arc<CoreUpdateInstallService> {
+        &self.inner.update_install
     }
 
     /// 便捷访问入口：一步拿到更新检查服务的共享句柄（惰性初始化 + 可替换）。

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -283,6 +283,24 @@ impl std::fmt::Display for ServerCatalogServiceError {
 }
 impl std::error::Error for ServerCatalogServiceError {}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateInstallServiceError {
+    InvalidInput,
+    OperationFailed,
+    Unsupported,
+}
+impl std::fmt::Display for UpdateInstallServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::InvalidInput => "invalid update installation input",
+            Self::OperationFailed => "update installation operation failed",
+            Self::Unsupported => "update installation is unsupported",
+        })
+    }
+}
+impl std::error::Error for UpdateInstallServiceError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -310,6 +328,10 @@ mod tests {
             (serde_json::to_string(&JavaServiceError::InvalidInput), "\"invalid_input\""),
             (
                 serde_json::to_string(&ServerCatalogServiceError::OperationFailed),
+                "\"operation_failed\"",
+            ),
+            (
+                serde_json::to_string(&UpdateInstallServiceError::OperationFailed),
                 "\"operation_failed\"",
             ),
         ];

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -49,6 +49,7 @@ pub use error::SettingsServiceError;
 pub use error::SystemServiceError;
 /// 应用更新检查错误枚举。
 pub use error::UpdateCheckServiceError;
+pub use error::UpdateInstallServiceError;
 /// 服务器实例记录管理服务端口。
 pub use instance::InstanceService;
 pub use java::JavaService;
@@ -62,3 +63,4 @@ pub use settings::SettingsService;
 pub use system::SystemService;
 /// 应用更新检查服务端口。
 pub use update::UpdateCheckService;
+pub use update::UpdateInstallService;

--- a/crates/interface/src/update/mod.rs
+++ b/crates/interface/src/update/mod.rs
@@ -4,4 +4,4 @@ mod models;
 mod service;
 
 pub use models::{UpdateInfo, UpdateSource};
-pub use service::UpdateCheckService;
+pub use service::{UpdateCheckService, UpdateInstallService};

--- a/crates/interface/src/update/models.rs
+++ b/crates/interface/src/update/models.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 /// 提供更新信息的发布源。
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "snake_case")]
 pub enum UpdateSource {
     /// GitHub Releases。
     Github,
@@ -58,7 +58,7 @@ mod tests {
 
         assert_eq!(value["has_update"], true);
         assert_eq!(value["latest_version"], "2.0.0");
-        assert_eq!(value["source"], "arch-aur");
+        assert_eq!(value["source"], "arch_aur");
         assert!(value.get("hasUpdate").is_none());
         assert!(value.get("latestVersion").is_none());
     }

--- a/crates/interface/src/update/service.rs
+++ b/crates/interface/src/update/service.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 
 use crate::error::UpdateCheckServiceError;
+use crate::error::UpdateInstallServiceError;
+use sealantern_extra::update::PendingUpdate;
 
 use super::models::UpdateInfo;
 
@@ -12,4 +14,21 @@ use super::models::UpdateInfo;
 pub trait UpdateCheckService: Send + Sync {
     /// 检查当前平台是否存在新版本。
     async fn check(&self) -> Result<UpdateInfo, UpdateCheckServiceError>;
+}
+
+#[async_trait]
+pub trait UpdateInstallService: Send + Sync {
+    async fn download(
+        &self,
+        url: String,
+        expected_hash: Option<String>,
+        version: String,
+    ) -> Result<String, UpdateInstallServiceError>;
+    async fn pending(&self) -> Result<Option<PendingUpdate>, UpdateInstallServiceError>;
+    async fn clear_pending(&self) -> Result<(), UpdateInstallServiceError>;
+    async fn install(
+        &self,
+        file_path: String,
+        arguments: Vec<String>,
+    ) -> Result<(), UpdateInstallServiceError>;
 }

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -9,3 +9,4 @@ pub mod server;
 pub mod settings;
 pub mod system;
 pub mod update;
+pub mod update_install;

--- a/src-tauri/src/adapter/tauri/commands/update_install.rs
+++ b/src-tauri/src/adapter/tauri/commands/update_install.rs
@@ -2,16 +2,14 @@ use sealantern_application::services::AppServices;
 use sealantern_extra::update::PendingUpdate;
 use sealantern_interface::{UpdateInstallService, UpdateInstallServiceError};
 async fn service() -> Result<AppServices, UpdateInstallServiceError> {
-    AppServices::get()
-        .await
-        .map_err(|error| {
-            tracing::error!(
-                target: "sealantern.tauri.update_install",
-                error = %error,
-                "failed to initialize application services for update installation"
-            );
-            UpdateInstallServiceError::OperationFailed
-        })
+    AppServices::get().await.map_err(|error| {
+        tracing::error!(
+            target: "sealantern.tauri.update_install",
+            error = %error,
+            "failed to initialize application services for update installation"
+        );
+        UpdateInstallServiceError::OperationFailed
+    })
 }
 #[tauri::command]
 pub async fn update_download(

--- a/src-tauri/src/adapter/tauri/commands/update_install.rs
+++ b/src-tauri/src/adapter/tauri/commands/update_install.rs
@@ -1,0 +1,39 @@
+use sealantern_application::services::AppServices;
+use sealantern_extra::update::PendingUpdate;
+use sealantern_interface::{UpdateInstallService, UpdateInstallServiceError};
+async fn service() -> Result<AppServices, UpdateInstallServiceError> {
+    AppServices::get()
+        .await
+        .map_err(|_| UpdateInstallServiceError::OperationFailed)
+}
+#[tauri::command]
+pub async fn update_download(
+    url: String,
+    expected_hash: Option<String>,
+    version: String,
+) -> Result<String, UpdateInstallServiceError> {
+    service()
+        .await?
+        .update_install()
+        .download(url, expected_hash, version)
+        .await
+}
+#[tauri::command]
+pub async fn update_pending() -> Result<Option<PendingUpdate>, UpdateInstallServiceError> {
+    service().await?.update_install().pending().await
+}
+#[tauri::command]
+pub async fn update_clear_pending() -> Result<(), UpdateInstallServiceError> {
+    service().await?.update_install().clear_pending().await
+}
+#[tauri::command]
+pub async fn update_install(
+    file_path: String,
+    arguments: Vec<String>,
+) -> Result<(), UpdateInstallServiceError> {
+    service()
+        .await?
+        .update_install()
+        .install(file_path, arguments)
+        .await
+}

--- a/src-tauri/src/adapter/tauri/commands/update_install.rs
+++ b/src-tauri/src/adapter/tauri/commands/update_install.rs
@@ -4,7 +4,14 @@ use sealantern_interface::{UpdateInstallService, UpdateInstallServiceError};
 async fn service() -> Result<AppServices, UpdateInstallServiceError> {
     AppServices::get()
         .await
-        .map_err(|_| UpdateInstallServiceError::OperationFailed)
+        .map_err(|error| {
+            tracing::error!(
+                target: "sealantern.tauri.update_install",
+                error = %error,
+                "failed to initialize application services for update installation"
+            );
+            UpdateInstallServiceError::OperationFailed
+        })
 }
 #[tauri::command]
 pub async fn update_download(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,9 @@ use adapter::tauri::commands::system::{
     get_directory_usage, get_process_usage, get_system_snapshot,
 };
 use adapter::tauri::commands::update::check_update;
+use adapter::tauri::commands::update_install::{
+    update_clear_pending, update_download, update_install, update_pending,
+};
 use desktop::{
     desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
     desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
@@ -115,6 +118,10 @@ pub fn run() {
             plan_modpack_provision,
             //应用更新检查契约命令
             check_update,
+            update_clear_pending,
+            update_download,
+            update_install,
+            update_pending,
             //插件 v2 宿主能力与策略管理
             plugin_v2_audit,
             plugin_v2_disable,


### PR DESCRIPTION
接入既有更新下载、待安装状态与安装能力。

## Summary by Sourcery

在界面层、应用核心层和 Tauri 层中公开一个新的更新安装服务，支持下载、跟踪、清理和安装待处理的应用更新，并包含对不受支持平台的错误处理。

New Features:
- 引入 `UpdateInstallService` 接口，提供用于下载、查询、清理和安装待处理更新的方法。
- 添加 `CoreUpdateInstallService` 实现，将其接入全局 `AppServices` 容器，并通过新的 Tauri 命令对外暴露，用于执行更新下载、待处理状态检查、清理和安装操作。

Bug Fixes:
- 调整 `UpdateSource` 的序列化方式为 `snake_case`，修正 Arch AUR 源的序列化值。

Enhancements:
- 定义专用的 `UpdateInstallServiceError` 枚举，为更新安装操作提供结构化、可序列化的错误报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a new update installation service across the interface, application core, and Tauri layer to support downloading, tracking, clearing, and installing pending app updates, including error handling for unsupported platforms.

New Features:
- Introduce an UpdateInstallService interface with methods for downloading, querying, clearing, and installing pending updates.
- Add a CoreUpdateInstallService implementation wired into the global AppServices container and exposed via new Tauri commands for update download, pending-state inspection, clearing, and installation.

Bug Fixes:
- Align UpdateSource serialization to use snake_case, correcting the serialized value for the Arch AUR source.

Enhancements:
- Define a dedicated UpdateInstallServiceError enum with structured, serializable error reporting for update installation operations.

</details>