### PR TITLE
docs: 为后端服务暴露链路补充代码注释

### DIFF
--- a/application/src/service/catalog.rs
+++ b/application/src/service/catalog.rs
@@ -4,9 +4,9 @@
 //! `extra` 的下载链接管理能力（[`LinkManager`]），向宿主提供可用的
 //! 服务器类型、版本与下载详情查询。
 //!
-//! 错误分层：底层配置拉取失败统一收敛为
-//! [`ServerCatalogServiceError::OperationFailed`]；指定类型不存在
-//! （版本 / 详情查询依赖类型存在性）收敛为
+//! 错误分层：类型列表查询失败统一收敛为
+//! [`ServerCatalogServiceError::OperationFailed`]；版本与详情查询失败
+//! （类型不存在或底层配置不可用）统一收敛为
 //! [`ServerCatalogServiceError::NotFound`]。
 
 use async_trait::async_trait;
@@ -30,7 +30,7 @@ impl ServerCatalogService for CoreServerCatalogService {
     }
     /// 查询指定服务器类型支持的版本列表。
     ///
-    /// 依赖类型存在性：类型不存在时收敛为
+    /// 查询失败（类型不存在或底层配置不可用）统一收敛为
     /// [`ServerCatalogServiceError::NotFound`]。
     async fn versions(
         &self,
@@ -42,7 +42,7 @@ impl ServerCatalogService for CoreServerCatalogService {
     }
     /// 查询指定服务器类型的下载详情（版本 → 文件下载链接）。
     ///
-    /// 依赖类型存在性：类型不存在时收敛为
+    /// 查询失败（类型不存在或底层配置不可用）统一收敛为
     /// [`ServerCatalogServiceError::NotFound`]。
     async fn details(
         &self,

--- a/application/src/service/catalog.rs
+++ b/application/src/service/catalog.rs
@@ -1,15 +1,37 @@
+//! 服务器目录服务实现。
+//!
+//! 实现 [`sealantern_interface::ServerCatalogService`] 能力端口，组合
+//! `extra` 的下载链接管理能力（[`LinkManager`]），向宿主提供可用的
+//! 服务器类型、版本与下载详情查询。
+//!
+//! 错误分层：底层配置拉取失败统一收敛为
+//! [`ServerCatalogServiceError::OperationFailed`]；指定类型不存在
+//! （版本 / 详情查询依赖类型存在性）收敛为
+//! [`ServerCatalogServiceError::NotFound`]。
+
 use async_trait::async_trait;
 use sealantern_extra::download_link::{LinkManager, TypeDownloadLinks};
 use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
+
+/// 基于 `extra` 下载链接管理的服务器目录服务实现。
 #[derive(Debug, Default)]
 pub struct CoreServerCatalogService;
+
 #[async_trait]
 impl ServerCatalogService for CoreServerCatalogService {
+    /// 查询可用的服务器类型列表。
+    ///
+    /// 类型列表来自远程下载链接配置，配置拉取 / 解析失败时收敛为
+    /// [`ServerCatalogServiceError::OperationFailed`]。
     async fn server_types(&self) -> Result<Vec<String>, ServerCatalogServiceError> {
         LinkManager::get_server_types()
             .await
             .map_err(|_| ServerCatalogServiceError::OperationFailed)
     }
+    /// 查询指定服务器类型支持的版本列表。
+    ///
+    /// 依赖类型存在性：类型不存在时收敛为
+    /// [`ServerCatalogServiceError::NotFound`]。
     async fn versions(
         &self,
         server_type: String,
@@ -18,6 +40,10 @@ impl ServerCatalogService for CoreServerCatalogService {
             .await
             .map_err(|_| ServerCatalogServiceError::NotFound)
     }
+    /// 查询指定服务器类型的下载详情（版本 → 文件下载链接）。
+    ///
+    /// 依赖类型存在性：类型不存在时收敛为
+    /// [`ServerCatalogServiceError::NotFound`]。
     async fn details(
         &self,
         server_type: String,

--- a/application/src/service/java.rs
+++ b/application/src/service/java.rs
@@ -1,3 +1,16 @@
+//! Java 环境检测与校验服务实现。
+//!
+//! 实现 [`sealantern_interface::JavaService`] 能力端口，组合 `extra` 的
+//! Java 探测能力（[`detect_java_installations_with_diagnostics`]、
+//! [`validate_java`]），向宿主提供本机 Java 安装检测与指定可执行文件校验。
+//!
+//! 探测与校验都是同步且可能耗时的文件系统 / 进程操作，经 `spawn_blocking`
+//! 调度到阻塞线程池执行，避免阻塞异步运行时的核心线程。
+//!
+//! 错误分层：任务调度失败（join 错误）收敛为
+//! [`JavaServiceError::OperationFailed`]；校验判定 Java 无效收敛为
+//! [`JavaServiceError::InvalidInput`]。
+
 use async_trait::async_trait;
 use sealantern_extra::java::{
     detect_java_installations_with_diagnostics, validate_java, JavaDetectionReport,
@@ -5,19 +18,31 @@ use sealantern_extra::java::{
 use sealantern_extra::models::JavaInfo;
 use sealantern_interface::{JavaService, JavaServiceError};
 
+/// 基于 `extra` Java 探测能力的 Java 环境服务实现。
 #[derive(Debug, Default)]
 pub struct CoreJavaService;
+
 #[async_trait]
 impl JavaService for CoreJavaService {
+    /// 检测本机已安装的全部 Java 环境。
+    ///
+    /// Java 探测是同步的文件系统扫描，经 `spawn_blocking` 调度到阻塞
+    /// 线程池执行，避免阻塞异步运行时的核心线程。
     async fn detect(&self) -> Result<JavaDetectionReport, JavaServiceError> {
         tokio::task::spawn_blocking(detect_java_installations_with_diagnostics)
             .await
             .map_err(|_| JavaServiceError::OperationFailed)
     }
+    /// 校验指定 Java 可执行文件并读取其安装信息。
+    ///
+    /// 同步的进程 / 文件操作经 `spawn_blocking` 调度；闭包 move 捕获路径，
+    /// 避免借用跨 await 边界。
     async fn validate(&self, path: String) -> Result<JavaInfo, JavaServiceError> {
         tokio::task::spawn_blocking(move || validate_java(&path))
             .await
+            // 任务调度失败（任务 panic / 取消）视为操作失败。
             .map_err(|_| JavaServiceError::OperationFailed)?
+            // 校验判定 Java 无效（路径为空 / 不是有效安装）视为输入非法。
             .map_err(|_| JavaServiceError::InvalidInput)
     }
 }

--- a/application/src/service/mod.rs
+++ b/application/src/service/mod.rs
@@ -1,7 +1,9 @@
 //! 应用层服务实现模块。
 //!
 //! 存放各类宿主能力的默认实现（如 [`CoreInstanceService`]、[`CoreSystemService`]、
-//! [`CoreServerService`]、[`CoreDownloadService`]、[`CoreCronTaskService`]），实现
+//! [`CoreServerService`]、[`CoreDownloadService`]、[`CoreCronTaskService`]、
+//! [`CoreJavaService`]、[`CoreServerCatalogService`]、[`CoreProvisioningService`]、
+//! [`CoreOnlineTunnelService`]、[`CoreUpdateInstallService`]），实现
 //! `interface` 的能力端口，由 `services` 装配层组装进全局容器。
 
 mod catalog;

--- a/application/src/service/online_tunnel.rs
+++ b/application/src/service/online_tunnel.rs
@@ -1,3 +1,16 @@
+//! 在线隧道服务实现。
+//!
+//! 实现 [`sealantern_interface::OnlineTunnelService`] 能力端口，包装
+//! `extra` 的在线隧道实现（[`ExtraOnlineTunnelService`]），向宿主提供
+//! 开服（host）/ 联机（join）/ 停止 / 状态查询 / 事件订阅 / 关闭能力。
+//!
+//! 本层只做两件事：把接口请求转换为 `extra` 的请求模型，并把 `extra`
+//! 返回的状态、事件与错误映射回接口契约类型。
+//!
+//! 错误分层：底层 [`OnlineTunnelError`] 按语义映射为
+//! [`OnlineTunnelServiceError`]：非法请求 → `InvalidInput`，隧道忙碌 →
+//! `Busy`，未运行 → `NotRunning`，其余 provider 失败 → `OperationFailed`。
+
 use async_trait::async_trait;
 use sealantern_extra::online::{
     HostTunnelRequest, JoinTunnelRequest, OnlineTunnelError,
@@ -10,13 +23,21 @@ use sealantern_interface::{
 };
 use tokio::sync::broadcast;
 
+/// 基于 `extra` 在线隧道实现的在线隧道服务。
+///
+/// 内部持有 `extra` 层隧道服务句柄，对外提供接口契约视图；
+/// 隧道会话由底层维护，本服务只做请求转换与结果映射。
 #[derive(Clone, Default)]
 pub struct CoreOnlineTunnelService {
+    /// `extra` 层的隧道服务（实际连接与事件源）。
     inner: ExtraOnlineTunnelService,
 }
 
 #[async_trait]
 impl OnlineTunnelService for CoreOnlineTunnelService {
+    /// 以开服者身份建立在线隧道。
+    ///
+    /// 可选身份密钥先转为底层需要的字节形式；转换失败视为非法输入。
     async fn host(
         &self,
         request: OnlineTunnelHostRequest,
@@ -43,6 +64,9 @@ impl OnlineTunnelService for CoreOnlineTunnelService {
             .map_err(map_error)
     }
 
+    /// 以票据加入他人隧道。
+    ///
+    /// 票据解析失败直接以非法输入返回，不进入底层。
     async fn join(
         &self,
         request: OnlineTunnelJoinRequest,
@@ -61,14 +85,20 @@ impl OnlineTunnelService for CoreOnlineTunnelService {
             .map_err(map_error)
     }
 
+    /// 停止当前隧道。
     async fn stop(&self) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError> {
         self.inner.stop().await.map(map_status).map_err(map_error)
     }
 
+    /// 查询当前隧道状态快照。
     async fn status(&self) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError> {
         self.inner.status().await.map(map_status).map_err(map_error)
     }
 
+    /// 订阅隧道事件流。
+    ///
+    /// 底层事件模型与接口不同，这里起一个转发任务，把底层广播流的
+    /// 每个事件映射为接口事件后重新广播；转发任务随源流关闭而结束。
     async fn subscribe(
         &self,
     ) -> Result<broadcast::Receiver<OnlineTunnelEvent>, OnlineTunnelServiceError> {
@@ -82,11 +112,13 @@ impl OnlineTunnelService for CoreOnlineTunnelService {
         Ok(receiver)
     }
 
+    /// 关闭隧道并释放底层资源。
     async fn shutdown(&self) -> Result<(), OnlineTunnelServiceError> {
         self.inner.shutdown().await.map_err(map_error)
     }
 }
 
+/// 将底层隧道错误按语义映射为接口契约错误。
 fn map_error(error: OnlineTunnelError) -> OnlineTunnelServiceError {
     match error {
         OnlineTunnelError::InvalidRequest { .. } => OnlineTunnelServiceError::InvalidInput,
@@ -96,6 +128,7 @@ fn map_error(error: OnlineTunnelError) -> OnlineTunnelServiceError {
     }
 }
 
+/// 将底层隧道角色映射为接口角色。
 fn map_mode(value: TunnelMode) -> OnlineTunnelMode {
     match value {
         TunnelMode::Host => OnlineTunnelMode::Host,
@@ -103,6 +136,7 @@ fn map_mode(value: TunnelMode) -> OnlineTunnelMode {
     }
 }
 
+/// 将底层对端连接快照映射为接口连接快照。
 fn map_connection(value: TunnelConnection) -> OnlineTunnelConnection {
     OnlineTunnelConnection {
         remote_id: value.remote_id,
@@ -115,6 +149,7 @@ fn map_connection(value: TunnelConnection) -> OnlineTunnelConnection {
     }
 }
 
+/// 将底层隧道状态快照映射为接口状态快照。
 fn map_status(value: TunnelStatus) -> OnlineTunnelStatus {
     OnlineTunnelStatus {
         active: value.active,
@@ -124,6 +159,7 @@ fn map_status(value: TunnelStatus) -> OnlineTunnelStatus {
     }
 }
 
+/// 将底层隧道事件映射为接口事件。
 fn map_event(value: TunnelEvent) -> OnlineTunnelEvent {
     match value {
         TunnelEvent::PlayerJoined { remote_id } => OnlineTunnelEvent::PlayerJoined { remote_id },

--- a/application/src/service/provisioning.rs
+++ b/application/src/service/provisioning.rs
@@ -1,4 +1,17 @@
-//! Application adapter for side-effect-free provisioning operations.
+//! 服务端检查与供给计划服务实现。
+//!
+//! 实现 [`sealantern_interface::ProvisioningService`] 能力端口，组合
+//! `core` 的供给规划能力（[`inspect_server_artifact`]、
+//! [`parse_startup_script_file`]、[`plan_existing_instance`]、
+//! [`plan_copy`]、[`plan_modpack`]），向宿主提供服务器文件检查、
+//! 启动脚本解析与各类供给计划生成。
+//!
+//! 所有暴露操作只做"检查 / 规划"，不产生副作用（不复制文件、不写盘）。
+//!
+//! 错误分层：`spawn_blocking` 任务调度失败收敛为
+//! [`ProvisioningServiceError::OperationFailed`]；服务器检查失败收敛为
+//! [`ProvisioningServiceError::InspectionFailed`]；启动脚本解析失败与
+//! 各规划请求非法收敛为 [`ProvisioningServiceError::InvalidInput`]。
 
 use std::path::Path;
 
@@ -11,12 +24,18 @@ use sealantern_core::provisioning::{
 };
 use sealantern_interface::{ProvisioningService, ProvisioningServiceError};
 
-/// Default provisioning service. All exposed operations inspect or plan only.
+/// 基于 `core` 供给规划能力的检查与计划服务实现。
+///
+/// 暴露的操作均为纯检查 / 规划，不产生副作用。
 #[derive(Debug, Default)]
 pub struct CoreProvisioningService;
 
 #[async_trait]
 impl ProvisioningService for CoreProvisioningService {
+    /// 检查服务器文件结构并生成检查报告。
+    ///
+    /// 文件检查是同步且可能耗时的目录扫描，经 `spawn_blocking` 调度到
+    /// 阻塞线程池执行，避免阻塞异步运行时的核心线程。
     async fn inspect_server(
         &self,
         path: &Path,
@@ -26,10 +45,16 @@ impl ProvisioningService for CoreProvisioningService {
             inspect_server_artifact(&path, &InspectionOptions::default())
         })
         .await
+        // 任务调度失败（任务 panic / 取消）视为操作失败。
         .map_err(|_| ProvisioningServiceError::OperationFailed)?
+        // 检查判定目标不是可用服务器结构（目录缺失 / 结构不符）视为检查失败。
         .map_err(|_| ProvisioningServiceError::InspectionFailed)
     }
 
+    /// 解析启动脚本并提取可移植的启动信息。
+    ///
+    /// 同步的文件解析经 `spawn_blocking` 调度，避免阻塞异步 runtime；
+    /// 解析失败（脚本缺失 / 格式不支持）统一收敛为非法输入。
     async fn parse_startup_script(
         &self,
         path: &Path,
@@ -37,10 +62,15 @@ impl ProvisioningService for CoreProvisioningService {
         let path = path.to_path_buf();
         tokio::task::spawn_blocking(move || parse_startup_script_file(&path))
             .await
+            // 任务调度失败视为操作失败。
             .map_err(|_| ProvisioningServiceError::OperationFailed)?
+            // 解析失败视为输入非法。
             .map_err(|_| ProvisioningServiceError::InvalidInput)
     }
 
+    /// 为导入既有实例生成供给计划。
+    ///
+    /// 请求非法（目录缺失 / 信息不完整）时收敛为非法输入。
     async fn plan_existing_instance(
         &self,
         request: InstanceImportRequest,
@@ -48,6 +78,7 @@ impl ProvisioningService for CoreProvisioningService {
         plan_existing_instance(request).map_err(|_| ProvisioningServiceError::InvalidInput)
     }
 
+    /// 为复制实例生成供给计划（复制范围与步骤清单）。
     async fn plan_copy(
         &self,
         request: CopyInstanceRequest,
@@ -55,6 +86,7 @@ impl ProvisioningService for CoreProvisioningService {
         plan_copy(request).map_err(|_| ProvisioningServiceError::InvalidInput)
     }
 
+    /// 为导入整合包生成供给计划。
     async fn plan_modpack(
         &self,
         request: ModpackProvisionRequest,

--- a/application/src/service/update_install.rs
+++ b/application/src/service/update_install.rs
@@ -1,3 +1,15 @@
+//! 应用更新安装服务实现。
+//!
+//! 实现 [`sealantern_interface::UpdateInstallService`] 能力端口，组合
+//! `extra` 的更新落盘能力（[`download_update_file_without_events`]、
+//! [`write_pending_update`]、[`check_pending_update`] 等），向宿主提供
+//! 更新文件下载、待安装记录查询 / 清理与安装进程拉起。
+//!
+//! 错误分层：底层下载 / 落盘 / 查询失败统一收敛为
+//! [`UpdateInstallServiceError::OperationFailed`]；版本号为空等非法参数
+//! 收敛为 [`UpdateInstallServiceError::InvalidInput`]；非 Windows 平台
+//! 无法拉起安装进程，返回 [`UpdateInstallServiceError::Unsupported`]。
+
 use async_trait::async_trait;
 use sealantern_extra::update::{
     check_pending_update, clear_pending_update, download_update_file_without_events,
@@ -5,11 +17,16 @@ use sealantern_extra::update::{
 };
 use sealantern_interface::{UpdateInstallService, UpdateInstallServiceError};
 
+/// 基于 `extra` 更新落盘能力的更新安装服务实现。
 #[derive(Debug, Default)]
 pub struct CoreUpdateInstallService;
 
 #[async_trait]
 impl UpdateInstallService for CoreUpdateInstallService {
+    /// 下载更新文件并登记为待安装。
+    ///
+    /// 版本号为空视为非法输入；下载成功后把文件路径与版本写入待安装
+    /// 记录，供应用重启后的安装流程读取。
     async fn download(
         &self,
         url: String,
@@ -26,16 +43,26 @@ impl UpdateInstallService for CoreUpdateInstallService {
             .map_err(|_| UpdateInstallServiceError::OperationFailed)?;
         Ok(path)
     }
+
+    /// 查询是否存在待安装更新（下载完成但尚未安装）。
     async fn pending(&self) -> Result<Option<PendingUpdate>, UpdateInstallServiceError> {
         check_pending_update()
             .await
             .map_err(|_| UpdateInstallServiceError::OperationFailed)
     }
+
+    /// 清除待安装更新记录。
     async fn clear_pending(&self) -> Result<(), UpdateInstallServiceError> {
         clear_pending_update()
             .await
             .map_err(|_| UpdateInstallServiceError::OperationFailed)
     }
+
+    /// 启动更新安装流程。
+    ///
+    /// Windows 下通过提权进程拉起安装器；安装完成后由底层监视进程
+    /// 删除安装文件与待安装记录，并重启主应用。其他平台暂不支持
+    /// 进程级安装，直接返回不支持。
     async fn install(
         &self,
         file_path: String,
@@ -44,6 +71,8 @@ impl UpdateInstallService for CoreUpdateInstallService {
         #[cfg(target_os = "windows")]
         {
             let refs = arguments.iter().map(String::as_str).collect::<Vec<_>>();
+            // 提权启动安装器，并把安装文件与待安装记录路径交给底层监视进程，
+            // 使其在安装完成后执行清理并重启主应用。
             sealantern_extra::update::spawn_elevated_windows_process(
                 &file_path,
                 &refs,
@@ -54,6 +83,7 @@ impl UpdateInstallService for CoreUpdateInstallService {
         }
         #[cfg(not(target_os = "windows"))]
         {
+            // 非 Windows 平台暂无安装通道，参数仅做丢弃处理。
             let _ = (file_path, arguments);
             Err(UpdateInstallServiceError::Unsupported)
         }

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -41,8 +41,11 @@ pub struct AppServicesInner {
     pub download: Arc<CoreDownloadService>,
     /// 服务器实例记录管理服务。
     pub instance: Arc<CoreInstanceService>,
+    /// Java 环境检测与校验服务。
     pub java: Arc<CoreJavaService>,
+    /// 在线隧道服务。
     pub online_tunnel: Arc<CoreOnlineTunnelService>,
+    /// 服务器目录（类型 / 版本 / 下载详情）服务。
     pub catalog: Arc<CoreServerCatalogService>,
     /// 服务端检查与供给计划服务。
     pub provisioning: Arc<CoreProvisioningService>,
@@ -58,6 +61,7 @@ pub struct AppServicesInner {
     pub system: Arc<CoreSystemService>,
     /// 应用更新检查服务。
     pub update: Arc<CoreUpdateCheckService>,
+    /// 应用更新安装服务。
     pub update_install: Arc<CoreUpdateInstallService>,
     /// 惰性初始化的应用插件服务。
     plugin: tokio::sync::OnceCell<Arc<CorePluginService>>,
@@ -163,12 +167,18 @@ impl AppServices {
     pub fn instance(&self) -> &Arc<CoreInstanceService> {
         &self.inner.instance
     }
+
+    /// 访问 Java 环境检测与校验服务（`Arc` 共享句柄，clone 廉价）。
     pub fn java(&self) -> &Arc<CoreJavaService> {
         &self.inner.java
     }
+
+    /// 访问在线隧道服务（`Arc` 共享句柄，clone 廉价）。
     pub fn online_tunnel(&self) -> &Arc<CoreOnlineTunnelService> {
         &self.inner.online_tunnel
     }
+
+    /// 访问服务器目录服务（`Arc` 共享句柄，clone 廉价）。
     pub fn catalog(&self) -> &Arc<CoreServerCatalogService> {
         &self.inner.catalog
     }
@@ -259,6 +269,8 @@ impl AppServices {
     pub fn update(&self) -> &Arc<CoreUpdateCheckService> {
         &self.inner.update
     }
+
+    /// 访问应用更新安装服务（`Arc` 共享句柄，clone 廉价）。
     pub fn update_install(&self) -> &Arc<CoreUpdateInstallService> {
         &self.inner.update_install
     }

--- a/crates/extra/src/java/discovery.rs
+++ b/crates/extra/src/java/discovery.rs
@@ -32,6 +32,8 @@ impl JavaSearchSource {
 }
 
 /// Java 自动检测结果；成功安装和非致命错误同时保留。
+///
+/// 可序列化导出给服务接口层，字段使用 snake_case 命名。
 #[derive(Debug, Default, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct JavaDetectionReport {

--- a/crates/extra/src/java/error.rs
+++ b/crates/extra/src/java/error.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
 /// Java 自动检测中单个来源或候选产生的非致命错误。
+///
+/// 可随检测报告一起序列化导出，字段使用 snake_case 命名。
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct JavaDiscoveryError {

--- a/crates/extra/src/models/download_link.rs
+++ b/crates/extra/src/models/download_link.rs
@@ -1,17 +1,26 @@
 //! 服务器核心下载链接模型。
+//!
+//! 数据按「服务器核心类型 → Minecraft 版本 → 下载链接」三级结构组织，
+//! 字段统一采用 snake_case 命名，便于 JSON 序列化交换。
 
 use serde::{Deserialize, Serialize};
 
-/// 单个下载链接。
+/// 单个下载链接，对应某 Minecraft 版本下的一个可下载文件。
+///
+/// 序列化时字段统一使用 snake_case 命名，如 `file_name`。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct DownloadLink {
+    /// Minecraft 版本号，如 `1.21.1`。
     pub version: String,
+    /// 下载文件的名称，如 `server.jar`。
     pub file_name: String,
+    /// 下载地址。
     pub url: String,
 }
 
 impl DownloadLink {
+    /// 构造单个下载链接。
     pub fn new(version: String, file_name: String, url: String) -> Self {
         Self { version, file_name, url }
     }
@@ -20,20 +29,26 @@ impl DownloadLink {
 /// 同一服务器核心类型的版本和下载链接。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypeDownloadLinks {
+    /// 服务器核心类型名称。
     pub server_type: String,
+    /// 该类型支持的 Minecraft 版本列表。
     pub versions: Vec<String>,
+    /// 各版本对应的下载链接。
     pub links: Vec<DownloadLink>,
 }
 
 impl TypeDownloadLinks {
+    /// 构造指定类型的版本与下载链接数据。
     pub fn new(server_type: String, versions: Vec<String>, links: Vec<DownloadLink>) -> Self {
         Self { server_type, versions, links }
     }
 
+    /// 返回该类型支持的版本列表。
     pub fn get_versions(&self) -> Vec<String> {
         self.versions.clone()
     }
 
+    /// 按版本号查找对应的下载链接。
     pub fn get_link_by_version(&self, version: &str) -> Option<&DownloadLink> {
         self.links.iter().find(|link| link.version == version)
     }
@@ -42,19 +57,24 @@ impl TypeDownloadLinks {
 /// 所有服务器核心类型的下载链接数据。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseDownloadLinks {
+    /// 全部服务器核心类型名称。
     pub server_types: Vec<String>,
+    /// 各类型的版本与下载链接数据。
     pub links: Vec<TypeDownloadLinks>,
 }
 
 impl BaseDownloadLinks {
+    /// 构造完整的下载链接数据集合。
     pub fn new(server_types: Vec<String>, links: Vec<TypeDownloadLinks>) -> Self {
         Self { server_types, links }
     }
 
+    /// 返回全部服务器核心类型名称。
     pub fn get_types(&self) -> Vec<String> {
         self.server_types.clone()
     }
 
+    /// 按类型名称查找对应的版本与下载链接数据。
     pub fn get_type_by_name(&self, type_name: &str) -> Option<&TypeDownloadLinks> {
         self.links.iter().find(|link| link.server_type == type_name)
     }
@@ -64,6 +84,7 @@ impl BaseDownloadLinks {
 mod tests {
     use super::DownloadLink;
 
+    // 校验序列化输出统一使用 snake_case 字段名。
     #[test]
     fn download_link_uses_snake_case_field_names() {
         let value = serde_json::to_value(DownloadLink::new(

--- a/crates/interface/src/catalog/mod.rs
+++ b/crates/interface/src/catalog/mod.rs
@@ -1,2 +1,6 @@
+//! 服务器核心下载目录服务契约。
+//!
+//! 提供服务器核心类型、版本与下载链接查询的宿主能力端口，供各宿主统一消费。
+
 pub mod service;
 pub use service::ServerCatalogService;

--- a/crates/interface/src/catalog/service.rs
+++ b/crates/interface/src/catalog/service.rs
@@ -1,11 +1,21 @@
+//! 服务器核心下载目录宿主能力端口。
+
 use crate::error::ServerCatalogServiceError;
 use async_trait::async_trait;
 use sealantern_extra::download_link::TypeDownloadLinks;
+
+/// 服务器核心下载目录宿主能力端口。
+///
+/// 方法均为异步：下载目录数据可能来自远程配置。实现方组合 `infra` 或 `extra` 的
+/// 下载链接能力，不依赖任何具体宿主。
 #[async_trait]
 pub trait ServerCatalogService: Send + Sync {
+    /// 返回全部可用的服务器核心类型。
     async fn server_types(&self) -> Result<Vec<String>, ServerCatalogServiceError>;
+    /// 返回指定服务器核心类型的可用版本列表。
     async fn versions(&self, server_type: String)
         -> Result<Vec<String>, ServerCatalogServiceError>;
+    /// 返回指定服务器核心类型的版本与下载链接明细。
     async fn details(
         &self,
         server_type: String,

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -236,7 +236,7 @@ impl std::error::Error for UpdateCheckServiceError {}
 pub enum ProvisioningServiceError {
     /// 客户端提供的输入不合法（如路径为空、请求字段冲突）。
     InvalidInput,
-    /// 服务器目录检查或启动脚本解析失败。
+    /// 服务器目录检查失败。
     InspectionFailed,
     /// 未分类的内部供给计划操作失败。
     OperationFailed,
@@ -296,7 +296,7 @@ impl std::error::Error for ServerCatalogServiceError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateInstallServiceError {
-    /// 客户端提供的安装输入不合法（如 URL 为空、哈希格式错误）。
+    /// 客户端提供的安装输入不合法（如版本号为空）。
     InvalidInput,
     /// 底层下载、校验或安装过程失败。
     OperationFailed,

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -234,8 +234,11 @@ impl std::error::Error for UpdateCheckServiceError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProvisioningServiceError {
+    /// 客户端提供的输入不合法（如路径为空、请求字段冲突）。
     InvalidInput,
+    /// 服务器目录检查或启动脚本解析失败。
     InspectionFailed,
+    /// 未分类的内部供给计划操作失败。
     OperationFailed,
 }
 
@@ -251,10 +254,13 @@ impl std::fmt::Display for ProvisioningServiceError {
 
 impl std::error::Error for ProvisioningServiceError {}
 
+/// Java 检测与校验失败的契约错误类别。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum JavaServiceError {
+    /// 客户端提供的 Java 路径不合法或不可访问。
     InvalidInput,
+    /// 底层 Java 检测或校验操作失败。
     OperationFailed,
 }
 impl std::fmt::Display for JavaServiceError {
@@ -267,10 +273,13 @@ impl std::fmt::Display for JavaServiceError {
 }
 impl std::error::Error for JavaServiceError {}
 
+/// 服务器核心下载目录失败的契约错误类别。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ServerCatalogServiceError {
+    /// 指定的服务器核心类型或版本不存在。
     NotFound,
+    /// 底层下载目录查询操作失败。
     OperationFailed,
 }
 impl std::fmt::Display for ServerCatalogServiceError {
@@ -283,11 +292,15 @@ impl std::fmt::Display for ServerCatalogServiceError {
 }
 impl std::error::Error for ServerCatalogServiceError {}
 
+/// 应用更新下载与安装失败的契约错误类别。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateInstallServiceError {
+    /// 客户端提供的安装输入不合法（如 URL 为空、哈希格式错误）。
     InvalidInput,
+    /// 底层下载、校验或安装过程失败。
     OperationFailed,
+    /// 当前宿主不支持更新安装。
     Unsupported,
 }
 impl std::fmt::Display for UpdateInstallServiceError {
@@ -304,9 +317,13 @@ impl std::error::Error for UpdateInstallServiceError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OnlineTunnelServiceError {
+    /// 客户端提供的隧道请求不合法（如票据为空）。
     InvalidInput,
+    /// 已有隧道正在启动、运行或停止，无法响应新操作。
     Busy,
+    /// 当前没有运行中的隧道。
     NotRunning,
+    /// 底层隧道操作失败。
     OperationFailed,
 }
 

--- a/crates/interface/src/java/mod.rs
+++ b/crates/interface/src/java/mod.rs
@@ -1,2 +1,6 @@
+//! Java 检测与校验服务契约。
+//!
+//! 提供本机 Java 安装扫描与指定路径校验的宿主能力端口。
+
 pub mod service;
 pub use service::JavaService;

--- a/crates/interface/src/java/service.rs
+++ b/crates/interface/src/java/service.rs
@@ -1,11 +1,20 @@
+//! Java 检测与校验宿主能力端口。
+
 use async_trait::async_trait;
 use sealantern_extra::java::JavaDetectionReport;
 use sealantern_extra::models::JavaInfo;
 
 use crate::error::JavaServiceError;
 
+/// Java 检测与校验宿主能力端口。
 #[async_trait]
 pub trait JavaService: Send + Sync {
+    /// 扫描本机可用的 Java 安装。
+    ///
+    /// 返回的报告中同时保留成功安装与非致命错误，供调用方判断缺失项。
     async fn detect(&self) -> Result<JavaDetectionReport, JavaServiceError>;
+    /// 校验指定路径的 Java 安装是否可用，并返回其环境信息。
+    ///
+    /// 路径不可用、不可执行或无法解析版本时返回错误。
     async fn validate(&self, path: String) -> Result<JavaInfo, JavaServiceError>;
 }

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![forbid(unsafe_code)]
 
+/// 服务器核心下载目录相关模型与服务端口。
 pub mod catalog;
 /// 服务器定时任务相关模型与服务端口。
 pub mod cron;
@@ -14,8 +15,9 @@ pub mod download;
 pub mod error;
 /// 服务器实例记录相关模型与服务端口。
 pub mod instance;
+/// Java 检测与校验相关模型与服务端口。
 pub mod java;
-/// Online tunnel related service contracts.
+/// 在线隧道相关模型与服务端口。
 pub mod online;
 /// 服务端检查与实例供给计划相关服务端口。
 pub mod provisioning;
@@ -28,6 +30,7 @@ pub mod system;
 /// 应用更新检查相关模型与服务端口。
 pub mod update;
 
+/// 服务器核心下载目录服务端口。
 pub use catalog::ServerCatalogService;
 /// 服务器定时任务服务端口。
 pub use cron::CronTaskService;
@@ -39,10 +42,13 @@ pub use error::CronTaskServiceError;
 pub use error::DownloadServiceError;
 /// 服务器实例管理错误枚举。
 pub use error::InstanceServiceError;
+/// Java 检测与校验错误枚举。
 pub use error::JavaServiceError;
+/// 在线隧道服务错误枚举。
 pub use error::OnlineTunnelServiceError;
 /// 服务端检查与实例供给计划失败类别。
 pub use error::ProvisioningServiceError;
+/// 服务器核心下载目录错误枚举。
 pub use error::ServerCatalogServiceError;
 /// 服务器进程管理错误枚举。
 pub use error::ServerServiceError;
@@ -52,10 +58,13 @@ pub use error::SettingsServiceError;
 pub use error::SystemServiceError;
 /// 应用更新检查错误枚举。
 pub use error::UpdateCheckServiceError;
+/// 应用更新安装错误枚举。
 pub use error::UpdateInstallServiceError;
 /// 服务器实例记录管理服务端口。
 pub use instance::InstanceService;
+/// Java 检测与校验服务端口。
 pub use java::JavaService;
+/// 在线隧道模型与服务端口。
 pub use online::{
     OnlineTunnelConnection, OnlineTunnelEvent, OnlineTunnelHostRequest, OnlineTunnelJoinRequest,
     OnlineTunnelMode, OnlineTunnelService, OnlineTunnelStatus,
@@ -70,4 +79,5 @@ pub use settings::SettingsService;
 pub use system::SystemService;
 /// 应用更新检查服务端口。
 pub use update::UpdateCheckService;
+/// 应用更新安装服务端口。
 pub use update::UpdateInstallService;

--- a/crates/interface/src/online/mod.rs
+++ b/crates/interface/src/online/mod.rs
@@ -1,4 +1,6 @@
-//! Online tunnel service contracts.
+//! 在线隧道服务契约。
+//!
+//! 定义隧道启动请求、运行状态与事件等模型，以及开启 / 加入隧道的宿主能力端口。
 
 mod model;
 mod service;

--- a/crates/interface/src/online/model.rs
+++ b/crates/interface/src/online/model.rs
@@ -1,88 +1,143 @@
+//! 在线隧道契约模型。
+//!
+//! 定义隧道启动请求、运行角色、对端连接快照、状态与事件等模型，
+//! 全部可序列化，供跨传输面传递。
+
 use serde::{Deserialize, Serialize};
 
+/// 以 Host 角色开启隧道的请求。
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct OnlineTunnelHostRequest {
+    /// 对外暴露给对端的 Minecraft 端口。
     pub minecraft_port: u16,
+    /// 可选的对端访问密码。
     pub password: Option<String>,
+    /// 可选的并发玩家数上限。
     pub max_players: Option<u32>,
+    /// 可选的中继服务器地址；为空时使用默认中继。
     pub relay_url: Option<String>,
-    /// Optional stable 32-byte host identity. It is never included in responses.
+    /// 可选的稳定 32 字节主机身份密钥，永远不会包含在响应中。
     pub identity: Option<Vec<u8>>,
 }
 
+/// 以 Join 角色加入已有隧道的请求。
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct OnlineTunnelJoinRequest {
+    /// 主机分享的隧道票据。
     pub ticket: String,
+    /// 本地需要暴露到隧道内的端口。
     pub local_port: u16,
+    /// 可选的对端访问密码。
     pub password: Option<String>,
+    /// 可选的连接失败最大重试次数。
     pub max_retries: Option<u32>,
 }
 
+/// 在线隧道的运行角色。
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OnlineTunnelMode {
+    /// 作为主机开启隧道。
     Host,
+    /// 作为对端加入隧道。
     Join,
 }
 
+/// 已建立隧道中单个对端的运行时快照。
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct OnlineTunnelConnection {
+    /// 对端唯一标识。
     pub remote_id: String,
+    /// 是否经过中继服务器转发。
     pub is_relay: bool,
+    /// 最近一次往返时延（毫秒）。
     pub rtt_ms: u64,
+    /// 累计发送字节。
     pub tx_bytes: u64,
+    /// 累计接收字节。
     pub rx_bytes: u64,
+    /// 对端当前是否在线。
     pub alive: bool,
+    /// 该连接已存在时长（毫秒）。
     pub elapsed_ms: u64,
 }
 
+/// 当前在线隧道状态快照。
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct OnlineTunnelStatus {
+    /// 隧道是否处于活动状态。
     pub active: bool,
+    /// 当前运行角色；隧道未启动时为空。
     pub mode: Option<OnlineTunnelMode>,
-    /// Present only for a hosted tunnel so the caller can share it with peers.
+    /// 仅 Host 隧道存在，供主机分享给对端使用。
     pub ticket: Option<String>,
+    /// 当前已建立的对端连接列表。
     pub connections: Vec<OnlineTunnelConnection>,
 }
 
+/// 应用层的在线隧道事件。
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum OnlineTunnelEvent {
+    /// 有玩家加入隧道。
     PlayerJoined {
+        /// 加入玩家的标识。
         remote_id: String,
     },
+    /// 有玩家离开隧道。
     PlayerLeft {
+        /// 离开玩家的标识。
         remote_id: String,
+        /// 离开原因。
         reason: String,
     },
+    /// 隧道已连通。
     Connected,
+    /// 隧道断开。
     Disconnected {
+        /// 断开原因。
         reason: String,
     },
+    /// 对端的数据路径发生变化（如改经中继转发）。
     PathChanged {
+        /// 路径变化对端的标识。
         remote_id: String,
+        /// 是否改经中继服务器转发。
         is_relay: bool,
+        /// 新路径的往返时延（毫秒）。
         rtt_ms: u64,
     },
+    /// 正在重连。
     Reconnecting {
+        /// 当前重连尝试次数。
         attempt: u32,
     },
+    /// 重连成功。
     Reconnected,
+    /// 对端身份认证失败。
     AuthenticationFailed {
+        /// 认证失败对端的标识。
         remote_id: String,
     },
+    /// 对端被拒绝接入。
     PlayerRejected {
+        /// 被拒绝对端的标识。
         remote_id: String,
+        /// 拒绝原因。
         reason: String,
     },
+    /// 隧道操作失败。
     Error {
+        /// 错误描述。
         message: String,
     },
+    /// 底层中继提供方上报的消息。
     ProviderMessage {
+        /// 提供方消息内容。
         message: String,
     },
 }

--- a/crates/interface/src/online/service.rs
+++ b/crates/interface/src/online/service.rs
@@ -1,3 +1,5 @@
+//! 在线隧道宿主能力端口。
+
 use async_trait::async_trait;
 use tokio::sync::broadcast;
 
@@ -7,20 +9,30 @@ use super::{
     OnlineTunnelEvent, OnlineTunnelHostRequest, OnlineTunnelJoinRequest, OnlineTunnelStatus,
 };
 
+/// 在线隧道宿主能力端口。
+///
+/// 一个服务实例同一时刻至多持有一条活动隧道；隧道启动或停止期间，新的
+/// host / join 请求会被拒绝。
 #[async_trait]
 pub trait OnlineTunnelService: Send + Sync {
+    /// 以 Host 角色开启隧道，返回建立完成后的状态。
     async fn host(
         &self,
         request: OnlineTunnelHostRequest,
     ) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError>;
+    /// 以 Join 角色加入票据指定的隧道，返回建立完成后的状态。
     async fn join(
         &self,
         request: OnlineTunnelJoinRequest,
     ) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError>;
+    /// 停止当前活动隧道，返回空闲状态。
     async fn stop(&self) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError>;
+    /// 查询当前隧道状态；隧道正在启动或停止时返回忙错误。
     async fn status(&self) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError>;
+    /// 订阅隧道事件广播流，供调用方实时监听对端接入、断线与错误等事件。
     async fn subscribe(
         &self,
     ) -> Result<broadcast::Receiver<OnlineTunnelEvent>, OnlineTunnelServiceError>;
+    /// 幂等关闭服务持有的活动隧道，供宿主退出流程调用。
     async fn shutdown(&self) -> Result<(), OnlineTunnelServiceError>;
 }

--- a/crates/interface/src/provisioning/mod.rs
+++ b/crates/interface/src/provisioning/mod.rs
@@ -1,4 +1,6 @@
-//! Server provisioning inspection and planning contracts.
+//! 服务端检查与实例供给计划契约。
+//!
+//! 提供服务器目录检查、启动脚本解析与实例供给计划生成的宿主能力端口。
 
 pub mod service;
 

--- a/crates/interface/src/provisioning/service.rs
+++ b/crates/interface/src/provisioning/service.rs
@@ -1,3 +1,5 @@
+//! 服务端检查与实例供给计划宿主能力端口。
+
 use std::path::Path;
 
 use async_trait::async_trait;
@@ -9,29 +11,36 @@ use sealantern_core::provisioning::{
 
 use crate::error::ProvisioningServiceError;
 
-/// Host-facing provisioning capability. Planning never changes the filesystem.
+/// 服务端检查与供给计划宿主能力端口。
+///
+/// 所有 `plan_*` 方法只生成计划、不做任何文件系统修改，实际落盘由宿主执行。
 #[async_trait]
 pub trait ProvisioningService: Send + Sync {
+    /// 检查指定服务器目录，返回核心类型、Minecraft 版本与 Java 要求等识别报告。
     async fn inspect_server(
         &self,
         path: &Path,
     ) -> Result<ServerInspectionReport, ProvisioningServiceError>;
 
+    /// 静态解析指定启动脚本（不执行其内容），返回脚本格式与 Java 启动信息。
     async fn parse_startup_script(
         &self,
         path: &Path,
     ) -> Result<StartupScriptInfo, ProvisioningServiceError>;
 
+    /// 规划将已有目录导入为受管实例，不执行任何文件系统操作。
     async fn plan_existing_instance(
         &self,
         request: InstanceImportRequest,
     ) -> Result<sealantern_core::instance::InstanceImportPlan, ProvisioningServiceError>;
 
+    /// 规划将已有目录复制为受管实例，不执行任何文件系统操作。
     async fn plan_copy(
         &self,
         request: CopyInstanceRequest,
     ) -> Result<CopyInstancePlan, ProvisioningServiceError>;
 
+    /// 规划整合包导入为受管实例，不执行任何文件系统操作。
     async fn plan_modpack(
         &self,
         request: ModpackProvisionRequest,

--- a/crates/interface/src/update/mod.rs
+++ b/crates/interface/src/update/mod.rs
@@ -1,4 +1,4 @@
-//! 应用更新检查契约。
+//! 应用更新检查与安装契约。
 
 mod models;
 mod service;

--- a/crates/interface/src/update/service.rs
+++ b/crates/interface/src/update/service.rs
@@ -9,23 +9,30 @@ use super::models::UpdateInfo;
 /// 应用更新检查宿主能力端口。
 ///
 /// 当前版本由实现方从应用构建信息获取，宿主不得覆盖；下载与安装属于独立能力，
-/// 后续通过单独的 trait 扩展。
+/// 由 [`UpdateInstallService`] 承担。
 #[async_trait]
 pub trait UpdateCheckService: Send + Sync {
     /// 检查当前平台是否存在新版本。
     async fn check(&self) -> Result<UpdateInfo, UpdateCheckServiceError>;
 }
 
+/// 应用更新下载与安装宿主能力端口。
 #[async_trait]
 pub trait UpdateInstallService: Send + Sync {
+    /// 下载指定版本的更新资源到本地，返回文件路径。
+    ///
+    /// `expected_hash` 非空时校验下载内容的 SHA-256，不一致视为失败。
     async fn download(
         &self,
         url: String,
         expected_hash: Option<String>,
         version: String,
     ) -> Result<String, UpdateInstallServiceError>;
+    /// 查询已下载、待安装的更新；没有待安装内容时返回 `None`。
     async fn pending(&self) -> Result<Option<PendingUpdate>, UpdateInstallServiceError>;
+    /// 清除已下载的待安装更新记录。
     async fn clear_pending(&self) -> Result<(), UpdateInstallServiceError>;
+    /// 安装指定的更新文件，`arguments` 为安装过程附加参数。
     async fn install(
         &self,
         file_path: String,

--- a/src-tauri/src/adapter/tauri/commands/catalog.rs
+++ b/src-tauri/src/adapter/tauri/commands/catalog.rs
@@ -1,6 +1,16 @@
+//! 服务器类型目录 Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`ServerCatalogService`] 查询服务器核心类型、可用版本与下载链接。
+//!
+//! 错误统一为接口契约错误 [`ServerCatalogServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
+
 use sealantern_application::services::AppServices;
 use sealantern_extra::download_link::TypeDownloadLinks;
 use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
+
+/// 查询全部可用的服务器核心类型。
 #[tauri::command]
 pub async fn catalog_server_types() -> Result<Vec<String>, ServerCatalogServiceError> {
     AppServices::get()
@@ -10,6 +20,8 @@ pub async fn catalog_server_types() -> Result<Vec<String>, ServerCatalogServiceE
         .server_types()
         .await
 }
+
+/// 查询指定服务器核心类型支持的全部版本。
 #[tauri::command]
 pub async fn catalog_versions(
     server_type: String,
@@ -21,6 +33,8 @@ pub async fn catalog_versions(
         .versions(server_type)
         .await
 }
+
+/// 查询指定服务器核心类型的版本列表与各版本下载链接。
 #[tauri::command]
 pub async fn catalog_details(
     server_type: String,

--- a/src-tauri/src/adapter/tauri/commands/java.rs
+++ b/src-tauri/src/adapter/tauri/commands/java.rs
@@ -1,8 +1,19 @@
+//! Java 运行时检测与校验 Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`JavaService`] 扫描本机 Java 安装，或校验指定路径的 Java 可执行文件。
+//!
+//! 错误统一为接口契约错误 [`JavaServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
+
 use sealantern_application::services::AppServices;
 use sealantern_extra::java::JavaDetectionReport;
 use sealantern_extra::models::JavaInfo;
 use sealantern_interface::{JavaService, JavaServiceError};
 
+/// 自动检测本机已安装的 Java 运行时。
+///
+/// 返回检测报告，成功安装与非致命错误同时保留，供前端选择 Java 版本。
 #[tauri::command]
 pub async fn java_detect() -> Result<JavaDetectionReport, JavaServiceError> {
     AppServices::get()
@@ -12,6 +23,8 @@ pub async fn java_detect() -> Result<JavaDetectionReport, JavaServiceError> {
         .detect()
         .await
 }
+
+/// 校验指定路径的 Java 可执行文件并返回其运行信息。
 #[tauri::command]
 pub async fn java_validate(path: String) -> Result<JavaInfo, JavaServiceError> {
     AppServices::get()

--- a/src-tauri/src/adapter/tauri/commands/mod.rs
+++ b/src-tauri/src/adapter/tauri/commands/mod.rs
@@ -1,3 +1,8 @@
+//! Tauri 命令适配模块。
+//!
+//! 每个子模块承载一类宿主能力，命令以 snake_case 命名直接暴露给前端
+//! `invoke` 调用，内部统一经应用装配层组合对应的应用服务。
+
 pub mod catalog;
 pub mod cron;
 pub mod download;

--- a/src-tauri/src/adapter/tauri/commands/online_tunnel.rs
+++ b/src-tauri/src/adapter/tauri/commands/online_tunnel.rs
@@ -1,4 +1,11 @@
-//! Snake-case Tauri commands for the process-owned online tunnel service.
+//! 在线隧道（联机）Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`OnlineTunnelService`] 以主机或加入模式建立隧道；隧道运行事件
+//! 由 [`OnlineTunnelEventForwarder`] 转发为前端 `online_tunnel_event` 事件。
+//!
+//! 错误统一为接口契约错误 [`OnlineTunnelServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
 
 use std::sync::Mutex;
 
@@ -9,12 +16,17 @@ use sealantern_interface::{
 };
 use tauri::{AppHandle, Emitter, State};
 
+/// 持有在线隧道事件转发任务的后台句柄。
+///
+/// 由 Tauri 全局托管（见 `lib.rs` 的 `manage` 调用），保证同一时刻
+/// 只有一个任务在监听事件流并向前端推送 `online_tunnel_event`。
 #[derive(Default)]
 pub struct OnlineTunnelEventForwarder {
     task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
 }
 
 impl OnlineTunnelEventForwarder {
+    /// 停止旧转发任务，重新订阅服务事件流并启动新的转发任务。
     async fn replace(
         &self,
         app: AppHandle,
@@ -45,6 +57,7 @@ impl OnlineTunnelEventForwarder {
         }
     }
 
+    /// 停止当前转发任务并等待其退出。
     pub async fn clear(&self) {
         let task = match self.task.lock() {
             Ok(mut slot) => slot.take(),
@@ -64,6 +77,7 @@ impl OnlineTunnelEventForwarder {
     }
 }
 
+/// 获取全局应用服务句柄（惰性初始化容器）。
 async fn services() -> Result<AppServices, OnlineTunnelServiceError> {
     AppServices::get().await.map_err(|error| {
         tracing::error!(
@@ -75,6 +89,7 @@ async fn services() -> Result<AppServices, OnlineTunnelServiceError> {
     })
 }
 
+/// 以主机模式开启在线隧道，把本地 Minecraft 端口转发到公网。
 #[tauri::command]
 pub async fn online_tunnel_host(
     app: AppHandle,
@@ -87,6 +102,7 @@ pub async fn online_tunnel_host(
     Ok(status)
 }
 
+/// 以加入模式通过票据连接主机，把隧道流量导向本地端口。
 #[tauri::command]
 pub async fn online_tunnel_join(
     app: AppHandle,
@@ -99,6 +115,7 @@ pub async fn online_tunnel_join(
     Ok(status)
 }
 
+/// 停止当前在线隧道。
 #[tauri::command]
 pub async fn online_tunnel_stop(
     forwarder: State<'_, OnlineTunnelEventForwarder>,
@@ -108,6 +125,7 @@ pub async fn online_tunnel_stop(
     Ok(status)
 }
 
+/// 查询当前在线隧道的运行状态。
 #[tauri::command]
 pub async fn online_tunnel_status() -> Result<OnlineTunnelStatus, OnlineTunnelServiceError> {
     services().await?.online_tunnel().status().await

--- a/src-tauri/src/adapter/tauri/commands/provisioning.rs
+++ b/src-tauri/src/adapter/tauri/commands/provisioning.rs
@@ -1,4 +1,11 @@
-//! Snake-case Tauri commands for inspection and provisioning plans.
+//! 服务端检查与供给计划 Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`ProvisioningService`] 检查服务器目录、解析启动脚本，并生成
+//! 现有实例导入、实例复制与整合包供给计划。计划阶段不修改文件系统。
+//!
+//! 错误统一为接口契约错误 [`ProvisioningServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
 
 use std::path::Path;
 
@@ -10,12 +17,14 @@ use sealantern_core::provisioning::{
 };
 use sealantern_interface::{ProvisioningService, ProvisioningServiceError};
 
+/// 获取全局应用服务句柄（惰性初始化容器）。
 async fn services() -> Result<AppServices, ProvisioningServiceError> {
     AppServices::get()
         .await
         .map_err(|_| ProvisioningServiceError::OperationFailed)
 }
 
+/// 检查指定服务器目录，返回服务器类型与版本等概况。
 #[tauri::command]
 pub async fn inspect_server(
     path: String,
@@ -27,6 +36,7 @@ pub async fn inspect_server(
         .await
 }
 
+/// 解析指定服务器目录下的启动脚本，返回内存与参数等配置信息。
 #[tauri::command]
 pub async fn parse_startup_script(
     path: String,
@@ -38,6 +48,7 @@ pub async fn parse_startup_script(
         .await
 }
 
+/// 为导入现有实例生成供给计划。
 #[tauri::command]
 pub async fn plan_existing_instance(
     request: InstanceImportRequest,
@@ -49,6 +60,7 @@ pub async fn plan_existing_instance(
         .await
 }
 
+/// 为复制实例生成供给计划。
 #[tauri::command]
 pub async fn plan_instance_copy(
     request: CopyInstanceRequest,
@@ -56,6 +68,7 @@ pub async fn plan_instance_copy(
     services().await?.provisioning().plan_copy(request).await
 }
 
+/// 为安装整合包生成供给计划。
 #[tauri::command]
 pub async fn plan_modpack_provision(
     request: ModpackProvisionRequest,

--- a/src-tauri/src/adapter/tauri/commands/update_install.rs
+++ b/src-tauri/src/adapter/tauri/commands/update_install.rs
@@ -1,6 +1,16 @@
+//! 应用更新下载与安装 Tauri 命令。
+//!
+//! 前端通过 `invoke` 调用这些命令，命令内部经应用装配层拿到
+//! [`UpdateInstallService`] 下载更新文件、管理待安装记录并拉起安装进程。
+//!
+//! 错误统一为接口契约错误 [`UpdateInstallServiceError`]，可序列化回前端，
+//! 不携带底层敏感细节。
+
 use sealantern_application::services::AppServices;
 use sealantern_extra::update::PendingUpdate;
 use sealantern_interface::{UpdateInstallService, UpdateInstallServiceError};
+
+/// 获取全局应用服务句柄（惰性初始化容器）。
 async fn service() -> Result<AppServices, UpdateInstallServiceError> {
     AppServices::get().await.map_err(|error| {
         tracing::error!(
@@ -11,6 +21,8 @@ async fn service() -> Result<AppServices, UpdateInstallServiceError> {
         UpdateInstallServiceError::OperationFailed
     })
 }
+
+/// 下载更新文件并登记为待安装，返回本地文件路径。
 #[tauri::command]
 pub async fn update_download(
     url: String,
@@ -23,14 +35,20 @@ pub async fn update_download(
         .download(url, expected_hash, version)
         .await
 }
+
+/// 查询待安装的更新（下载完成但尚未安装），无则为 `None`。
 #[tauri::command]
 pub async fn update_pending() -> Result<Option<PendingUpdate>, UpdateInstallServiceError> {
     service().await?.update_install().pending().await
 }
+
+/// 清除待安装的更新记录。
 #[tauri::command]
 pub async fn update_clear_pending() -> Result<(), UpdateInstallServiceError> {
     service().await?.update_install().clear_pending().await
 }
+
+/// 拉起更新安装流程；Windows 下提权启动安装器，其他平台暂不支持。
 #[tauri::command]
 pub async fn update_install(
     file_path: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,7 @@ pub fn run() {
             run_cron_task,
             set_cron_task_enabled,
             update_cron_task,
+            //服务器类型目录契约命令
             catalog_details,
             catalog_server_types,
             catalog_versions,
@@ -99,8 +100,10 @@ pub fn run() {
             list_instances,
             rename_instance,
             update_instance_path,
+            //Java 运行时检测与校验
             java_detect,
             java_validate,
+            //在线隧道（联机）契约命令
             online_tunnel_host,
             online_tunnel_join,
             online_tunnel_status,
@@ -130,6 +133,7 @@ pub fn run() {
             plan_modpack_provision,
             //应用更新检查契约命令
             check_update,
+            //应用更新下载与安装契约命令
             update_clear_pending,
             update_download,
             update_install,
@@ -184,6 +188,7 @@ pub fn run() {
     result.expect("error while running Sea Lantern");
 }
 
+/// 应用退出时关闭后台异步服务（当前为在线隧道）。
 fn shutdown_async_services() {
     let Some(services) = AppServices::try_get() else {
         return;


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- 为 crates/interface、application、src-tauri 与 crates/extra 共 30 个文件补充中文注释（模块头、函数与字段文档、错误变体语义），无代码逻辑改动

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

在不改变运行时行为的前提下，为在线隧道、预配（provisioning）、目录（catalog）、Java 和更新安装相关的后端服务契约以及 Tauri 命令适配器，补充完善的中文 API 文档和模块级注释。

Documentation:
- 为在线隧道模型、服务 trait 和 Tauri 命令编写文档，明确角色、事件以及错误语义。
- 扩展关于预配、目录、Java 和更新安装服务及错误的文档，详细说明各自职责、错误类别以及无副作用的保证。
- 在接口 crate 中添加模块级注释和 re-export 注释，描述后端服务契约及其用途。
- 强化额外层级模型（下载链接、Java 检测），补充 serde 和数据结构语义，以便跨层使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add comprehensive Chinese API documentation and module-level comments across backend service contracts and Tauri command adapters for online tunnels, provisioning, catalog, Java, and update installation, without changing runtime behavior.

Documentation:
- Document online tunnel models, service trait, and Tauri commands, clarifying roles, events, and error semantics.
- Expand documentation for provisioning, catalog, Java, and update installation services and errors, detailing responsibilities, error categories, and non-side-effect guarantees.
- Add module-level and re-export comments in the interface crate to describe backend service contracts and their purpose.
- Enhance extra-layer models (download links, Java detection) with serde and data-structure semantics for cross-layer use.

</details>