### PR TITLE
fix(proxy): 修复了因为配置获取失败导致的panic

### DIFF
--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -209,10 +209,15 @@ impl AppServices {
     }
 
     /// 加载持久化设置并同步全局网络运行时。
+    ///
+    /// 代理同步失败会在返回的错误中体现（宿主决定是否降级启动），
+    /// 但系统代理轮询始终启动：设置初始化失败仅表示网络运行时尚未
+    /// 按持久化设置同步，此时使用默认直连；系统代理恢复后由轮询或
+    /// 后续设置操作的重试自动跟上。
     pub async fn initialize_network_settings(
         &self,
     ) -> Result<(), sealantern_interface::SettingsServiceError> {
-        self.inner.settings.initialize().await?;
+        let settings_result = self.inner.settings.initialize().await;
         if self.inner.proxy_monitoring.start().await {
             tracing::info!(
                 target: "sealantern.application.proxy_monitoring",
@@ -220,7 +225,7 @@ impl AppServices {
                 "system proxy monitoring started"
             );
         }
-        Ok(())
+        settings_result
     }
 
     /// 便捷访问入口：一步拿到设置信息服务的共享句柄（惰性初始化 + 可替换）。

--- a/crates/infra/src/platform/proxy.rs
+++ b/crates/infra/src/platform/proxy.rs
@@ -189,6 +189,23 @@ fn optional_proxy_url(host: &str, port: u16) -> Result<Option<String>, SystemPro
 
 fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
     let host = host.trim();
+    // 兼容 Windows 上 ProxyServer 携带 scheme 的合法写法（如
+    // "http://127.0.0.1"），仅剥离 http / https 前缀，其余原样保留；
+    // 剥离后的 userinfo / 非法字符仍由下方白名单校验拦截。
+    let host = if host
+        .get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("http://"))
+    {
+        &host[7..]
+    } else if host
+        .get(..8)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("https://"))
+    {
+        &host[8..]
+    } else {
+        host
+    }
+    .trim();
     if host.is_empty() || port == 0 {
         tracing::warn!(
             target: "sealantern.infra.platform.proxy",
@@ -331,12 +348,36 @@ mod tests {
     fn invalid_enabled_proxy_is_rejected() {
         let empty_host = snapshot_from_sysproxy(&enabled_proxy("", 7890, "")).unwrap_err();
         let zero_port = snapshot_from_sysproxy(&enabled_proxy("127.0.0.1", 0, "")).unwrap_err();
-        let injected_scheme =
-            snapshot_from_sysproxy(&enabled_proxy("http://example.com", 7890, "")).unwrap_err();
+        let unsupported_scheme =
+            snapshot_from_sysproxy(&enabled_proxy("ftp://example.com", 7890, "")).unwrap_err();
 
         assert!(matches!(empty_host, SystemProxyReadError::InvalidProxy));
         assert!(matches!(zero_port, SystemProxyReadError::InvalidProxy));
-        assert!(matches!(injected_scheme, SystemProxyReadError::InvalidProxy));
+        assert!(matches!(unsupported_scheme, SystemProxyReadError::InvalidProxy));
+    }
+
+    #[test]
+    fn scheme_prefixed_proxy_host_is_normalized() {
+        let snapshot =
+            snapshot_from_sysproxy(&enabled_proxy("http://127.0.0.1", 7890, "")).unwrap();
+
+        assert_eq!(snapshot.routes().http_proxy(), Some("http://127.0.0.1:7890"));
+    }
+
+    #[test]
+    fn uppercase_scheme_prefix_is_normalized() {
+        let snapshot =
+            snapshot_from_sysproxy(&enabled_proxy("HTTP://127.0.0.1", 7890, "")).unwrap();
+
+        assert_eq!(snapshot.routes().http_proxy(), Some("http://127.0.0.1:7890"));
+    }
+
+    #[test]
+    fn scheme_prefixed_host_with_userinfo_is_still_rejected() {
+        let result =
+            snapshot_from_sysproxy(&enabled_proxy("http://user:pass@proxy.example.com", 7890, ""));
+
+        assert!(matches!(result, Err(SystemProxyReadError::InvalidProxy)));
     }
 
     #[test]

--- a/crates/infra/src/platform/proxy.rs
+++ b/crates/infra/src/platform/proxy.rs
@@ -72,28 +72,64 @@ pub fn current_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadErro
 
 #[cfg(target_os = "windows")]
 fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
-    let proxy = sysproxy::Sysproxy::get_system_proxy()
-        .map_err(|source| SystemProxyReadError::Read { source })?;
+    let proxy = sysproxy::Sysproxy::get_system_proxy().map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            error = %source,
+            "failed to read system proxy via sysproxy"
+        );
+        SystemProxyReadError::Read { source }
+    })?;
     snapshot_from_sysproxy(&proxy)
 }
 
 #[cfg(target_os = "linux")]
 fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
-    let enabled =
-        sysproxy::Sysproxy::get_enable().map_err(|source| SystemProxyReadError::Read { source })?;
+    let enabled = sysproxy::Sysproxy::get_enable().map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            error = %source,
+            "failed to read system proxy enable state"
+        );
+        SystemProxyReadError::Read { source }
+    })?;
     if !enabled {
         return Ok(SystemProxySnapshot::direct());
     }
 
