### PR TITLE
fix: download-link-manager链接错误

### DIFF
--- a/crates/extra/src/download_link/manager.rs
+++ b/crates/extra/src/download_link/manager.rs
@@ -7,7 +7,7 @@ use tokio::sync::{Mutex, OnceCell};
 
 /// 下载链接配置 URL
 const DOWNLOAD_LINK_LIST_URL: &str =
-    "https://raw.githubusercontent.com/SeaLantern-Studio/SeaLanternData/main/server_download.json";
+    "https://cnb.cool/SeaLantern-studio/ServerCore-Mirror/-/releases/download/26.02.27/jar_lfs_links.json";
 
 /// 下载链接查询错误。
 ///


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

Bug Fixes:
- 将下载链接配置端点更正为指向当前的 JSON 源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the download link configuration endpoint to point to the current JSON source.

</details>