### PR TITLE
feat: 新增 get_default_run_path 默认运行路径命令

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1304,17 @@ dependencies = [
  "option-ext",
  "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -5281,6 +5302,7 @@ dependencies = [
  "bytes",
  "cap-std",
  "dirs 5.0.1",
+ "dirs-next",
  "futures",
  "ipnet",
  "reqwest 0.12.28",

--- a/application/src/error/system.rs
+++ b/application/src/error/system.rs
@@ -24,6 +24,11 @@ pub enum SystemError {
         /// 底层来源错误。
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+    /// 无法确定默认运行路径（标准数据目录、文档目录与当前目录均不可用）。
+    DefaultRunPathUnresolved {
+        /// 底层来源错误。
+        source: std::io::Error,
+    },
     /// 该能力尚未实现（占位）。
     Unsupported,
 }
@@ -37,6 +42,9 @@ impl fmt::Display for SystemError {
                 write!(formatter, "system operation failed: {source}")
             }
             Self::Internal { source } => write!(formatter, "internal system task failed: {source}"),
+            Self::DefaultRunPathUnresolved { source } => {
+                write!(formatter, "default run path unresolved: {source}")
+            }
             Self::Unsupported => write!(formatter, "operation not supported"),
         }
     }
@@ -47,6 +55,7 @@ impl std::error::Error for SystemError {
         match self {
             Self::OperationFailed { source } => Some(source),
             Self::Internal { source } => Some(source.as_ref()),
+            Self::DefaultRunPathUnresolved { source } => Some(source),
             _ => None,
         }
     }
@@ -75,6 +84,7 @@ impl From<SystemError> for SystemServiceError {
             SystemError::OperationFailed { .. } | SystemError::Internal { .. } => {
                 Self::OperationFailed
             }
+            SystemError::DefaultRunPathUnresolved { .. } => Self::DefaultRunPathUnresolved,
             SystemError::Unsupported => Self::Unsupported,
         }
     }

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sealantern_infra::platform::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
-    collect_system_info, cpu_brand_name, directory_size, get_default_run_path,
-    path_disk_capacity, process_count,
+    collect_system_info, cpu_brand_name, directory_size, get_default_run_path, path_disk_capacity,
+    process_count,
 };
 use sealantern_interface::system::{
     CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -8,12 +8,14 @@
 //! [`SystemService`] 时统一转为接口契约错误 [`SystemServiceError`]。
 
 use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use sealantern_infra::platform::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
-    collect_system_info, cpu_brand_name, directory_size, path_disk_capacity, process_count,
+    collect_system_info, cpu_brand_name, directory_size, get_default_run_path,
+    path_disk_capacity, process_count,
 };
 use sealantern_interface::system::{
     CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
@@ -190,6 +192,16 @@ impl CoreSystemService {
             usage: percent(used, total_effective),
         })
     }
+
+    /// 解析默认运行路径，返回应用层主错误。
+    async fn default_run_path_inner() -> Result<PathBuf, SystemError> {
+        get_default_run_path().map_err(|error| match error {
+            sealantern_infra::platform::PlatformError::ResolveDefaultRunPath { source } => {
+                SystemError::DefaultRunPathUnresolved { source }
+            }
+            _ => SystemError::Unsupported,
+        })
+    }
 }
 
 #[async_trait]
@@ -204,6 +216,10 @@ impl SystemService for CoreSystemService {
 
     async fn directory_usage(&self, path: &Path) -> Result<DirectoryUsage, SystemServiceError> {
         Self::directory_usage_inner(path).await.map_err(Into::into)
+    }
+
+    async fn default_run_path(&self) -> Result<PathBuf, SystemServiceError> {
+        Self::default_run_path_inner().await.map_err(Into::into)
     }
 }
 
