### PR TITLE
ci: 修复 nightly 构建无法删除过期 tag

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -324,7 +324,7 @@ jobs:
             fi
 
             echo "删除旧 Nightly Release: $tag"
-            gh release delete "$tag" --cleanup-tag -y
+            gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --cleanup-tag -y
             deleted=1
           done
 


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

同标题。

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## 由 Sourcery 总结

CI：
- 更新 nightly-release 工作流，在删除旧的 nightly 版本时，将仓库显式传递给 GitHub CLI。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update nightly-release workflow to pass the repository explicitly to the GitHub CLI when deleting old nightly releases.

</details>