-    let http =
-        sysproxy::Sysproxy::get_http().map_err(|source| SystemProxyReadError::Read { source })?;
-    let https =
-        sysproxy::Sysproxy::get_https().map_err(|source| SystemProxyReadError::Read { source })?;
-    let bypass =
-        sysproxy::Sysproxy::get_bypass().map_err(|source| SystemProxyReadError::Read { source })?;
+    let http = sysproxy::Sysproxy::get_http().map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            error = %source,
+            "failed to read system HTTP proxy"
+        );
+        SystemProxyReadError::Read { source }
+    })?;
+    let https = sysproxy::Sysproxy::get_https().map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            error = %source,
+            "failed to read system HTTPS proxy"
+        );
+        SystemProxyReadError::Read { source }
+    })?;
+    let bypass = sysproxy::Sysproxy::get_bypass().map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            error = %source,
+            "failed to read system proxy bypass rules"
+        );
+        SystemProxyReadError::Read { source }
+    })?;
     let http_proxy = optional_proxy_url(&http.host, http.port)?;
     let https_proxy = optional_proxy_url(&https.host, https.port)?;
     if http_proxy.is_none() && https_proxy.is_none() {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            http_host_empty = http.host.trim().is_empty(),
+            https_host_empty = https.host.trim().is_empty(),
+            "system proxy is enabled but neither HTTP nor HTTPS endpoint is usable"
+        );
         return Err(SystemProxyReadError::UnsupportedProxyKind);
     }
 
@@ -134,7 +170,7 @@ fn snapshot_from_sysproxy(
     ))
 }
 
-#[cfg(any(target_os = "windows", test))]
+/// 记录诊断时对代理主机做脱敏：包含 `@`（可能的用户信息）时整体替换。
 fn diagnostic_proxy_host(host: &str) -> &str {
     if host.contains('@') {
         "<redacted>"
@@ -154,6 +190,12 @@ fn optional_proxy_url(host: &str, port: u16) -> Result<Option<String>, SystemPro
 fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
     let host = host.trim();
     if host.is_empty() || port == 0 {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            host_empty = host.is_empty(),
+            port = port,
+            "system proxy endpoint is invalid: empty host or zero port"
+        );
         return Err(SystemProxyReadError::InvalidProxy);
     }
 
@@ -163,7 +205,16 @@ fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
         format!("{host}:{port}")
     };
     let proxy_url = format!("http://{authority}");
-    let parsed = url::Url::parse(&proxy_url).map_err(|_| SystemProxyReadError::InvalidProxy)?;
+    let parsed = url::Url::parse(&proxy_url).map_err(|error| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            host = diagnostic_proxy_host(host),
+            port = port,
+            error = %error,
+            "system proxy endpoint failed URL parsing"
+        );
+        SystemProxyReadError::InvalidProxy
+    })?;
     let valid = parsed.scheme() == "http"
         && parsed.host().is_some()
         && parsed.port_or_known_default() == Some(port)
@@ -173,6 +224,15 @@ fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
         && parsed.query().is_none()
         && parsed.fragment().is_none();
     if !valid {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            host = diagnostic_proxy_host(host),
+            port = port,
+            scheme = %parsed.scheme(),
+            has_host = parsed.host().is_some(),
+            has_userinfo = !parsed.username().is_empty() || parsed.password().is_some(),
+            "system proxy endpoint failed validation"
+        );
         return Err(SystemProxyReadError::InvalidProxy);
     }
     Ok(proxy_url)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -65,8 +65,12 @@ pub async fn main() {
         }
     };
     if let Err(error) = services.initialize_network_settings().await {
-        tracing::error!(error = %error, "failed to initialize persisted network settings");
-        std::process::exit(1);
+        // 网络设置同步失败不阻止启动：网络运行时保持默认直连，
+        // 系统代理恢复后由轮询与后续设置操作的重试自动跟上。
+        tracing::error!(
+            error = %error,
+            "failed to initialize persisted network settings; continuing with direct network"
+        );
     }
 
     // 构建 Vite 配置并（在 dev 模式下）拉起 dev server。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,14 +162,14 @@ pub fn run() {
                         "failed to assemble application services: {error}"
                     ))
                 })?;
-                services
-                    .initialize_network_settings()
-                    .await
-                    .map_err(|error| {
-                        std::io::Error::other(format!(
-                            "failed to initialize persisted network settings: {error}"
-                        ))
-                    })?;
+                if let Err(error) = services.initialize_network_settings().await {
+                    // 网络设置同步失败不阻止启动：网络运行时保持默认直连，
+                    // 系统代理恢复后由轮询与后续设置操作的重试自动跟上。
+                    tracing::error!(
+                        error = %error,
+                        "failed to initialize persisted network settings; continuing with direct network"
+                    );
+                }
                 Ok::<(), std::io::Error>(())
             })?;
 


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

放宽网络设置初始化的要求，以避免在无法加载持久化配置时导致启动失败，同时继续使用直接网络模式，并保持代理监控处于活动状态。

Bug Fixes:
- 当网络设置初始化失败时，将错误视为非致命错误，防止应用和服务器进程发生 panic 或直接退出。

Enhancements:
- 将来自 AppServices 的设置初始化错误向上传递，由调用方决定是否降级处理，而不是无条件地吞掉这些错误。
- 改进与网络设置初始化失败相关的日志记录，明确说明启动会继续，并使用直接网络连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax network settings initialization to avoid startup failure when persisted configuration cannot be loaded, while continuing with a direct network mode and keeping proxy monitoring active.

Bug Fixes:
- Prevent application and server processes from panicking or exiting when network settings initialization fails by treating the error as non-fatal.

Enhancements:
- Propagate settings initialization errors from AppServices so callers can decide on downgrade behavior instead of unconditionally swallowing them.
- Improve logging around failed network settings initialization to clarify that startup continues with direct network connectivity.

</details>