@@ -260,5 +276,17 @@ mod tests {
             .await;
 
         assert_eq!(result, Err(SystemServiceError::PathNotFound));
+    }
+
+    #[tokio::test]
+    async fn default_run_path_resolves_to_sea_lantern_dir() {
+        let service = CoreSystemService;
+        let path = service.default_run_path().await.expect("default run path");
+
+        let name = path
+            .file_name()
+            .expect("path should have a file name")
+            .to_string_lossy();
+        assert_eq!(name, "SeaLantern", "unexpected default run dir: {name}");
     }
 }

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -8,7 +8,6 @@
 //! [`SystemService`] 时统一转为接口契约错误 [`SystemServiceError`]。
 
 use std::path::Path;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -194,13 +193,15 @@ impl CoreSystemService {
     }
 
     /// 解析默认运行路径，返回应用层主错误。
-    async fn default_run_path_inner() -> Result<PathBuf, SystemError> {
-        get_default_run_path().map_err(|error| match error {
-            sealantern_infra::platform::PlatformError::ResolveDefaultRunPath { source } => {
-                SystemError::DefaultRunPathUnresolved { source }
-            }
-            _ => SystemError::Unsupported,
-        })
+    async fn default_run_path_inner() -> Result<String, SystemError> {
+        get_default_run_path()
+            .map(|path| path.to_string_lossy().to_string())
+            .map_err(|error| match error {
+                sealantern_infra::platform::PlatformError::ResolveDefaultRunPath { source } => {
+                    SystemError::DefaultRunPathUnresolved { source }
+                }
+                _ => SystemError::Unsupported,
+            })
     }
 }
 
@@ -218,7 +219,7 @@ impl SystemService for CoreSystemService {
         Self::directory_usage_inner(path).await.map_err(Into::into)
     }
 
-    async fn default_run_path(&self) -> Result<PathBuf, SystemServiceError> {
+    async fn default_run_path(&self) -> Result<String, SystemServiceError> {
         Self::default_run_path_inner().await.map_err(Into::into)
     }
 }
@@ -283,7 +284,7 @@ mod tests {
         let service = CoreSystemService;
         let path = service.default_run_path().await.expect("default run path");
 
-        let name = path
+        let name = std::path::Path::new(&path)
             .file_name()
             .expect("path should have a file name")
             .to_string_lossy();

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -41,5 +41,6 @@ uuid = { version = "1", features = ["v4"] }
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
 sysinfo = "0.32"
 dirs = "5"
+dirs-next = "2"
 sysproxy = { path = "../vendor/sysproxy" }
 url = "2"

--- a/crates/infra/src/platform/error.rs
+++ b/crates/infra/src/platform/error.rs
@@ -20,6 +20,8 @@ pub enum PlatformError {
     },
     /// 系统命令返回了无法解释的输出。
     InvalidCommandOutput { operation: &'static str },
+    /// 无法确定默认运行路径（标准数据目录、文档目录与当前目录均不可用）。
+    ResolveDefaultRunPath { source: std::io::Error },
 }
 
 impl fmt::Display for PlatformError {
@@ -40,6 +42,9 @@ impl fmt::Display for PlatformError {
             Self::InvalidCommandOutput { operation } => {
                 write!(formatter, "{operation} returned an unexpected result")
             }
+            Self::ResolveDefaultRunPath { source } => {
+                write!(formatter, "failed to resolve default run path: {source}")
+            }
         }
     }
 }
@@ -47,7 +52,9 @@ impl fmt::Display for PlatformError {
 impl std::error::Error for PlatformError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::ReadCertificate { source, .. } | Self::Command { source, .. } => Some(source),
+            Self::ReadCertificate { source, .. }
+            | Self::Command { source, .. }
+            | Self::ResolveDefaultRunPath { source } => Some(source),
             _ => None,
         }
     }

