### PR TITLE
refactor: 统一通信时拼写方式为snake_case

### DIFF
--- a/crates/extra/src/models/app_update.rs
+++ b/crates/extra/src/models/app_update.rs
@@ -47,6 +47,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for NullablePatch<T> {
 
 /// 部分更新请求，只合并请求中明确包含的字段。
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct PartialAppSettings {
     pub close_servers_on_exit: Option<bool>,
     pub close_servers_on_update: Option<bool>,

--- a/crates/extra/src/models/task.rs
+++ b/crates/extra/src/models/task.rs
@@ -4,16 +4,17 @@ use sealantern_infra::download::DownloadSnapshot;
 use serde::{Deserialize, Serialize};
 
 /// 下载任务进度响应。
+///
+/// 契约字段统一使用 snake_case（`total_size` / `is_finished`），
+/// 与其余后端契约保持一致。
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct TaskProgressResponse {
     pub id: String,
-    #[serde(alias = "total_size")]
     pub total_size: u64,
     pub downloaded: u64,
     pub progress: f64,
     pub status: TaskStatus,
-    #[serde(alias = "is_finished")]
     pub is_finished: bool,
 }
 
@@ -68,7 +69,7 @@ mod tests {
     use super::{TaskProgressResponse, TaskStatus};
 
     #[test]
-    fn task_progress_preserves_id_and_uses_frontend_field_names() {
+    fn task_progress_serializes_snake_case_fields() {
         let response = TaskProgressResponse::from_snapshot(
             "task-42",
             DownloadSnapshot {
@@ -84,10 +85,10 @@ mod tests {
         assert_eq!(response.status, TaskStatus::Simple("Downloading".to_string()));
 
         let value = serde_json::to_value(response).expect("task progress should serialize");
-        assert_eq!(value["totalSize"], 1024);
-        assert_eq!(value["isFinished"], false);
-        assert!(value.get("total_size").is_none());
-        assert!(value.get("is_finished").is_none());
+        assert_eq!(value["total_size"], 1024);
+        assert_eq!(value["is_finished"], false);
+        assert!(value.get("totalSize").is_none());
+        assert!(value.get("isFinished").is_none());
     }
 
     #[test]
@@ -109,10 +110,10 @@ mod tests {
     }
 
     #[test]
-    fn task_progress_accepts_legacy_snake_case_fields() {
+    fn task_progress_accepts_snake_case_fields() {
         let response: TaskProgressResponse = serde_json::from_str(
             r#"{
-                "id":"task-legacy",
+                "id":"task-42",
                 "total_size":1024,
                 "downloaded":0,
                 "progress":0.0,
@@ -120,9 +121,9 @@ mod tests {
                 "is_finished":true
             }"#,
         )
-        .expect("legacy task progress should deserialize");
+        .expect("task progress should deserialize");
 
-        assert_eq!(response.id, "task-legacy");
+        assert_eq!(response.id, "task-42");
         assert_eq!(response.total_size, 1024);
         assert!(response.is_finished);
         assert_eq!(response.status, TaskStatus::Error { error: "connection reset".to_string() });

--- a/crates/interface/src/download/models.rs
+++ b/crates/interface/src/download/models.rs
@@ -40,10 +40,11 @@ impl serde::Serialize for DownloadTaskStatus {
 
 /// 下载任务信息（宿主消费的契约模型，对齐前端 `DownloadTaskInfo`）。
 ///
-/// `rename_all = "camelCase"` 使字段名匹配前端 `src/api/downloader.ts`
-/// 的 `DownloadTaskInfo` 形状（`totalSize`/`isFinished` 等）。
+/// `rename_all = "snake_case"` 显式声明契约字段命名：序列化输出
+/// `total_size` / `is_finished` 等 snake_case 字段名，与其余契约模型
+/// 保持一致（前端 `src/api/downloader.ts` 同步消费 snake_case 形状）。
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct DownloadTaskInfo {
     /// 任务标识。
     pub id: String,
@@ -91,9 +92,8 @@ mod tests {
     }
 
     #[test]
-    fn task_info_serializes_camel_case_fields() {
-        // 前端 DownloadTaskInfo 期望 totalSize/isFinished（camelCase），
-        // 而非后端 snake_case 的 total_size/is_finished。
+    fn task_info_serializes_snake_case_fields() {
+        // 契约统一使用 snake_case（total_size/is_finished），与其余模型一致。
         let info = DownloadTaskInfo {
             id: "abc".into(),
             total_size: 100,
@@ -103,8 +103,9 @@ mod tests {
             is_finished: false,
         };
         let json = serde_json::to_string(&info).unwrap();
-        assert!(json.contains("\"totalSize\":100"), "missing totalSize: {json}");
-        assert!(json.contains("\"isFinished\":false"), "missing isFinished: {json}");
-        assert!(!json.contains("total_size"), "snake_case leaked: {json}");
+        assert!(json.contains("\"total_size\":100"), "missing total_size: {json}");
+        assert!(json.contains("\"is_finished\":false"), "missing is_finished: {json}");
+        assert!(!json.contains("totalSize"), "camelCase leaked: {json}");
+        assert!(!json.contains("isFinished"), "camelCase leaked: {json}");
     }
 }

--- a/src-tauri/src/adapter/tauri/commands/catalog.rs
+++ b/src-tauri/src/adapter/tauri/commands/catalog.rs
@@ -11,7 +11,7 @@ use sealantern_extra::download_link::DownloadLink;
 use sealantern_interface::{ServerCatalogService, ServerCatalogServiceError};
 
 /// 查询全部可用的服务器核心类型。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn catalog_server_types() -> Result<Vec<String>, ServerCatalogServiceError> {
     AppServices::get()
         .await
@@ -22,7 +22,7 @@ pub async fn catalog_server_types() -> Result<Vec<String>, ServerCatalogServiceE
 }
 
 /// 查询指定服务器核心类型支持的全部版本。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn catalog_versions(
     server_type: String,
 ) -> Result<Vec<String>, ServerCatalogServiceError> {
@@ -35,7 +35,7 @@ pub async fn catalog_versions(
 }
 
 /// 查询指定服务器核心类型、指定版本的下载链接。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn catalog_details(
     server_type: String,
     server_version: String,

--- a/src-tauri/src/adapter/tauri/commands/cron.rs
+++ b/src-tauri/src/adapter/tauri/commands/cron.rs
@@ -15,19 +15,19 @@ async fn cron_service() -> Result<Arc<CoreCronTaskService>, CronTaskServiceError
 }
 
 /// 列出全部定时任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn list_cron_tasks() -> Result<Vec<CronTask>, CronTaskServiceError> {
     cron_service().await?.list().await
 }
 
 /// 创建定时任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn create_cron_task(draft: CronTaskDraft) -> Result<CronTask, CronTaskServiceError> {
     cron_service().await?.create(draft).await
 }
 
 /// 更新定时任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_cron_task(
     id: String,
     draft: CronTaskDraft,
@@ -36,13 +36,13 @@ pub async fn update_cron_task(
 }
 
 /// 删除定时任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn delete_cron_task(id: String) -> Result<(), CronTaskServiceError> {
     cron_service().await?.delete(&id).await
 }
 
 /// 启用或禁用定时任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn set_cron_task_enabled(
     id: String,
     enabled: bool,
@@ -51,7 +51,7 @@ pub async fn set_cron_task_enabled(
 }
 
 /// 立即执行一次定时任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn run_cron_task(id: String) -> Result<CronTaskRun, CronTaskServiceError> {
     cron_service().await?.run_now(&id).await
 }

--- a/src-tauri/src/adapter/tauri/commands/download.rs
+++ b/src-tauri/src/adapter/tauri/commands/download.rs
@@ -1,7 +1,7 @@
 //! 下载任务管理 Tauri 命令。
 //!
-//! 参数/响应遵循「前端驼峰、后端蛇拼」：结构体 DTO 用 `rename_all = "camelCase"`
-//! 输出 camelCase（匹配前端规范），Rust 字段保持 snake_case。
+//! 参数/响应统一遵循 snake_case：命令参数与结构体 DTO 均显式声明
+//! `rename_all = "snake_case"`，与后端契约模型保持一致。
 use std::sync::Arc;
 
 use serde::Deserialize;
@@ -21,9 +21,9 @@ async fn download_service() -> Result<Arc<CoreDownloadService>, DownloadServiceE
 
 /// 创建下载任务请求。
 ///
-/// 前端传 camelCase（`savePath`/`threadCount`），内部映射为 snake_case。
+/// 前端以 snake_case 传参（`save_path`/`thread_count`），与命令层契约直接匹配。
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 pub struct CreateDownloadRequest {
     /// 下载 URL。
     pub url: String,
@@ -34,7 +34,7 @@ pub struct CreateDownloadRequest {
 }
 
 /// 创建下载任务，返回任务信息。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn download_create(
     request: CreateDownloadRequest,
 ) -> Result<DownloadTaskInfo, DownloadServiceError> {
@@ -53,7 +53,7 @@ pub async fn download_create(
 }
 
 /// 查询下载任务进度。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn download_query(id: String) -> Result<DownloadTaskInfo, DownloadServiceError> {
     let service = download_service().await?;
     service
@@ -63,7 +63,7 @@ pub async fn download_query(id: String) -> Result<DownloadTaskInfo, DownloadServ
 }
 
 /// 取消下载任务。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn download_cancel(id: String) -> Result<(), DownloadServiceError> {
     let service = download_service().await?;
     service.cancel(&id).await

--- a/src-tauri/src/adapter/tauri/commands/instance.rs
+++ b/src-tauri/src/adapter/tauri/commands/instance.rs
@@ -34,14 +34,14 @@ fn parse_id_for_tauri(id: String) -> Result<InstanceId, InstanceServiceError> {
 }
 
 /// 列出全部实例。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn list_instances() -> Result<Vec<Instance>, InstanceServiceError> {
     let service = instance_service().await?;
     service.list().await
 }
 
 /// 按 ID 查找实例，不存在时返回 `None`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn get_instance(id: String) -> Result<Option<Instance>, InstanceServiceError> {
     let service = instance_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -49,14 +49,14 @@ pub async fn get_instance(id: String) -> Result<Option<Instance>, InstanceServic
 }
 
 /// 创建新实例并持久化。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn create_instance(spec: InstanceSpec) -> Result<Instance, InstanceServiceError> {
     let service = instance_service().await?;
     service.create(spec).await
 }
 
 /// 删除实例；实例不存在时返回 [`InstanceServiceError::InstanceNotFound`]。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn delete_instance(id: String) -> Result<(), InstanceServiceError> {
     let service = instance_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -64,7 +64,7 @@ pub async fn delete_instance(id: String) -> Result<(), InstanceServiceError> {
 }
 
 /// 重命名实例。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn rename_instance(id: String, name: String) -> Result<(), InstanceServiceError> {
     let service = instance_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -72,7 +72,7 @@ pub async fn rename_instance(id: String, name: String) -> Result<(), InstanceSer
 }
 
 /// 更新实例目录路径。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_instance_path(id: String, path: String) -> Result<(), InstanceServiceError> {
     let service = instance_service().await?;
     let id = parse_id_for_tauri(id)?;

--- a/src-tauri/src/adapter/tauri/commands/java.rs
+++ b/src-tauri/src/adapter/tauri/commands/java.rs
@@ -14,7 +14,7 @@ use sealantern_interface::{JavaService, JavaServiceError};
 /// 自动检测本机已安装的 Java 运行时。
 ///
 /// 返回检测报告，成功安装与非致命错误同时保留，供前端选择 Java 版本。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn java_detect() -> Result<JavaDetectionReport, JavaServiceError> {
     AppServices::get()
         .await
@@ -25,7 +25,7 @@ pub async fn java_detect() -> Result<JavaDetectionReport, JavaServiceError> {
 }
 
 /// 校验指定路径的 Java 可执行文件并返回其运行信息。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn java_validate(path: String) -> Result<JavaInfo, JavaServiceError> {
     AppServices::get()
         .await

--- a/src-tauri/src/adapter/tauri/commands/online_tunnel.rs
+++ b/src-tauri/src/adapter/tauri/commands/online_tunnel.rs
@@ -90,7 +90,7 @@ async fn services() -> Result<AppServices, OnlineTunnelServiceError> {
 }
 
 /// 以主机模式开启在线隧道，把本地 Minecraft 端口转发到公网。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn online_tunnel_host(
     app: AppHandle,
     forwarder: State<'_, OnlineTunnelEventForwarder>,
@@ -103,7 +103,7 @@ pub async fn online_tunnel_host(
 }
 
 /// 以加入模式通过票据连接主机，把隧道流量导向本地端口。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn online_tunnel_join(
     app: AppHandle,
     forwarder: State<'_, OnlineTunnelEventForwarder>,
@@ -116,7 +116,7 @@ pub async fn online_tunnel_join(
 }
 
 /// 停止当前在线隧道。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn online_tunnel_stop(
     forwarder: State<'_, OnlineTunnelEventForwarder>,
 ) -> Result<OnlineTunnelStatus, OnlineTunnelServiceError> {
@@ -126,7 +126,7 @@ pub async fn online_tunnel_stop(
 }
 
 /// 查询当前在线隧道的运行状态。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn online_tunnel_status() -> Result<OnlineTunnelStatus, OnlineTunnelServiceError> {
     services().await?.online_tunnel().status().await
 }

--- a/src-tauri/src/adapter/tauri/commands/plugin.rs
+++ b/src-tauri/src/adapter/tauri/commands/plugin.rs
@@ -19,12 +19,12 @@ fn map_error(error: PluginServiceError) -> String {
     error.to_string()
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_discover() -> Result<Vec<PathBuf>, String> {
     plugin_service().await?.discover().await.map_err(map_error)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_load(plugin_dir: PathBuf) -> Result<PluginInfo, String> {
     plugin_service()
         .await?
@@ -33,7 +33,7 @@ pub async fn plugin_v2_load(plugin_dir: PathBuf) -> Result<PluginInfo, String> {
         .map_err(map_error)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_enable(plugin_id: String) -> Result<(), String> {
     plugin_service()
         .await?
@@ -42,7 +42,7 @@ pub async fn plugin_v2_enable(plugin_id: String) -> Result<(), String> {
         .map_err(map_error)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_disable(plugin_id: String) -> Result<(), String> {
     plugin_service()
         .await?
@@ -51,7 +51,7 @@ pub async fn plugin_v2_disable(plugin_id: String) -> Result<(), String> {
         .map_err(map_error)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_unload(plugin_id: String) -> Result<(), String> {
     plugin_service()
         .await?
@@ -60,12 +60,12 @@ pub async fn plugin_v2_unload(plugin_id: String) -> Result<(), String> {
         .map_err(map_error)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_plugins() -> Result<Vec<PluginInfo>, String> {
     plugin_service().await?.plugins().await.map_err(map_error)
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_grant_persistent(
     plugin_id: String,
     capability_id: String,
@@ -79,7 +79,7 @@ pub async fn plugin_v2_grant_persistent(
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_revoke_persistent(
     plugin_id: String,
     capability_id: String,
@@ -93,7 +93,7 @@ pub async fn plugin_v2_revoke_persistent(
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_set_trust(
     plugin_id: String,
     trust_source: TrustSource,
@@ -106,7 +106,7 @@ pub async fn plugin_v2_set_trust(
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_grant_session(grant: SessionGrant) -> Result<(), String> {
     plugin_service()
         .await?
@@ -116,7 +116,7 @@ pub async fn plugin_v2_grant_session(grant: SessionGrant) -> Result<(), String> 
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_approve_session(approval: SessionApproval) -> Result<(), String> {
     plugin_service()
         .await?
@@ -126,7 +126,7 @@ pub async fn plugin_v2_approve_session(approval: SessionApproval) -> Result<(), 
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_issue_approval_token(
     session_id: String,
     plugin_id: String,
@@ -141,7 +141,7 @@ pub async fn plugin_v2_issue_approval_token(
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_end_session(session_id: String) -> Result<(), String> {
     plugin_service()
         .await?
@@ -151,7 +151,7 @@ pub async fn plugin_v2_end_session(session_id: String) -> Result<(), String> {
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_audit(limit: u32) -> Result<Vec<AuditEntry>, String> {
     plugin_service()
         .await?
@@ -161,7 +161,7 @@ pub async fn plugin_v2_audit(limit: u32) -> Result<Vec<AuditEntry>, String> {
         .map_err(|error| error.to_string())
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_invoke(
     invocation: CapabilityInvocation,
 ) -> Result<serde_json::Value, String> {

--- a/src-tauri/src/adapter/tauri/commands/provisioning.rs
+++ b/src-tauri/src/adapter/tauri/commands/provisioning.rs
@@ -25,7 +25,7 @@ async fn services() -> Result<AppServices, ProvisioningServiceError> {
 }
 
 /// 检查指定服务器目录，返回服务器类型与版本等概况。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn inspect_server(
     path: String,
 ) -> Result<ServerInspectionReport, ProvisioningServiceError> {
@@ -37,7 +37,7 @@ pub async fn inspect_server(
 }
 
 /// 解析指定服务器目录下的启动脚本，返回内存与参数等配置信息。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn parse_startup_script(
     path: String,
 ) -> Result<StartupScriptInfo, ProvisioningServiceError> {
@@ -49,7 +49,7 @@ pub async fn parse_startup_script(
 }
 
 /// 为导入现有实例生成供给计划。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plan_existing_instance(
     request: InstanceImportRequest,
 ) -> Result<InstanceImportPlan, ProvisioningServiceError> {
@@ -61,7 +61,7 @@ pub async fn plan_existing_instance(
 }
 
 /// 为复制实例生成供给计划。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plan_instance_copy(
     request: CopyInstanceRequest,
 ) -> Result<CopyInstancePlan, ProvisioningServiceError> {
@@ -69,7 +69,7 @@ pub async fn plan_instance_copy(
 }
 
 /// 为安装整合包生成供给计划。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn plan_modpack_provision(
     request: ModpackProvisionRequest,
 ) -> Result<ModpackProvisionPlan, ProvisioningServiceError> {

--- a/src-tauri/src/adapter/tauri/commands/server.rs
+++ b/src-tauri/src/adapter/tauri/commands/server.rs
@@ -24,7 +24,7 @@ fn parse_id_for_tauri(id: String) -> Result<InstanceId, ServerServiceError> {
 }
 
 /// 查询服务器进程状态。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn server_status(id: String) -> Result<ServerSnapshot, ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -32,7 +32,7 @@ pub async fn server_status(id: String) -> Result<ServerSnapshot, ServerServiceEr
 }
 
 /// 启动服务器进程。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -40,7 +40,7 @@ pub async fn start_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 重启服务器进程。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn restart_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -48,7 +48,7 @@ pub async fn restart_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 优雅停止服务器进程。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -56,7 +56,7 @@ pub async fn stop_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 强制停止服务器进程（终止进程树）。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn force_stop_server(id: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;
@@ -64,7 +64,7 @@ pub async fn force_stop_server(id: String) -> Result<(), ServerServiceError> {
 }
 
 /// 向服务器控制台发送单行命令。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn send_server_command(id: String, command: String) -> Result<(), ServerServiceError> {
     let service = server_service().await?;
     let id = parse_id_for_tauri(id)?;

--- a/src-tauri/src/adapter/tauri/commands/settings.rs
+++ b/src-tauri/src/adapter/tauri/commands/settings.rs
@@ -16,25 +16,25 @@ async fn settings_service() -> Result<Arc<CoreSettingsService>, SettingsServiceE
 }
 
 /// 获取设置概览（所有分组及其设置项列表）。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn settings_overview() -> Result<SettingsOverview, SettingsServiceError> {
     settings_service().await?.settings_overview().await
 }
 
 /// 获取当前完整设置。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn get_settings() -> Result<AppSettings, SettingsServiceError> {
     settings_service().await?.get().await
 }
 
 /// 全量替换当前设置。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_settings(settings: AppSettings) -> Result<UpdateResult, SettingsServiceError> {
     settings_service().await?.update(settings).await
 }
 
 /// 部分更新当前设置。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_settings_partial(
     partial: PartialAppSettings,
 ) -> Result<UpdateResult, SettingsServiceError> {
@@ -42,19 +42,19 @@ pub async fn update_settings_partial(
 }
 
 /// 恢复默认设置。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn reset_settings() -> Result<AppSettings, SettingsServiceError> {
     settings_service().await?.reset().await
 }
 
 /// 导出当前设置为 JSON 字符串。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn export_settings() -> Result<String, SettingsServiceError> {
     settings_service().await?.export_json().await
 }
 
 /// 从 JSON 字符串导入设置。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn import_settings(json: String) -> Result<UpdateResult, SettingsServiceError> {
     settings_service().await?.import_json(&json).await
 }

--- a/src-tauri/src/adapter/tauri/commands/system.rs
+++ b/src-tauri/src/adapter/tauri/commands/system.rs
@@ -24,7 +24,7 @@ async fn system_service() -> Result<Arc<CoreSystemService>, SystemServiceError> 
 }
 
 /// 采集整机系统资源快照。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn get_system_snapshot() -> Result<SystemSnapshot, SystemServiceError> {
     let service = system_service().await?;
     service.system_snapshot().await
@@ -33,14 +33,14 @@ pub async fn get_system_snapshot() -> Result<SystemSnapshot, SystemServiceError>
 /// 采集指定进程的资源使用。
 ///
 /// 进程不存在或无权访问时返回 `pid = null` 的空结果。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn get_process_usage(pid: u32) -> Result<ProcessResourceUsage, SystemServiceError> {
     let service = system_service().await?;
     service.process_usage(pid).await
 }
 
 /// 计算指定目录的磁盘占用。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn get_directory_usage(path: String) -> Result<DirectoryUsage, SystemServiceError> {
     let service = system_service().await?;
     service.directory_usage(Path::new(&path)).await

--- a/src-tauri/src/adapter/tauri/commands/update.rs
+++ b/src-tauri/src/adapter/tauri/commands/update.rs
@@ -20,7 +20,7 @@ async fn update_service() -> Result<Arc<CoreUpdateCheckService>, UpdateCheckServ
 }
 
 /// 检查当前平台是否存在应用更新。
-#[tauri::command(rename_all="snake_case")]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn check_update() -> Result<UpdateInfo, UpdateCheckServiceError> {
     update_service().await?.check().await
 }

--- a/src-tauri/src/adapter/tauri/commands/update.rs
+++ b/src-tauri/src/adapter/tauri/commands/update.rs
@@ -20,7 +20,7 @@ async fn update_service() -> Result<Arc<CoreUpdateCheckService>, UpdateCheckServ
 }
 
 /// 检查当前平台是否存在应用更新。
-#[tauri::command]
+#[tauri::command(rename_all="snake_case")]
 pub async fn check_update() -> Result<UpdateInfo, UpdateCheckServiceError> {
     update_service().await?.check().await
 }

--- a/src-tauri/src/adapter/tauri/commands/update_install.rs
+++ b/src-tauri/src/adapter/tauri/commands/update_install.rs
@@ -23,7 +23,7 @@ async fn service() -> Result<AppServices, UpdateInstallServiceError> {
 }
 
 /// 下载更新文件并登记为待安装，返回本地文件路径。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_download(
     url: String,
     expected_hash: Option<String>,
@@ -37,19 +37,19 @@ pub async fn update_download(
 }
 
 /// 查询待安装的更新（下载完成但尚未安装），无则为 `None`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_pending() -> Result<Option<PendingUpdate>, UpdateInstallServiceError> {
     service().await?.update_install().pending().await
 }
 
 /// 清除待安装的更新记录。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_clear_pending() -> Result<(), UpdateInstallServiceError> {
     service().await?.update_install().clear_pending().await
 }
 
 /// 拉起更新安装流程；Windows 下提权启动安装器，其他平台暂不支持。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_install(
     file_path: String,
     arguments: Vec<String>,

--- a/src-tauri/src/desktop/dialog.rs
+++ b/src-tauri/src/desktop/dialog.rs
@@ -16,7 +16,7 @@ use tauri_plugin_dialog::DialogExt;
 /// 打开系统文件选择器选择 JAR 文件。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
@@ -35,7 +35,7 @@ pub fn desktop_pick_jar_file(app: tauri::AppHandle) -> Result<Option<String>, St
 /// 打开系统文件选择器选择压缩包文件（.zip/.tar/.tar.gz/.tgz/.jar）。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
@@ -59,7 +59,7 @@ pub fn desktop_pick_archive_file(app: tauri::AppHandle) -> Result<Option<String>
 ///
 /// `mode` 决定过滤器：`"jar"` / `"bat"` / `"sh"`，未知模式按 JAR 处理。
 /// 返回选中文件的路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_startup_file(
     app: tauri::AppHandle,
     mode: String,
@@ -98,7 +98,7 @@ pub fn desktop_pick_startup_file(
 /// 打开系统文件选择器选择服务端可执行文件，同时返回启动模式。
 ///
 /// 返回 `[路径, 启动模式]`，模式为 `"jar" | "bat" | "sh"`；取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_server_executable(
     app: tauri::AppHandle,
 ) -> Result<Option<(String, String)>, String> {
@@ -137,7 +137,7 @@ pub fn desktop_pick_server_executable(
 ///
 /// Windows 上按 `.exe` 过滤，其他平台不设扩展名过滤器（Java 二进制无扩展名）。
 /// 返回选中文件的路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
@@ -158,7 +158,7 @@ pub fn desktop_pick_java_file(app: tauri::AppHandle) -> Result<Option<String>, S
 /// 打开系统文件保存对话框。
 ///
 /// 返回保存路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
@@ -175,7 +175,7 @@ pub fn desktop_pick_save_file(app: tauri::AppHandle) -> Result<Option<String>, S
 /// 打开系统文件夹选择器。
 ///
 /// 返回选中的文件夹路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_folder(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 
@@ -192,7 +192,7 @@ pub fn desktop_pick_folder(app: tauri::AppHandle) -> Result<Option<String>, Stri
 /// 打开系统文件选择器选择图片文件。
 ///
 /// 返回选中文件的路径，取消则返回 `null`。
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub fn desktop_pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, String> {
     let (tx, rx) = mpsc::channel();
 


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

对后端 Tauri 命令接口及相关数据模型进行对齐，统一在所有请求和响应字段中使用 `snake_case` 命名。

增强点：
- 配置插件、下载、设置、定时任务（cron）、实例、服务器、预配（provisioning）、在线隧道、更新、目录（catalog）、系统、Java 和更新检查等所有 Tauri 命令，使其暴露的参数和载荷统一使用 `snake_case`。
- 标准化与下载相关的 DTO 和 extra/interface 模型，使其在序列化和反序列化时使用 `snake_case` 字段名，并更新相关测试以验证新的约定。
- 注解 `PartialAppSettings` 使用 `snake_case` 字段命名，以与其他后端约定保持一致。

测试：
- 更新下载和任务进度的序列化/反序列化测试，断言字段名为 `snake_case`，并确保不再生成 `camelCase` 变体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align backend Tauri command interfaces and related data models to consistently use snake_case naming for all request and response fields.

Enhancements:
- Configure all Tauri commands across plugins, downloads, settings, cron, instances, servers, provisioning, online tunnel, updates, catalog, system, Java, and update check to expose snake_case arguments and payloads.
- Standardize download-related DTOs and extra/interface models to serialize and deserialize snake_case field names, updating associated tests to validate the new contract.
- Annotate PartialAppSettings to use snake_case field naming to match the rest of the backend contracts.

Tests:
- Update download and task progress serialization/deserialization tests to assert snake_case field names and ensure camelCase variants are no longer emitted.

</details>