### PR TITLE
feat(plugin): register v2 policy commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,8 +24,10 @@ use adapter::tauri::commands::online_tunnel::{
     OnlineTunnelEventForwarder,
 };
 use adapter::tauri::commands::plugin::{
-    plugin_v2_audit, plugin_v2_disable, plugin_v2_discover, plugin_v2_enable, plugin_v2_load,
-    plugin_v2_plugins, plugin_v2_unload,
+    plugin_v2_approve_session, plugin_v2_audit, plugin_v2_disable, plugin_v2_discover,
+    plugin_v2_enable, plugin_v2_end_session, plugin_v2_grant_persistent, plugin_v2_grant_session,
+    plugin_v2_invoke, plugin_v2_issue_approval_token, plugin_v2_load, plugin_v2_plugins,
+    plugin_v2_revoke_persistent, plugin_v2_set_trust, plugin_v2_unload,
 };
 use adapter::tauri::commands::provisioning::{
     inspect_server, parse_startup_script, plan_existing_instance, plan_instance_copy,
@@ -133,12 +135,20 @@ pub fn run() {
             update_install,
             update_pending,
             //插件 v2 宿主能力与策略管理
+            plugin_v2_approve_session,
             plugin_v2_audit,
             plugin_v2_disable,
             plugin_v2_discover,
             plugin_v2_enable,
+            plugin_v2_end_session,
+            plugin_v2_grant_persistent,
+            plugin_v2_grant_session,
+            plugin_v2_invoke,
+            plugin_v2_issue_approval_token,
             plugin_v2_load,
             plugin_v2_plugins,
+            plugin_v2_revoke_persistent,
+            plugin_v2_set_trust,
             plugin_v2_unload
         ])
         .setup(|app| {


### PR DESCRIPTION
补全既有插件 v2 生命周期及策略会话命令注册。

## Summary by Sourcery

通过 Tauri 主机暴露插件 v2 策略和信任生命周期相关命令。

新特性：
- 注册用于管理插件 v2 策略会话的 Tauri 命令，包括审批、授予和撤销权限，以及结束会话。
- 注册用于插件 v2 信任管理和调用的 Tauri 命令，包括发放审批令牌和设置信任状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose plugin v2 policy and trust lifecycle commands through the Tauri host.

New Features:
- Register Tauri commands for managing plugin v2 policy sessions, including approval, granting and revoking permissions, and ending sessions.
- Register Tauri commands for plugin v2 trust management and invocation, including issuing approval tokens and setting trust state.

</details>

新功能：
- 通过 Tauri 命令接口暴露插件 v2 策略会话管理命令（批准、授予/撤销、结束会话）
- 通过 Tauri 命令接口暴露插件 v2 信任与调用命令

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过 Tauri 主机暴露插件 v2 策略和信任生命周期相关命令。

新特性：
- 注册用于管理插件 v2 策略会话的 Tauri 命令，包括审批、授予和撤销权限，以及结束会话。
- 注册用于插件 v2 信任管理和调用的 Tauri 命令，包括发放审批令牌和设置信任状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose plugin v2 policy and trust lifecycle commands through the Tauri host.

New Features:
- Register Tauri commands for managing plugin v2 policy sessions, including approval, granting and revoking permissions, and ending sessions.
- Register Tauri commands for plugin v2 trust management and invocation, including issuing approval tokens and setting trust state.

</details>

</details>