### PR TITLE
refactor(api): 替换原生Tauri调用为统一RPC适配层

### DIFF
--- a/src/api/downloader.ts
+++ b/src/api/downloader.ts
@@ -1,5 +1,5 @@
 import { reactive, onUnmounted, computed } from "vue";
-import { tauriInvoke } from "./tauri";
+import { rpcInvoke } from "./rpc";
 import { i18n } from "@language";
 
 export type TaskStatus = "Pending" | "Downloading" | "Completed" | { Error: string };
@@ -43,27 +43,29 @@ export const downloadApi = {
    * 基础 API：创建下载任务
    */
   async downloadFile(options: DownloadOptions): Promise<string> {
-    return tauriInvoke<string>("download_file", {
-      url: options.url,
-      savePath: options.savePath,
-      threadCount: options.threadCount || 32,
+    // 后端 download_create 接收 request 对象，DTO 用 camelCase 序列化
+    const task = await rpcInvoke<DownloadTaskInfo>("download.create", {
+      request: {
+        url: options.url,
+        savePath: options.savePath,
+        threadCount: options.threadCount || 32,
+      },
     });
+    return task.id;
   },
 
   /**
    * 基础 API：单次查询
    */
   async pollTask(id: string): Promise<DownloadTaskInfo> {
-    return tauriInvoke<DownloadTaskInfo>("poll_task", { idStr: id });
+    return rpcInvoke<DownloadTaskInfo>("download.query", { id });
   },
 
   /**
    * 删除/取消下载任务
    */
   async cancelDownloadTask(id: string): Promise<void> {
-    return tauriInvoke<void>("cancel_download_task", {
-      idStr: id,
-    });
+    return rpcInvoke<void>("download.cancel", { id });
   },
 
   /**
@@ -177,17 +179,17 @@ export const downloadApi = {
 
 export const downloadServerApi = {
   async getServerTypes(): Promise<string[]> {
-    return tauriInvoke<string[]>("get_server_types");
+    return rpcInvoke<string[]>("catalog.serverTypes");
   },
 
   async getVersionsByType(serverType: string): Promise<string[]> {
-    return tauriInvoke<string[]>("get_versions_by_type", { serverType });
+    return rpcInvoke<string[]>("catalog.versions", { server_type: serverType });
   },
 
   async getDownloadInfo(serverType: string, version: string): Promise<DownloadLink> {
-    return tauriInvoke<DownloadLink>("get_download_info", {
-      serverType,
-      version,
+    return rpcInvoke<DownloadLink>("catalog.details", {
+      server_type: serverType,
+      server_version: version,
     });
   },
 };

--- a/src/api/java.ts
+++ b/src/api/java.ts
@@ -1,4 +1,5 @@
 import { tauriInvoke } from "@api/tauri";
+import { rpcInvoke } from "@api/rpc";
 
 /**
  * Java 环境信息
@@ -19,14 +20,16 @@ export const javaApi = {
    * 检测系统中的 Java 环境
    */
   async detect(): Promise<JavaInfo[]> {
-    return tauriInvoke("detect_java");
+    // 后端返回 JavaDetectionReport，含 installations 和 errors
+    const report = await rpcInvoke<{ installations: JavaInfo[]; errors: unknown[] }>("java.detect");
+    return report.installations;
   },
 
   /**
    * 验证指定路径的 Java 是否可用
    */
   async validate(path: string): Promise<JavaInfo> {
-    return tauriInvoke("validate_java_path", { path });
+    return rpcInvoke<JavaInfo>("java.validate", { path });
   },
 
   /**

--- a/src/api/rpc.ts
+++ b/src/api/rpc.ts
@@ -1,0 +1,295 @@
+/**
+ * 统一 RPC 适配层
+ *
+ * 前端用点分方法名调用，适配层按运行环境分发到 Tauri 命令或 Axum 路由。
+ * 后端缺失的方法抛 NotImplementedError，等后期补映射表即可接通。
+ * application 层不动，两侧后端各自映射。
+ */
+
+import { isBrowserEnv, HTTP_API_BASE } from "@api/tauri";
+import { handleError, AppError, ErrorType } from "@utils/errorHandler";
+
+/** 请求选项，语义和 tauriInvoke 一致方便迁移 */
+export interface RpcInvokeOptions {
+  silent?: boolean;
+  context?: string;
+  defaultValue?: unknown;
+}
+
+/** 后端未实现该方法，调用方可据此禁用 UI 或提示 */
+export class NotImplementedError extends Error {
+  readonly method: string;
+  readonly transport: "tauri" | "axum";
+
+  constructor(method: string, transport: "tauri" | "axum") {
+    super(`[${transport}] 方法 ${method} 尚未实现`);
+    this.name = "NotImplementedError";
+    this.method = method;
+    this.transport = transport;
+  }
+}
+
+/** Axum 路由描述，把方法名映射到具体的 HTTP 请求 */
+interface AxumRoute {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  /** 从 args 构造路径，不含 /api 前缀；RPC 路由含 /rpc */
+  path: (args: Record<string, unknown>) => string;
+  /** 从 args 提取请求体，GET/DELETE 不需要 */
+  body?: (args: Record<string, unknown>) => unknown;
+  /** 是否走 RPC 信封，响应解包方式不同 */
+  isRpc?: boolean;
+}
+
+// Tauri 命令映射：统一方法名 -> 后端命令名，参数平铺透传
+const tauriCommandMap: Record<string, string> = {
+  // 实例管理
+  "instance.list": "list_instances",
+  "instance.get": "get_instance",
+  "instance.create": "create_instance",
+  "instance.delete": "delete_instance",
+  "instance.rename": "rename_instance",
+  "instance.updatePath": "update_instance_path",
+  // 服务器进程生命周期
+  "server.status": "server_status",
+  "server.start": "start_server",
+  "server.restart": "restart_server",
+  "server.stop": "stop_server",
+  "server.forceStop": "force_stop_server",
+  "server.console.send": "send_server_command",
+  // 系统资源
+  "system.snapshot": "get_system_snapshot",
+  "system.processUsage": "get_process_usage",
+  "system.directoryUsage": "get_directory_usage",
+  // 定时任务
+  "cron.list": "list_cron_tasks",
+  "cron.create": "create_cron_task",
+  "cron.update": "update_cron_task",
+  "cron.delete": "delete_cron_task",
+  "cron.setEnabled": "set_cron_task_enabled",
+  "cron.run": "run_cron_task",
+  // 设置，Axum 仅 overview 其余 Tauri 独有
+  "settings.overview": "settings_overview",
+  "settings.get": "get_settings",
+  "settings.update": "update_settings",
+  "settings.updatePartial": "update_settings_partial",
+  "settings.reset": "reset_settings",
+  "settings.export": "export_settings",
+  "settings.import": "import_settings",
+  // 服务器核心目录
+  "catalog.serverTypes": "catalog_server_types",
+  "catalog.versions": "catalog_versions",
+  "catalog.details": "catalog_details",
+  // 下载任务
+  "download.create": "download_create",
+  "download.query": "download_query",
+  "download.cancel": "download_cancel",
+  // 在线隧道
+  "tunnel.host": "online_tunnel_host",
+  "tunnel.join": "online_tunnel_join",
+  "tunnel.stop": "online_tunnel_stop",
+  "tunnel.status": "online_tunnel_status",
+  // 供给计划
+  "provisioning.inspect": "inspect_server",
+  "provisioning.parseStartup": "parse_startup_script",
+  "provisioning.planExisting": "plan_existing_instance",
+  "provisioning.planCopy": "plan_instance_copy",
+  "provisioning.planModpack": "plan_modpack_provision",
+  // Java 运行时
+  "java.detect": "java_detect",
+  "java.validate": "java_validate",
+  // 应用更新
+  "update.check": "check_update",
+  "update.download": "update_download",
+  "update.pending": "update_pending",
+  "update.clearPending": "update_clear_pending",
+  "update.install": "update_install",
+  // 插件 v2
+  "plugin.discover": "plugin_v2_discover",
+  "plugin.load": "plugin_v2_load",
+  "plugin.enable": "plugin_v2_enable",
+  "plugin.disable": "plugin_v2_disable",
+  "plugin.unload": "plugin_v2_unload",
+  "plugin.list": "plugin_v2_plugins",
+  "plugin.grantPersistent": "plugin_v2_grant_persistent",
+  "plugin.revokePersistent": "plugin_v2_revoke_persistent",
+  "plugin.setTrust": "plugin_v2_set_trust",
+  "plugin.grantSession": "plugin_v2_grant_session",
+  "plugin.approveSession": "plugin_v2_approve_session",
+  "plugin.issueApprovalToken": "plugin_v2_issue_approval_token",
+  "plugin.endSession": "plugin_v2_end_session",
+  "plugin.audit": "plugin_v2_audit",
+  "plugin.invoke": "plugin_v2_invoke",
+};
+
+// Axum 路由映射：仅含后端已实现的接口，缺失方法浏览器模式抛 NotImplemented
+const axumRouteMap: Record<string, AxumRoute> = {
+  "instance.list": { method: "GET", path: () => "/instances" },
+  "instance.get": { method: "GET", path: (a) => `/instances/${encodeURIComponent(String(a.id))}` },
+  "instance.create": { method: "POST", path: () => "/instances", body: (a) => a.spec },
+  "instance.delete": {
+    method: "DELETE",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}`,
+  },
+  "instance.rename": {
+    method: "PATCH",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}`,
+    body: (a) => ({ name: a.name }),
+  },
+  "instance.updatePath": {
+    method: "PUT",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}/path`,
+    body: (a) => ({ path: a.path }),
+  },
+  "server.status": {
+    method: "GET",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}/status`,
+  },
+  "server.start": {
+    method: "POST",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}/start`,
+  },
+  "server.restart": {
+    method: "POST",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}/restart`,
+  },
+  "server.stop": {
+    method: "POST",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}/stop`,
+  },
+  "server.forceStop": {
+    method: "POST",
+    path: (a) => `/instances/${encodeURIComponent(String(a.id))}/force-stop`,
+  },
+  "server.console.send": {
+    method: "POST",
+    path: () => "/rpc/server/console/send",
+    body: (a) => ({ instanceId: a.id, command: a.command }),
+    isRpc: true,
+  },
+  "system.snapshot": { method: "GET", path: () => "/system" },
+  "system.processUsage": {
+    method: "GET",
+    path: (a) => `/system/process/${encodeURIComponent(String(a.pid))}`,
+  },
+  "system.directoryUsage": {
+    method: "GET",
+    path: (a) => `/system/directory/${encodeURIComponent(String(a.path))}`,
+  },
+  "cron.list": { method: "GET", path: () => "/cron-tasks" },
+  "cron.create": { method: "POST", path: () => "/cron-tasks", body: (a) => a.draft },
+  "cron.update": {
+    method: "PUT",
+    path: (a) => `/cron-tasks/${encodeURIComponent(String(a.id))}`,
+    body: (a) => a.draft,
+  },
+  "cron.delete": {
+    method: "DELETE",
+    path: (a) => `/cron-tasks/${encodeURIComponent(String(a.id))}`,
+  },
+  "cron.setEnabled": {
+    method: "PUT",
+    path: (a) => `/cron-tasks/${encodeURIComponent(String(a.id))}/enabled`,
+    body: (a) => ({ enabled: a.enabled }),
+  },
+  "cron.run": {
+    method: "POST",
+    path: (a) => `/cron-tasks/${encodeURIComponent(String(a.id))}/run`,
+  },
+  "settings.overview": { method: "GET", path: () => "/settings" },
+  "update.check": { method: "GET", path: () => "/update" },
+};
+
+/** Tauri 原生 invoke，动态导入避免浏览器环境加载失败 */
+async function tauriNativeInvoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<T>(command, args);
+}
+
+/** 通过 Axum HTTP 调用，处理 REST 和 RPC 两种响应信封 */
+async function axumFetch<T>(route: AxumRoute, args: Record<string, unknown>): Promise<T> {
+  const url = `${HTTP_API_BASE}/api${route.path(args)}`;
+  const init: RequestInit = { method: route.method };
+
+  if (route.body) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(route.body(args));
+  }
+
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    // REST 错误是 {code, message}，RPC 错误是 {requestId, code, message, retryable}
+    const errorBody = await response.json().catch(() => ({
+      code: "unknown",
+      message: response.statusText,
+    }));
+    throw new Error(errorBody.message || errorBody.code || `HTTP ${response.status}`);
+  }
+
+  // 204 无内容
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const json = await response.json();
+  // RPC 路由响应包在 {requestId, data} 里，REST 直接是数据
+  return (route.isRpc ? json.data : json) as T;
+}
+
+/**
+ * 统一 RPC 调用入口
+ *
+ * 根据运行环境自动选择 Tauri 命令或 Axum HTTP 路由。
+ * 方法名不在映射表里时抛 NotImplementedError，表示该后端尚未实现。
+ */
+export async function rpcInvoke<T>(
+  method: string,
+  args: Record<string, unknown> = {},
+  options: RpcInvokeOptions = {},
+): Promise<T> {
+  const isHttp = isBrowserEnv();
+
+  try {
+    let result: T;
+
+    if (isHttp) {
+      const route = axumRouteMap[method];
+      if (!route) {
+        throw new NotImplementedError(method, "axum");
+      }
+      result = await axumFetch<T>(route, args);
+    } else {
+      const command = tauriCommandMap[method];
+      if (!command) {
+        throw new NotImplementedError(method, "tauri");
+      }
+      result = await tauriNativeInvoke<T>(command, args);
+    }
+
+    if (import.meta.env.DEV) {
+      console.debug(`[${isHttp ? "HTTP" : "Tauri"}] ${method} ok`);
+    }
+
+    return result;
+  } catch (error) {
+    // NotImplementedError 直接向上抛，方便调用方识别并禁用功能
+    if (error instanceof NotImplementedError) {
+      if (!options.silent) {
+        throw error;
+      }
+      return options.defaultValue as T;
+    }
+
+    const errorMessage = handleError(error, options.context || method);
+
+    if (import.meta.env.DEV) {
+      console.warn(`[${isHttp ? "HTTP" : "Tauri"}] ${method} failed:`, errorMessage);
+    }
+
+    if (!options.silent) {
+      throw new AppError(errorMessage, ErrorType.SERVER, options.context);
+    }
+
+    return options.defaultValue as T;
+  }
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,4 +1,5 @@
 import { tauriInvoke, isBrowserEnv, HTTP_API_BASE } from "@api/tauri";
+import { rpcInvoke } from "@api/rpc";
 import type { ServerInstance } from "@type/server";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
@@ -67,6 +68,82 @@ interface StartupScanResultRaw {
   mc_version_options: string[];
   detected_mc_version: string | null;
   mc_version_detection_failed: boolean;
+}
+
+/** 后端 Instance 原始结构，字段和前端 ServerInstance 差异较大需转换 */
+interface InstanceRaw {
+  id: string;
+  name: string;
+  aliases: string[];
+  core_type: string;
+  core_version: string;
+  game_version: string;
+  directory: string;
+  port: number;
+  max_memory_mib: number;
+  min_memory_mib: number;
+  created_at_unix_secs: number;
+  last_started_at_unix_secs: number | null;
+  server_metadata: unknown;
+  launch: LocalLaunchRaw;
+}
+
+/** 后端启动配置，前端把部分字段平铺到 ServerInstance */
+interface LocalLaunchRaw {
+  startup_mode: string;
+  startup_target: string | null;
+  custom_command: string | null;
+  custom_executable: string | null;
+  custom_arguments: string[];
+  java_executable: string | null;
+  jvm_arguments: string[];
+}
+
+/** 后端 ServerSnapshot 原始结构 */
+interface ServerSnapshotRaw {
+  instance_id: string;
+  state: string;
+  pid: number | null;
+  uptime_secs: number | null;
+  error_message: string | null;
+}
+
+/** Instance 原始结构转前端 ServerInstance */
+function toServerInstance(i: InstanceRaw): ServerInstance {
+  return {
+    id: i.id,
+    name: i.name,
+    core_type: i.core_type,
+    core_version: i.core_version,
+    mc_version: i.game_version,
+    path: i.directory,
+    jar_path: i.launch.startup_target ?? "",
+    startup_mode: i.launch.startup_mode as ServerInstance["startup_mode"],
+    custom_command: i.launch.custom_command,
+    java_path: i.launch.java_executable ?? "",
+    max_memory: i.max_memory_mib,
+    min_memory: i.min_memory_mib,
+    jvm_args: i.launch.jvm_arguments,
+    port: i.port,
+    created_at: i.created_at_unix_secs,
+    last_started_at: i.last_started_at_unix_secs,
+  };
+}
+
+/** 后端 state 小写枚举转前端 PascalCase 状态 */
+function toServerStatusInfo(s: ServerSnapshotRaw): ServerStatusInfo {
+  const stateMap: Record<string, ServerStatusInfo["status"]> = {
+    starting: "Starting",
+    running: "Running",
+    stopping: "Stopping",
+    stopped: "Stopped",
+  };
+  return {
+    id: s.instance_id,
+    status: stateMap[s.state] ?? "Stopped",
+    pid: s.pid,
+    uptime: s.uptime_secs,
+  };
 }
 
 export const serverApi = {
@@ -221,11 +298,11 @@ export const serverApi = {
   },
 
   async start(id: string): Promise<void> {
-    return tauriInvoke("start_server", { id });
+    await rpcInvoke("server.start", { id });
   },
 
   async stop(id: string): Promise<void> {
-    return tauriInvoke("stop_server", { id });
+    await rpcInvoke("server.stop", { id });
   },
 
   async prepareForceStop(id: string): Promise<ForceStopPreparation> {
@@ -233,23 +310,27 @@ export const serverApi = {
   },
 
   async forceStop(id: string, confirmationToken: string): Promise<void> {
-    return tauriInvoke("force_stop_server", { id, confirmationToken });
+    // 后端 force_stop_server 只收 id，token 在后端不校验
+    void confirmationToken;
+    await rpcInvoke("server.forceStop", { id });
   },
 
   async sendCommand(id: string, command: string): Promise<void> {
-    return tauriInvoke("send_command", { id, command });
+    await rpcInvoke("server.console.send", { id, command });
   },
 
   async getList(): Promise<ServerInstance[]> {
-    return tauriInvoke("get_server_list");
+    const raw = await rpcInvoke<InstanceRaw[]>("instance.list");
+    return raw.map(toServerInstance);
   },
 
   async getStatus(id: string): Promise<ServerStatusInfo> {
-    return tauriInvoke("get_server_status", { id });
+    const raw = await rpcInvoke<ServerSnapshotRaw>("server.status", { id });
+    return toServerStatusInfo(raw);
   },
 
   async deleteServer(id: string): Promise<void> {
-    return tauriInvoke("delete_server", { id });
+    await rpcInvoke("instance.delete", { id });
   },
 
   async getLogs(id: string, since: number, maxLines?: number): Promise<string[]> {
@@ -302,7 +383,7 @@ export const serverApi = {
   },
 
   async updateServerName(id: string, name: string): Promise<void> {
-    return tauriInvoke("update_server_name", { id, name });
+    await rpcInvoke("instance.rename", { id, name });
   },
 
   async validateServerPath(newPath: string): Promise<{

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,4 +1,5 @@
 import { isBrowserEnv, tauriInvoke } from "@api/tauri";
+import { rpcInvoke } from "@api/rpc";
 import type { JavaInfo } from "@api/java";
 
 export type SettingsGroup =
@@ -107,26 +108,26 @@ export interface UpdateSettingsResult {
 
 export const settingsApi = {
   async get(): Promise<AppSettings> {
-    return tauriInvoke("get_settings");
+    return rpcInvoke("settings.get");
   },
   async save(settings: AppSettings): Promise<void> {
     // 后端 update_settings 返回 UpdateResult，这里只关心副作用，丢弃结果
-    await tauriInvoke("update_settings", { settings });
+    await rpcInvoke("settings.update", { settings });
   },
   async saveWithDiff(settings: AppSettings): Promise<UpdateSettingsResult> {
-    return tauriInvoke("update_settings", { settings });
+    return rpcInvoke("settings.update", { settings });
   },
   async updatePartial(partial: PartialSettings): Promise<UpdateSettingsResult> {
-    return tauriInvoke("update_settings_partial", { partial });
+    return rpcInvoke("settings.updatePartial", { partial });
   },
   async reset(): Promise<AppSettings> {
-    return tauriInvoke("reset_settings");
+    return rpcInvoke("settings.reset");
   },
   async exportJson(): Promise<string> {
-    return tauriInvoke("export_settings");
+    return rpcInvoke("settings.export");
   },
   async importJson(json: string): Promise<AppSettings> {
-    return tauriInvoke("import_settings", { json });
+    return rpcInvoke("settings.import", { json });
   },
   async applyAcrylic(enabled: boolean): Promise<void> {
     if (isBrowserEnv()) return;

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -1,4 +1,5 @@
 import { tauriInvoke } from "@api/tauri";
+import { rpcInvoke } from "@api/rpc";
 import { isUploadSupported, pickFileFromBrowser, uploadFile } from "@api/upload";
 
 export interface CpuInfo {
@@ -93,6 +94,40 @@ export interface IPv6TestResult {
   targets?: IPv6TestTarget[];
 }
 
+/** 后端 SystemSnapshot 原始结构，和前端 SystemInfo 字段有差异需转换 */
+interface SystemSnapshotRaw {
+  os: string;
+  arch: string;
+  os_name: string;
+  os_version: string;
+  kernel_version: string;
+  host_name: string;
+  cpu: CpuInfo;
+  memory: MemoryInfo;
+  swap: SwapInfo;
+  disk: {
+    total: number;
+    used: number;
+    available: number;
+    usage: number;
+    disks: DiskDetailRaw[];
+  };
+  networks: { interface: string; received: number; transmitted: number }[];
+  uptime: number;
+  process_count: number;
+}
+
+/** 后端单个磁盘信息，比前端 DiskDetail 少 usage 字段需计算补齐 */
+interface DiskDetailRaw {
+  name: string;
+  mount_point: string;
+  file_system: string;
+  total: number;
+  used: number;
+  available: number;
+  is_removable: boolean;
+}
+
 export const systemApi = {
   async pickAndUploadBrowserFile(accept?: string): Promise<string | null> {
     if (!isUploadSupported()) {
@@ -125,7 +160,41 @@ export const systemApi = {
   },
 
   async getSystemInfo(): Promise<SystemInfo> {
-    return tauriInvoke("get_system_info");
+    const raw = await rpcInvoke<SystemSnapshotRaw>("system.snapshot");
+    // 后端 networks 是数组，前端 NetworkInfo 要汇总总量并映射字段名
+    return {
+      os: raw.os,
+      arch: raw.arch,
+      os_name: raw.os_name,
+      os_version: raw.os_version,
+      kernel_version: raw.kernel_version,
+      host_name: raw.host_name,
+      cpu: raw.cpu,
+      memory: raw.memory,
+      swap: raw.swap,
+      disk: {
+        total: raw.disk.total,
+        used: raw.disk.used,
+        available: raw.disk.available,
+        usage: raw.disk.usage,
+        disks: raw.disk.disks.map((d) => ({
+          ...d,
+          // 后端 DiskInfo 没有 usage，按容量占比计算
+          usage: d.total > 0 ? (d.used / d.total) * 100 : 0,
+        })),
+      },
+      network: {
+        total_received: raw.networks.reduce((s, n) => s + n.received, 0),
+        total_transmitted: raw.networks.reduce((s, n) => s + n.transmitted, 0),
+        interfaces: raw.networks.map((n) => ({
+          name: n.interface,
+          received: n.received,
+          transmitted: n.transmitted,
+        })),
+      },
+      uptime: raw.uptime,
+      process_count: raw.process_count,
+    };
   },
 
   async getServerResourceUsage(serverId: string): Promise<ServerResourceUsage> {

--- a/src/api/tunnel.ts
+++ b/src/api/tunnel.ts
@@ -1,4 +1,5 @@
 import { tauriInvoke } from "@api/tauri";
+import { rpcInvoke } from "@api/rpc";
 
 export interface TunnelConnection {
   remote_id: string;
@@ -35,30 +36,82 @@ export interface TunnelJoinParams {
   password?: string;
 }
 
+/** 后端 OnlineTunnelStatus 原始结构，字段和前端 TunnelStatus 差异较大 */
+interface TunnelStatusRaw {
+  active: boolean;
+  mode: "host" | "join" | null;
+  ticket: string | null;
+  connections: TunnelConnectionRaw[];
+}
+
+/** 后端连接信息用 elapsed_ms，前端用 elapsed_secs */
+interface TunnelConnectionRaw {
+  remote_id: string;
+  is_relay: boolean;
+  rtt_ms: number;
+  tx_bytes: number;
+  rx_bytes: number;
+  alive: boolean;
+  elapsed_ms: number;
+}
+
+/** 后端状态转前端，后端不支持的字段给默认值 */
+function toTunnelStatus(raw: TunnelStatusRaw): TunnelStatus {
+  return {
+    running: raw.active,
+    mode: raw.mode,
+    ticket: raw.ticket,
+    connections: raw.connections.map((c) => ({
+      remote_id: c.remote_id,
+      is_relay: c.is_relay,
+      rtt_ms: c.rtt_ms,
+      tx_bytes: c.tx_bytes,
+      rx_bytes: c.rx_bytes,
+      alive: c.alive,
+      // 后端毫秒，前端秒
+      elapsed_secs: c.elapsed_ms / 1000,
+    })),
+    logs: [],
+    host_port: 0,
+    join_port: 0,
+    last_ticket: null,
+    relay_url: null,
+  };
+}
+
 export const tunnelApi = {
   async host(params: TunnelHostParams): Promise<TunnelStatus> {
-    return tauriInvoke("tunnel_host", {
-      port: params.port,
-      password: params.password,
-      maxPlayers: params.maxPlayers,
-      relayUrl: params.relayUrl,
+    // 后端 OnlineTunnelHostRequest 用 snake_case，port 映射为 minecraft_port
+    const raw = await rpcInvoke<TunnelStatusRaw>("tunnel.host", {
+      request: {
+        minecraft_port: params.port,
+        password: params.password,
+        max_players: params.maxPlayers,
+        relay_url: params.relayUrl,
+      },
     });
+    return toTunnelStatus(raw);
   },
 
   async join(params: TunnelJoinParams): Promise<TunnelStatus> {
-    return tauriInvoke("tunnel_join", {
-      ticket: params.ticket,
-      localPort: params.localPort,
-      password: params.password,
+    const raw = await rpcInvoke<TunnelStatusRaw>("tunnel.join", {
+      request: {
+        ticket: params.ticket,
+        local_port: params.localPort,
+        password: params.password,
+      },
     });
+    return toTunnelStatus(raw);
   },
 
   async stop(): Promise<TunnelStatus> {
-    return tauriInvoke("tunnel_stop");
+    const raw = await rpcInvoke<TunnelStatusRaw>("tunnel.stop");
+    return toTunnelStatus(raw);
   },
 
   async status(): Promise<TunnelStatus> {
-    return tauriInvoke("tunnel_status");
+    const raw = await rpcInvoke<TunnelStatusRaw>("tunnel.status");
+    return toTunnelStatus(raw);
   },
 
   async copyTicket(): Promise<boolean> {

--- a/src/api/update.ts
+++ b/src/api/update.ts
@@ -1,4 +1,5 @@
 import { tauriInvoke } from "@api/tauri";
+import { rpcInvoke } from "@api/rpc";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 export interface UpdateInfo {
@@ -24,8 +25,7 @@ export interface DownloadProgress {
 
 export async function checkUpdate(): Promise<UpdateInfo | null> {
   try {
-    const result = await tauriInvoke<UpdateInfo>("check_update");
-    return result;
+    return await rpcInvoke<UpdateInfo>("update.check");
   } catch (error) {
     console.error("检查更新失败:", error);
     throw error;
@@ -37,19 +37,28 @@ export async function downloadUpdate(
   expectedHash?: string,
   version?: string,
 ): Promise<string> {
-  return tauriInvoke<string>("download_update", { url, expectedHash, version });
+  // 后端参数名是 snake_case，version 非可选需给默认值
+  return rpcInvoke<string>("update.download", {
+    url,
+    expected_hash: expectedHash,
+    version: version ?? "",
+  });
 }
 
 export async function installUpdate(filePath: string, version: string): Promise<void> {
-  return tauriInvoke<void>("install_update", { filePath, version });
+  // 后端 update_install 接收 file_path 和 arguments 数组
+  return rpcInvoke<void>("update.install", {
+    file_path: filePath,
+    arguments: [version],
+  });
 }
 
 export async function checkPendingUpdate(): Promise<PendingUpdate | null> {
-  return tauriInvoke<PendingUpdate | null>("check_pending_update");
+  return rpcInvoke<PendingUpdate | null>("update.pending");
 }
 
 export async function clearPendingUpdate(): Promise<void> {
-  return tauriInvoke<void>("clear_pending_update");
+  return rpcInvoke<void>("update.clearPending");
 }
 
 export async function restartAndInstall(): Promise<void> {


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [ ] 已阅读 `docs/CONTRIBUTING.md`
- [ ] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

引入统一的 RPC 适配层，并将现有 API 模块从直接调用 Tauri 切换到新的基于 RPC 的调用约定。

增强内容：
- 添加共享的 `rpcInvoke` 适配器，根据运行时环境将点号表示法的方法路由到 Tauri 命令或 Axum HTTP 端点，并提供集中化的错误处理和未实现（NotImplemented）信号。
- 规范并转换后端数据结构（实例、服务器状态、隧道状态、系统快照、磁盘/网络详情），使其符合现有的前端模型，以适配新的 RPC 端点。
- 更新服务器、隧道、系统、下载器、更新、设置和 Java API 模块，使用统一的 RPC 适配器和新的方法命名方案，而不是直接调用 Tauri。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified RPC adapter layer and switch existing API modules from direct Tauri invocations to the new RPC-based calling conventions.

Enhancements:
- Add a shared rpcInvoke adapter that routes dot-notation methods to either Tauri commands or Axum HTTP endpoints depending on runtime environment, with centralized error handling and NotImplemented signaling.
- Normalize and convert backend data shapes (instances, server status, tunnel status, system snapshot, disk/network details) into existing frontend models to work with the new RPC endpoints.
- Update server, tunnel, system, downloader, update, settings, and Java API modules to use the unified RPC adapter and new method naming scheme instead of raw Tauri invocations.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入统一的 RPC 适配层，并将现有 API 模块从直接调用 Tauri 切换到新的基于 RPC 的调用约定。

增强内容：
- 添加共享的 `rpcInvoke` 适配器，根据运行时环境将点号表示法的方法路由到 Tauri 命令或 Axum HTTP 端点，并提供集中化的错误处理和未实现（NotImplemented）信号。
- 规范并转换后端数据结构（实例、服务器状态、隧道状态、系统快照、磁盘/网络详情），使其符合现有的前端模型，以适配新的 RPC 端点。
- 更新服务器、隧道、系统、下载器、更新、设置和 Java API 模块，使用统一的 RPC 适配器和新的方法命名方案，而不是直接调用 Tauri。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified RPC adapter layer and switch existing API modules from direct Tauri invocations to the new RPC-based calling conventions.

Enhancements:
- Add a shared rpcInvoke adapter that routes dot-notation methods to either Tauri commands or Axum HTTP endpoints depending on runtime environment, with centralized error handling and NotImplemented signaling.
- Normalize and convert backend data shapes (instances, server status, tunnel status, system snapshot, disk/network details) into existing frontend models to work with the new RPC endpoints.
- Update server, tunnel, system, downloader, update, settings, and Java API modules to use the unified RPC adapter and new method naming scheme instead of raw Tauri invocations.

</details>

</details>