### PR TITLE
fix: 修复了“清初Lucky”头像无法正常显示的问题

### DIFF
--- a/src/data/contributors.ts
+++ b/src/data/contributors.ts
@@ -97,7 +97,7 @@ export const contributors: Contributor[] = [
   {
     name: "清初Lucky",
     role: "喵喵喵~",
-    avatar: "https://api.rms.net.cn/head/qingchu2010",
+    avatar: "https://api.rms.net.cn/head/QINGCHU_MC",
   },
   {
     name: "ieshishinjin",


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

Bug Fixes:
- 修复贡献者 清初Lucky 的头像 URL 不正确导致个人资料图片无法渲染的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect avatar URL for contributor 清初Lucky causing the profile image not to render.

</details>