### PR TITLE
feat(console): tauri 日志事件实时转发

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,6 +5209,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-window-state",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/application/src/service/log_recorder.rs
+++ b/application/src/service/log_recorder.rs
@@ -10,20 +10,20 @@
 //! 自己的传输（前端事件 / SSE）。订阅方消费慢导致的事件丢失可由
 //! `ConsoleService::logs(since)` 拉取补漏。
 
-use std::path::Path;
-use std::sync::OnceLock;
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use sealantern_core::process::read_output_lines;
 use sealantern_core::process::TerminalOutput;
 use sealantern_extra::server::log::{open_log_database, LogSource, LogWriter};
 use sealantern_interface::console::ConsoleLogLine;
+use serde::Serialize;
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// 广播通道容量；消费慢时丢弃旧事件，调用方可拉取补漏。
 const LOG_EVENT_CHANNEL_CAPACITY: usize = 1024;
 
 /// 实时日志事件（落库后产生，携带行号游标）。
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LogEvent {
     /// 所属实例 ID。
     pub instance_id: String,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ sealantern-interface = { path = "../crates/interface" }
 async-trait = "0.1.91"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1.53.1", features = ["sync"] }
 
 [features]
 docker = []

--- a/src-tauri/src/adapter/tauri/events/mod.rs
+++ b/src-tauri/src/adapter/tauri/events/mod.rs
@@ -1,0 +1,3 @@
+pub mod server_log;
+
+pub use server_log::LogSenderState;

--- a/src-tauri/src/adapter/tauri/events/server_log.rs
+++ b/src-tauri/src/adapter/tauri/events/server_log.rs
@@ -1,0 +1,106 @@
+//! 服务器日志实时事件转发（Tauri 宿主侧）。
+//!
+//! 订阅 application 层的全局日志事件广播（[`subscribe_log_events`]），
+//! 将日志行转发为 Tauri 前端事件 `server-log-line`，使前端控制台能
+//! 实时展示服务器输出，无需轮询。
+//!
+//! [`LogSenderState`] 负责转发任务的生命周期：
+//! - `start` 惰性启动单个转发任务（幂等，重复调用不会叠加任务）；
+//! - `stop` 通过 `watch` 通道发送停止信号，转发任务自主退出后等待回收；
+//! - 任务内以 `tokio::select!` 同时监听停止信号与日志事件，避免
+//!   阻塞在事件接收上无法响应停止请求。
+
+use sealantern_application::service::subscribe_log_events;
+use std::sync::Arc;
+use tauri::async_runtime::JoinHandle;
+use tauri::{async_runtime::spawn, AppHandle, Emitter};
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::{watch, Mutex};
+
+/// 服务器日志事件转发器的运行状态。
+///
+/// 持有 `watch` 停止信号与后台转发任务的句柄；作为 Tauri 托管状态
+/// （`.manage()`）供 setup 启动、窗口销毁时停止。
+pub struct LogSenderState {
+    /// 运行标志（`watch` 发送端）：`start` 置 `true`，`stop` 置 `false`，
+    /// 置值会唤醒转发任务中等待的 `changed()` 分支。
+    running: watch::Sender<bool>,
+    /// 后台转发任务的句柄；`None` 表示未启动或已停止。
+    handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl Default for LogSenderState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LogSenderState {
+    /// 创建处于停止状态的转发器。
+    pub fn new() -> LogSenderState {
+        let (running, _) = watch::channel(false);
+        Self {
+            running,
+            handle: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// 启动日志事件转发任务（幂等）。
+    ///
+    /// 若已有转发任务在运行则直接返回，避免重复订阅广播产生重复推送。
+    /// 任务订阅全局日志广播并转发为 `server-log-line` 事件；停止信号
+    /// 到来或广播关闭时自行退出。
+    pub async fn start(&self, app_handle: AppHandle) {
+        if self.handle.lock().await.is_some() {
+            return;
+        }
+
+        // 置运行标志并持有其接收端：`stop` 改值即可唤醒下方 `select`。
+        let _ = self.running.send(true);
+        let mut stop_signal = self.running.subscribe();
+
+        let handle = spawn(async move {
+            let mut receiver = subscribe_log_events();
+            loop {
+                tokio::select! {
+                    // 停止信号：`stop()` 已调用，任务自行退出。
+                    _ = stop_signal.changed() => {
+                        break
+                    }
+                    // 日志事件：转发到前端。
+                    event = receiver.recv() => match event {
+                        Ok(event) => {
+                            if let Err(e) = app_handle.emit("server-log-line", &event) {
+                                tracing::error!(
+                                    target: "sealantern.tauri.server_log",
+                                    error = e.to_string(),
+                                    "failed to emit server log event"
+                                )
+                            }
+                        }
+                        // 广播通道关闭：静态广播不会发生，防御性退出。
+                        Err(RecvError::Closed) => {
+                            break;
+                        }
+                        // 消费落后被跳过 n 条：预期背压行为，仅记录提示。
+                        Err(RecvError::Lagged(n)) => {
+                            tracing::warn!(target: "sealantern.tauri.server_log", skipped = n, "server log subscriber lagged")
+                        }
+                    }
+                }
+            }
+        });
+        *self.handle.lock().await = Some(handle);
+    }
+
+    /// 停止转发任务：发送停止信号并等待任务自行退出。
+    ///
+    /// 采用优雅停止（而非 `abort` 强杀），保证任务内正在进行的
+    /// 事件转发不被中途打断；重复调用安全（句柄已取出）。
+    pub async fn stop(&self) {
+        let _ = self.running.send(false);
+        if let Some(handle) = self.handle.lock().await.take() {
+            let _ = handle.await;
+        }
+    }
+}

--- a/src-tauri/src/adapter/tauri/mod.rs
+++ b/src-tauri/src/adapter/tauri/mod.rs
@@ -1,1 +1,2 @@
 pub mod commands;
+pub mod events;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -63,7 +63,7 @@ pub fn run() {
     // 初始化 tracing 日志（在 Tauri 构建之前）
     observability::init();
 
-    let result = tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
@@ -164,9 +164,16 @@ pub fn run() {
             plugin_v2_unload
         ])
         .setup(setup)
-        .run(tauri::generate_context!());
+        .build(tauri::generate_context!())
+        .expect("error while building Sea Lantern");
 
-    result.expect("error while running Sea Lantern");
+    // 全局退出钩子：覆盖窗口销毁、`app.exit`、操作系统关闭等所有退出路径，
+    // 保证异步服务（日志转发、在线隧道）在进程退出前统一清理。
+    app.run(|app_handle, event| {
+        if let tauri::RunEvent::Exit = event {
+            on_shutdown(app_handle.clone());
+        }
+    });
 }
 
 fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -197,14 +204,6 @@ fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let handle_for_server_log = app_handle.clone();
     let log_sender: tauri::State<'_, LogSenderState> = app_handle.state();
     tauri::async_runtime::block_on(async { log_sender.start(handle_for_server_log).await });
-
-    if let Some(window) = app.get_webview_window("main") {
-        window.on_window_event(move |event| {
-            if let tauri::WindowEvent::Destroyed = event {
-                on_shutdown(app_handle.clone())
-            }
-        });
-    }
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ pub mod observability;
 
 use sealantern_application::services::AppServices;
 use sealantern_interface::OnlineTunnelService;
-use tauri::Manager;
+use tauri::{AppHandle, Manager};
 
 use adapter::tauri::commands::catalog::{catalog_details, catalog_server_types, catalog_versions};
 use adapter::tauri::commands::console::get_server_logs;
@@ -50,6 +50,7 @@ use adapter::tauri::commands::update::check_update;
 use adapter::tauri::commands::update_install::{
     update_clear_pending, update_download, update_install, update_pending,
 };
+use adapter::tauri::events::LogSenderState;
 use desktop::{
     desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
     desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
@@ -70,6 +71,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .manage(OnlineTunnelEventForwarder::default())
+        .manage(LogSenderState::new())
         .invoke_handler(tauri::generate_handler![
             //桌面端能力（由desktop/dialog提供）
             desktop_pick_archive_file,
@@ -161,44 +163,61 @@ pub fn run() {
             plugin_v2_set_trust,
             plugin_v2_unload
         ])
-        .setup(|app| {
-            tauri::async_runtime::block_on(async {
-                let services = AppServices::get().await.map_err(|error| {
-                    std::io::Error::other(format!(
-                        "failed to assemble application services: {error}"
-                    ))
-                })?;
-                if let Err(error) = services.initialize_network_settings().await {
-                    // 网络设置同步失败不阻止启动：网络运行时保持默认直连，
-                    // 系统代理恢复后由轮询与后续设置操作的重试自动跟上。
-                    tracing::error!(
-                        error = %error,
-                        "failed to initialize persisted network settings; continuing with direct network"
-                    );
-                }
-                Ok::<(), std::io::Error>(())
-            })?;
-
-            // 前端提供自定义标题栏；macOS 仍使用 Overlay 承载系统交通灯。
-            #[cfg(not(target_os = "macos"))]
-            if let Some(window) = app.get_webview_window("main") {
-                window.set_decorations(false)?;
-            }
-
-            Ok(())
-        })
+        .setup(setup)
         .run(tauri::generate_context!());
-
-    shutdown_async_services();
 
     result.expect("error while running Sea Lantern");
 }
 
-/// 应用退出时关闭后台异步服务（当前为在线隧道）。
-fn shutdown_async_services() {
+fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    //这里提供app_handle，便于使用时直接clone
+    let app_handle = app.handle().clone();
+
+    tauri::async_runtime::block_on(async {
+        let services = AppServices::get().await.map_err(|error| {
+            std::io::Error::other(format!("failed to assemble application services: {error}"))
+        })?;
+        if let Err(error) = services.initialize_network_settings().await {
+            // 网络设置同步失败不阻止启动：网络运行时保持默认直连，
+            // 系统代理恢复后由轮询与后续设置操作的重试自动跟上。
+            tracing::error!(
+                error = %error,
+                "failed to initialize persisted network settings; continuing with direct network"
+            );
+        }
+        Ok::<(), std::io::Error>(())
+    })?;
+
+    // 前端提供自定义标题栏；macOS 仍使用 Overlay 承载系统交通灯。
+    #[cfg(not(target_os = "macos"))]
+    if let Some(window) = app.get_webview_window("main") {
+        window.set_decorations(false)?;
+    }
+
+    let handle_for_server_log = app_handle.clone();
+    let log_sender: tauri::State<'_, LogSenderState> = app_handle.state();
+    tauri::async_runtime::block_on(async { log_sender.start(handle_for_server_log).await });
+
+    if let Some(window) = app.get_webview_window("main") {
+        window.on_window_event(move |event| {
+            if let tauri::WindowEvent::Destroyed = event {
+                on_shutdown(app_handle.clone())
+            }
+        });
+    }
+
+    Ok(())
+}
+
+/// 应用退出时关闭后台异步服务（当前为在线隧道和日志提交器）。
+fn on_shutdown(app_handle: AppHandle) {
+    let log_sender: tauri::State<'_, LogSenderState> = app_handle.state();
+    tauri::async_runtime::block_on(async { log_sender.stop().await });
+
     let Some(services) = AppServices::try_get() else {
         return;
     };
+
     tauri::async_runtime::block_on(async move {
         if let Err(error) = services.online_tunnel().shutdown().await {
             tracing::error!(


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- 新增 LogSenderState（watch 停止信号 + select 双路监听，幂等启动/优雅停止），订阅全局日志广播并 emit server-log-line；LogEvent 补 Serialize；setup 提取并托管转发器生命周期


<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

添加一个受管的 Tauri 端服务器日志事件转发器，将应用程序日志事件流式传输到前端，并将其生命周期整合到应用启动和关闭流程中。

新特性：
- 通过由应用程序日志广播支持的 `server-log-line` 事件，将实时服务器日志事件暴露给 Tauri 前端。

优化：
- 将 Tauri 应用的初始化重构为独立的 `setup` 函数，同时接入日志转发的启动逻辑以及窗口销毁时的关闭钩子。

构建：
- 在 Tauri crate 中添加 Tokio sync 依赖，用于基于 watch/broadcast 的任务协调。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a managed Tauri-side server log event forwarder that streams application log events to the frontend and integrate its lifecycle into app setup and shutdown.

New Features:
- Expose real-time server log events to the Tauri frontend via a `server-log-line` event backed by the application log broadcast.

Enhancements:
- Refactor Tauri app setup into a dedicated `setup` function that also wires log forwarding startup and window-destroy shutdown hooks.

Build:
- Add Tokio sync dependency to the Tauri crate for watch/broadcast-based task coordination.

</details>