### PR TITLE
refactor(link): 优化下载链接获取接口

### DIFF
--- a/application/src/service/catalog.rs
+++ b/application/src/service/catalog.rs
@@ -9,7 +9,7 @@
 //! 收敛为 [`ServerCatalogServiceError::NotFound`]。
 
 use async_trait::async_trait;
-use sealantern_extra::download_link::{LinkError, LinkManager, TypeDownloadLinks};
+use sealantern_extra::download_link::{DownloadLink, LinkError, LinkManager};
 use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
 
 /// 基于 `extra` 下载链接管理的服务器目录服务实现。
@@ -40,16 +40,17 @@ impl ServerCatalogService for CoreServerCatalogService {
             .await
             .map_err(map_link_error)
     }
-    /// 查询指定服务器类型的下载详情（版本 → 文件下载链接）。
+    /// 查询指定服务器类型、指定版本的下载链接。
     ///
-    /// 类型不存在时收敛为 [`ServerCatalogServiceError::NotFound`]；
+    /// 类型或版本不存在时收敛为 [`ServerCatalogServiceError::NotFound`]；
     /// 底层配置拉取 / 解析失败收敛为
     /// [`ServerCatalogServiceError::OperationFailed`]。
     async fn details(
         &self,
         server_type: String,
-    ) -> Result<TypeDownloadLinks, ServerCatalogServiceError> {
-        LinkManager::get_type_by_name(&server_type)
+        server_version: String,
+    ) -> Result<DownloadLink, ServerCatalogServiceError> {
+        LinkManager::get_link_by_type_and_version(&server_type, &server_version)
             .await
             .map_err(map_link_error)
     }

--- a/crates/extra/src/download_link/manager.rs
+++ b/crates/extra/src/download_link/manager.rs
@@ -135,4 +135,20 @@ impl LinkManager {
     pub async fn get_versions_by_type(type_name: &str) -> Result<Vec<String>, LinkError> {
         Ok(Self::get_type_by_name(type_name).await?.get_versions())
     }
+
+    /// 根据类型与版本获取单个下载链接。
+    ///
+    /// 类型或版本不存在时返回 [`LinkError::NotFound`]。
+    pub async fn get_link_by_type_and_version(
+        type_name: &str,
+        version: &str,
+    ) -> Result<DownloadLink, LinkError> {
+        let type_links = Self::get_type_by_name(type_name).await?;
+        type_links
+            .get_link_by_version(version)
+            .cloned()
+            .ok_or_else(|| {
+                LinkError::NotFound(format!("Version {} not found for type {}", version, type_name))
+            })
+    }
 }

--- a/crates/interface/src/catalog/service.rs
+++ b/crates/interface/src/catalog/service.rs
@@ -2,7 +2,7 @@
 
 use crate::error::ServerCatalogServiceError;
 use async_trait::async_trait;
-use sealantern_extra::download_link::TypeDownloadLinks;
+use sealantern_extra::download_link::DownloadLink;
 
 /// 服务器核心下载目录宿主能力端口。
 ///
@@ -15,9 +15,10 @@ pub trait ServerCatalogService: Send + Sync {
     /// 返回指定服务器核心类型的可用版本列表。
     async fn versions(&self, server_type: String)
         -> Result<Vec<String>, ServerCatalogServiceError>;
-    /// 返回指定服务器核心类型的版本与下载链接明细。
+    /// 返回指定服务器核心类型、指定版本的下载链接。
     async fn details(
         &self,
         server_type: String,
-    ) -> Result<TypeDownloadLinks, ServerCatalogServiceError>;
+        server_version: String,
+    ) -> Result<DownloadLink, ServerCatalogServiceError>;
 }

--- a/src-tauri/src/adapter/tauri/commands/catalog.rs
+++ b/src-tauri/src/adapter/tauri/commands/catalog.rs
@@ -7,7 +7,7 @@
 //! 不携带底层敏感细节。
 
 use sealantern_application::services::AppServices;
-use sealantern_extra::download_link::TypeDownloadLinks;
+use sealantern_extra::download_link::DownloadLink;
 use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
 
 /// 查询全部可用的服务器核心类型。
@@ -34,15 +34,16 @@ pub async fn catalog_versions(
         .await
 }
 
-/// 查询指定服务器核心类型的版本列表与各版本下载链接。
+/// 查询指定服务器核心类型、指定版本的下载链接。
 #[tauri::command]
 pub async fn catalog_details(
     server_type: String,
-) -> Result<TypeDownloadLinks, ServerCatalogServiceError> {
+    server_version: String,
+) -> Result<DownloadLink, ServerCatalogServiceError> {
     AppServices::get()
         .await
         .map_err(|_| ServerCatalogServiceError::OperationFailed)?
         .catalog()
-        .details(server_type)
+        .details(server_type, server_version)
         .await
 }


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

公开一个类型安全的 API，用于根据服务器类型和版本获取单个下载链接，并在目录服务和 Tauri 命令接口中传播这一更改。

New Features:
- 添加一个 `LinkManager` API，用于按类型和版本获取单个下载链接，并具有适当的“未找到”处理逻辑。

Enhancements:
- 更改服务器目录服务的接口和实现，使其根据给定的类型和版本返回单个下载链接，而不是返回所有版本链接的映射。
- 更新 Tauri 的目录详情命令，使其接受服务器版本参数并返回单个下载链接结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a typed API for retrieving a single download link by server type and version and propagate this change through the catalog service and Tauri command interfaces.

New Features:
- Add a LinkManager API to fetch a single download link by type and version with proper not-found handling.

Enhancements:
- Change the server catalog service interface and implementation to return a single download link for a given type and version instead of a map of all version links.
- Update the Tauri catalog details command to accept a server version parameter and return a single download link result.

</details>