--- a/crates/infra/src/platform/locations.rs
+++ b/crates/infra/src/platform/locations.rs
@@ -134,11 +134,10 @@ pub fn get_or_create_app_data_dir() -> String {
 
 /// 获取默认运行路径。
 ///
-/// 路径优先级：标准数据目录 → 文档目录 → 当前工作目录，
-/// 统一使用 `SeaLantern` 目录名（与旧版本路径保持一致，避免升级后找不到旧数据）。
+/// 路径优先级：标准数据目录 → 文档目录 → 当前工作目录。
 ///
-/// 返回原始 `PathBuf` 而非字符串，避免路径在 `to_string_lossy` 过程中丢失非 UTF-8 信息；
-/// 目录全部不可用时以 [`PlatformError::ResolveDefaultRunPath`] 返回原始错误。
+/// 返回原始 `PathBuf` 而非字符串；目录全部不可用时以
+/// [`PlatformError::ResolveDefaultRunPath`] 返回原始错误。
 pub fn get_default_run_path() -> Result<PathBuf, PlatformError> {
     if let Some(base) = dirs_next::data_dir().or_else(dirs_next::document_dir) {
         return Ok(base.join("SeaLantern"));

--- a/crates/infra/src/platform/locations.rs
+++ b/crates/infra/src/platform/locations.rs
@@ -9,6 +9,7 @@
 
 use std::path::PathBuf;
 
+use super::error::PlatformError;
 use crate::observability;
 
 const APP_DATA_DIR_ENV: &str = "SEALANTERN_DATA_DIR";
@@ -131,6 +132,23 @@ pub fn get_or_create_app_data_dir() -> String {
     data_dir.to_string_lossy().to_string()
 }
 
+/// 获取默认运行路径。
+///
+/// 路径优先级：标准数据目录 → 文档目录 → 当前工作目录，
+/// 统一使用 `SeaLantern` 目录名（与旧版本路径保持一致，避免升级后找不到旧数据）。
+///
+/// 返回原始 `PathBuf` 而非字符串，避免路径在 `to_string_lossy` 过程中丢失非 UTF-8 信息；
+/// 目录全部不可用时以 [`PlatformError::ResolveDefaultRunPath`] 返回原始错误。
+pub fn get_default_run_path() -> Result<PathBuf, PlatformError> {
+    if let Some(base) = dirs_next::data_dir().or_else(dirs_next::document_dir) {
+        return Ok(base.join("SeaLantern"));
+    }
+
+    std::env::current_dir()
+        .map(|cwd| cwd.join("SeaLantern"))
+        .map_err(|source| PlatformError::ResolveDefaultRunPath { source })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,5 +179,22 @@ mod tests {
     fn test_get_or_create_app_data_dir_returns_non_empty() {
         let dir_str = get_or_create_app_data_dir();
         assert!(!dir_str.is_empty());
+    }
+
+    #[test]
+    fn test_get_default_run_path_returns_non_empty() {
+        let path = get_default_run_path().expect("default run path should resolve");
+        assert!(!path.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn test_get_default_run_path_ends_with_app_name() {
+        let path = get_default_run_path().expect("default run path should resolve");
+        let name = path
+            .file_name()
+            .expect("path should have a file name")
+            .to_string_lossy();
+
+        assert_eq!(name, "SeaLantern", "expected SeaLantern directory name, got: {name}");
     }
 }

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -17,7 +17,7 @@ pub use certificate::{
 pub use elevation::{is_elevated, request_elevation, ElevationLaunch};
 pub use environment::{Environment, EnvironmentError};
 pub use error::PlatformError;
-pub use locations::{get_app_data_dir, get_or_create_app_data_dir};
+pub use locations::{get_app_data_dir, get_default_run_path, get_or_create_app_data_dir};
 pub use proxy::{current_system_proxy, PlatformSystemProxyProvider, SystemProxyReadError};
 pub use system::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,

--- a/crates/interface/src/error.rs
+++ b/crates/interface/src/error.rs
@@ -190,6 +190,8 @@ pub enum SystemServiceError {
     PathNotFound,
     /// 底层系统采集 / IO 操作失败。
     OperationFailed,
+    /// 无法确定默认运行路径（标准数据目录、文档目录与当前目录均不可用）。
+    DefaultRunPathUnresolved,
     /// 该能力尚未实现（占位）。
     Unsupported,
 }
@@ -200,6 +202,7 @@ impl std::fmt::Display for SystemServiceError {
             Self::ProcessNotFound => "process not found",
             Self::PathNotFound => "path not found",
             Self::OperationFailed => "system operation failed",
+            Self::DefaultRunPathUnresolved => "default run path unresolved",
             Self::Unsupported => "operation not supported",
         };
         formatter.write_str(message)

--- a/crates/interface/src/system/service.rs
+++ b/crates/interface/src/system/service.rs
@@ -1,6 +1,6 @@
 //! 系统资源信息服务端口。
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -26,4 +26,9 @@ pub trait SystemService: Send + Sync {
 
     /// 计算目录磁盘占用。
     async fn directory_usage(&self, path: &Path) -> Result<DirectoryUsage, SystemServiceError>;
+
+    /// 获取默认运行路径。
+    ///
+    /// 路径优先级：标准数据目录 → 文档目录 → 当前工作目录。
+    async fn default_run_path(&self) -> Result<PathBuf, SystemServiceError>;
 }

--- a/crates/interface/src/system/service.rs
+++ b/crates/interface/src/system/service.rs
@@ -1,6 +1,6 @@
 //! 系统资源信息服务端口。
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use async_trait::async_trait;
 
@@ -30,5 +30,5 @@ pub trait SystemService: Send + Sync {
     /// 获取默认运行路径。
     ///
     /// 路径优先级：标准数据目录 → 文档目录 → 当前工作目录。
-    async fn default_run_path(&self) -> Result<PathBuf, SystemServiceError>;
+    async fn default_run_path(&self) -> Result<String, SystemServiceError>;
 }

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -198,13 +198,16 @@ impl HttpError {
                 code: "system_resource_not_found",
                 message: error.to_string(),
             },
-            SystemServiceError::OperationFailed | SystemServiceError::DefaultRunPathUnresolved => {
-                Self {
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
-                    code: "system_operation_failed",
-                    message: error.to_string(),
-                }
-            }
+            SystemServiceError::OperationFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "system_operation_failed",
+                message: error.to_string(),
+            },
+            SystemServiceError::DefaultRunPathUnresolved => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "default_run_path_unresolved",
+                message: error.to_string(),
+            },
             SystemServiceError::Unsupported => Self {
                 status: StatusCode::NOT_IMPLEMENTED,
                 code: "operation_unsupported",

--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -198,11 +198,13 @@ impl HttpError {
                 code: "system_resource_not_found",
                 message: error.to_string(),
             },
-            SystemServiceError::OperationFailed => Self {
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                code: "system_operation_failed",
-                message: error.to_string(),
-            },
+            SystemServiceError::OperationFailed | SystemServiceError::DefaultRunPathUnresolved => {
+                Self {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    code: "system_operation_failed",
+                    message: error.to_string(),
+                }
+            }
             SystemServiceError::Unsupported => Self {
                 status: StatusCode::NOT_IMPLEMENTED,
                 code: "operation_unsupported",

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -24,5 +24,5 @@ pub use server::{
     stop_server,
 };
 pub use settings::settings_overview;
-pub use system::{directory_usage, process_usage, system_snapshot};
+pub use system::{default_run_path, directory_usage, process_usage, system_snapshot};
 pub use update::check_update;

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -58,7 +58,7 @@ pub async fn directory_usage(
 /// `GET /api/system/default-run-path` — 获取默认运行路径。
 pub async fn default_run_path(
     State(state): State<AppState>,
-) -> Result<Json<std::path::PathBuf>, HttpError> {
+) -> Result<Json<String>, HttpError> {
     state
         .system()
         .default_run_path()

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -54,3 +54,15 @@ pub async fn directory_usage(
         .map(Json)
         .map_err(HttpError::from)
 }
+
+/// `GET /api/system/default-run-path` — 获取默认运行路径。
+pub async fn default_run_path(
+    State(state): State<AppState>,
+) -> Result<Json<std::path::PathBuf>, HttpError> {
+    state
+        .system()
+        .default_run_path()
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -56,9 +56,7 @@ pub async fn directory_usage(
 }
 
 /// `GET /api/system/default-run-path` — 获取默认运行路径。
-pub async fn default_run_path(
-    State(state): State<AppState>,
-) -> Result<Json<String>, HttpError> {
+pub async fn default_run_path(State(state): State<AppState>) -> Result<Json<String>, HttpError> {
     state
         .system()
         .default_run_path()

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -67,7 +67,8 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
     let system_routes = Router::new()
         .route("/system", get(handlers::system_snapshot))
         .route("/system/process/{pid}", get(handlers::process_usage))
-        .route("/system/directory/{*path}", get(handlers::directory_usage));
+        .route("/system/directory/{*path}", get(handlers::directory_usage))
+        .route("/system/default-run-path", get(handlers::default_run_path));
 
     let cron_routes = Router::new()
         .route("/cron-tasks", get(handlers::list_cron_tasks))

--- a/src-tauri/src/adapter/tauri/commands/system.rs
+++ b/src-tauri/src/adapter/tauri/commands/system.rs
@@ -48,7 +48,7 @@ pub async fn get_directory_usage(path: String) -> Result<DirectoryUsage, SystemS
 
 /// 获取默认运行路径。
 #[tauri::command(rename_all = "snake_case")]
-pub async fn get_default_run_path() -> Result<std::path::PathBuf, SystemServiceError> {
+pub async fn get_default_run_path() -> Result<String, SystemServiceError> {
     let service = system_service().await?;
     service.default_run_path().await
 }

--- a/src-tauri/src/adapter/tauri/commands/system.rs
+++ b/src-tauri/src/adapter/tauri/commands/system.rs
@@ -45,3 +45,10 @@ pub async fn get_directory_usage(path: String) -> Result<DirectoryUsage, SystemS
     let service = system_service().await?;
     service.directory_usage(Path::new(&path)).await
 }
+
+/// 获取默认运行路径。
+#[tauri::command(rename_all = "snake_case")]
+pub async fn get_default_run_path() -> Result<std::path::PathBuf, SystemServiceError> {
+    let service = system_service().await?;
+    service.default_run_path().await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,7 +44,7 @@ use adapter::tauri::commands::settings::{
     update_settings, update_settings_partial,
 };
 use adapter::tauri::commands::system::{
-    get_directory_usage, get_process_usage, get_system_snapshot,
+    get_default_run_path, get_directory_usage, get_process_usage, get_system_snapshot,
 };
 use adapter::tauri::commands::update::check_update;
 use adapter::tauri::commands::update_install::{
@@ -96,6 +96,7 @@ pub fn run() {
             //服务器控制台日志契约命令
             get_server_logs,
             //系统资源能力（由adapter/tauri/commands接入application）
+            get_default_run_path,
             get_directory_usage,
             get_process_usage,
             get_system_snapshot,
@@ -237,6 +238,7 @@ mod tests {
         "run_cron_task",
         "set_cron_task_enabled",
         "update_cron_task",
+        "get_default_run_path",
         "get_directory_usage",
         "get_process_usage",
         "get_system_snapshot",


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## 由 Sourcery 提供的概要

引入一个后端功能，用于基于系统目录解析并暴露默认的应用运行路径，并将其贯通接入系统服务、HTTP API 和 Tauri 命令。

新功能：
- 添加平台级的 `get_default_run_path` 帮助函数，从标准数据目录、文档目录或当前工作目录推导 SeaLantern 的运行目录。
- 通过系统服务的 trait 和实现暴露默认运行路径，包括新增的 Tauri 命令和 HTTP 端点 `/api/system/default-run-path`。

增强：
- 扩展平台和系统错误类型，以及 HTTP 错误映射，用于表示解析默认运行路径失败的情况。
- 更新模块的再导出以及路由/命令注册，将新的默认运行路径功能集成到各个层次中。

构建：
- 在 infra crate 中添加 `dirs-next` 依赖，以实现跨平台目录解析。

测试：
- 添加单元测试和异步测试，以验证默认运行路径解析，并确保生成的目录名称为 `SeaLantern`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a backend capability to resolve and expose a default application run path based on system directories, and wire it through the system service, HTTP API, and Tauri commands.

New Features:
- Add a platform-level get_default_run_path helper that derives the SeaLantern run directory from standard data, documents, or current working directory.
- Expose the default run path via the system service trait and implementation, including a new Tauri command and HTTP endpoint /api/system/default-run-path.

Enhancements:
- Extend platform and system error types, along with HTTP error mapping, to represent failures when resolving the default run path.
- Update module re-exports and routing/command registration to integrate the new default run path functionality across layers.

Build:
- Add dirs-next dependency to the infra crate for cross-platform directory resolution.

Tests:
- Add unit and async tests to verify default run path resolution and that the resulting directory name is SeaLantern.

</details>