### PR TITLE
feat(download): 下载接口前后端全链路对接

### DIFF
--- a/server/src/adapter/http/error.rs
+++ b/server/src/adapter/http/error.rs
@@ -10,8 +10,8 @@ use axum::Json;
 use serde::Serialize;
 
 use sealantern_interface::{
-    ConsoleServiceError, CronTaskServiceError, InstanceServiceError, ServerServiceError,
-    SettingsServiceError, SystemServiceError, UpdateCheckServiceError,
+    ConsoleServiceError, CronTaskServiceError, DownloadServiceError, InstanceServiceError,
+    ServerServiceError, SettingsServiceError, SystemServiceError, UpdateCheckServiceError,
 };
 
 /// 展平的 HTTP 错误响应体。
@@ -242,6 +242,32 @@ impl HttpError {
         }
     }
 
+    /// 由下载任务管理契约错误构建 HTTP 错误。
+    pub fn from_download_error(error: DownloadServiceError) -> Self {
+        match error {
+            DownloadServiceError::TaskNotFound => Self {
+                status: StatusCode::NOT_FOUND,
+                code: "download_task_not_found",
+                message: error.to_string(),
+            },
+            DownloadServiceError::InvalidInput => Self {
+                status: StatusCode::BAD_REQUEST,
+                code: "invalid_input",
+                message: error.to_string(),
+            },
+            DownloadServiceError::OperationFailed => Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "download_operation_failed",
+                message: error.to_string(),
+            },
+            DownloadServiceError::Unsupported => Self {
+                status: StatusCode::NOT_IMPLEMENTED,
+                code: "operation_unsupported",
+                message: error.to_string(),
+            },
+        }
+    }
+
     /// 构建一个客户端输入错误（400），带具体错误码。
     pub fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
         Self {
@@ -294,6 +320,12 @@ impl From<SettingsServiceError> for HttpError {
 impl From<SystemServiceError> for HttpError {
     fn from(error: SystemServiceError) -> Self {
         Self::from_system_error(error)
+    }
+}
+
+impl From<DownloadServiceError> for HttpError {
+    fn from(error: DownloadServiceError) -> Self {
+        Self::from_download_error(error)
     }
 }
 

--- a/server/src/adapter/http/handlers/download.rs
+++ b/server/src/adapter/http/handlers/download.rs
@@ -1,0 +1,71 @@
+//! 下载任务管理 REST handler。
+//!
+//! 提供下载任务创建、进度查询与取消接口，薄转发到
+//! [`CoreDownloadService`](sealantern_application::service::CoreDownloadService)
+//! 并收敛错误为 [`HttpError`](super::super::error::HttpError)。
+
+use axum::extract::{Path, State};
+use axum::Json;
+
+use sealantern_interface::download::{DownloadRequest, DownloadTaskInfo};
+use sealantern_interface::DownloadService;
+
+use super::super::error::HttpError;
+use super::super::state::AppState;
+
+/// 创建下载任务请求体（snake_case 与后端契约一致）。
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateDownloadBody {
+    url: String,
+    save_path: String,
+    #[serde(default = "default_thread_count")]
+    thread_count: usize,
+}
+
+fn default_thread_count() -> usize {
+    32
+}
+
+/// `POST /api/downloads` — 创建下载任务，返回任务信息。
+pub async fn create_download(
+    State(state): State<AppState>,
+    Json(body): Json<CreateDownloadBody>,
+) -> Result<Json<DownloadTaskInfo>, HttpError> {
+    let id = state
+        .download()
+        .create(DownloadRequest {
+            url: body.url,
+            save_path: body.save_path,
+            thread_count: body.thread_count,
+        })
+        .await
+        .map_err(HttpError::from)?;
+    state
+        .download()
+        .poll(&id)
+        .await?
+        .ok_or(HttpError::from(sealantern_interface::DownloadServiceError::TaskNotFound))
+        .map(Json)
+}
+
+/// `GET /api/downloads/{id}` — 查询下载任务进度。
+pub async fn query_download(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<DownloadTaskInfo>, HttpError> {
+    state
+        .download()
+        .poll(&id)
+        .await?
+        .ok_or(HttpError::from(sealantern_interface::DownloadServiceError::TaskNotFound))
+        .map(Json)
+}
+
+/// `DELETE /api/downloads/{id}` — 取消下载任务。
+pub async fn cancel_download(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<(), HttpError> {
+    state.download().cancel(&id).await.map_err(HttpError::from)
+}

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod console;
 pub mod cron;
+pub mod download;
 pub mod instance;
 pub mod server;
 pub mod settings;
@@ -15,6 +16,7 @@ pub use cron::{
     create_cron_task, delete_cron_task, list_cron_tasks, run_cron_task, set_cron_task_enabled,
     update_cron_task,
 };
+pub use download::{cancel_download, create_download, query_download};
 pub use instance::{
     create_instance, delete_instance, get_instance, list_instances, rename_instance,
     update_instance_path,

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -80,12 +80,18 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
 
     let update_routes = Router::new().route("/update", get(handlers::check_update));
 
+    let download_routes = Router::new()
+        .route("/downloads", post(handlers::create_download))
+        .route("/downloads/{id}", get(handlers::query_download))
+        .route("/downloads/{id}", axum::routing::delete(handlers::cancel_download));
+
     Router::new()
         .nest(API_PREFIX, instance_routes)
         .nest(API_PREFIX, settings_routes)
         .nest(API_PREFIX, system_routes)
         .nest(API_PREFIX, cron_routes)
         .nest(API_PREFIX, update_routes)
+        .nest(API_PREFIX, download_routes)
         .merge(plugin_rpc_routes)
         .merge(spa_router(config))
         .with_state(state)

--- a/server/src/adapter/http/state.rs
+++ b/server/src/adapter/http/state.rs
@@ -10,8 +10,8 @@
 use std::sync::Arc;
 
 use sealantern_application::service::{
-    CoreConsoleService, CoreCronTaskService, CoreInstanceService, CoreServerService,
-    CoreSettingsService, CoreSystemService, CoreUpdateCheckService,
+    CoreConsoleService, CoreCronTaskService, CoreDownloadService, CoreInstanceService,
+    CoreServerService, CoreSettingsService, CoreSystemService, CoreUpdateCheckService,
 };
 use sealantern_application::services::AppServices;
 
@@ -67,5 +67,10 @@ impl AppState {
     /// 访问应用更新检查服务（`Arc` 共享句柄，clone 廉价）。
     pub fn update(&self) -> Arc<CoreUpdateCheckService> {
         self.services.update().clone()
+    }
+
+    /// 访问下载任务管理服务（`Arc` 共享句柄，clone 廉价）。
+    pub fn download(&self) -> Arc<CoreDownloadService> {
+        self.services.download().clone()
     }
 }

--- a/src/api/downloader.ts
+++ b/src/api/downloader.ts
@@ -6,17 +6,17 @@ export type TaskStatus = "Pending" | "Downloading" | "Completed" | { Error: stri
 
 export interface DownloadTaskInfo {
   id: string;
-  totalSize: number;
+  total_size: number;
   downloaded: number;
   progress: number;
   status: TaskStatus;
-  isFinished: boolean;
+  is_finished: boolean;
 }
 
 export interface DownloadOptions {
   url: string;
-  savePath: string;
-  threadCount?: number;
+  save_path: string;
+  thread_count?: number;
 }
 
 export interface DownloadLink {
@@ -43,12 +43,12 @@ export const downloadApi = {
    * 基础 API：创建下载任务
    */
   async downloadFile(options: DownloadOptions): Promise<string> {
-    // 后端 download_create 接收 request 对象，DTO 用 camelCase 序列化
+    // 后端 download_create 接收 request 结构体参数（snake_case 字段）
     const task = await invoke<DownloadTaskInfo>("download_create", {
       request: {
         url: options.url,
-        savePath: options.savePath,
-        threadCount: options.threadCount || 32,
+        save_path: options.save_path,
+        thread_count: options.thread_count || 32,
       },
     });
     return task.id;
@@ -74,11 +74,11 @@ export const downloadApi = {
   useDownload() {
     const taskInfo = reactive<DownloadTaskInfo>({
       id: "",
-      totalSize: 0,
+      total_size: 0,
       downloaded: 0,
       progress: 0,
       status: "Pending",
-      isFinished: false,
+      is_finished: false,
     });
 
     const errorMessage = computed(() => {
@@ -97,7 +97,7 @@ export const downloadApi = {
       stop();
 
       const session = ++activeSession;
-      taskInfo.isFinished = false;
+      taskInfo.is_finished = false;
       taskInfo.progress = 0;
       taskInfo.status = "Pending";
 
@@ -115,8 +115,8 @@ export const downloadApi = {
             return;
           }
 
-          if (pollingInFlight || taskInfo.id !== id || taskInfo.isFinished) {
-            if (taskInfo.id !== id || taskInfo.isFinished) {
+          if (pollingInFlight || taskInfo.id !== id || taskInfo.is_finished) {
+            if (taskInfo.id !== id || taskInfo.is_finished) {
               clearInterval(intervalId);
               if (timer === intervalId) timer = null;
             }
@@ -131,13 +131,13 @@ export const downloadApi = {
             }
 
             Object.assign(taskInfo, data);
-            if (data.isFinished) {
+            if (data.is_finished) {
               taskInfo.progress = 100;
               clearInterval(intervalId);
               if (timer === intervalId) timer = null;
             }
           } catch (err) {
-            if (session === activeSession && taskInfo.id === id && !taskInfo.isFinished) {
+            if (session === activeSession && taskInfo.id === id && !taskInfo.is_finished) {
               taskInfo.status = { Error: i18n.t("downloader.connection_lost") };
             }
             clearInterval(intervalId);
@@ -149,7 +149,7 @@ export const downloadApi = {
         timer = intervalId;
       } catch (err: any) {
         taskInfo.status = { Error: err.toString() };
-        taskInfo.isFinished = true;
+        taskInfo.is_finished = true;
       }
     };
 
@@ -164,11 +164,11 @@ export const downloadApi = {
     const reset = () => {
       stop();
       taskInfo.id = "";
-      taskInfo.totalSize = 0;
+      taskInfo.total_size = 0;
       taskInfo.downloaded = 0;
       taskInfo.progress = 0;
       taskInfo.status = "Pending";
-      taskInfo.isFinished = false;
+      taskInfo.is_finished = false;
     };
 
     onUnmounted(stop);

--- a/src/api/invoke.ts
+++ b/src/api/invoke.ts
@@ -101,6 +101,20 @@ const axumRouteMap: Record<string, AxumRoute> = {
   },
   settings_overview: { method: "GET", path: () => "/settings" },
   check_update: { method: "GET", path: () => "/update" },
+  download_create: {
+    method: "POST",
+    path: () => "/downloads",
+    // 前端按 Tauri 命令形状传 { request: {...} }，HTTP 侧解包 request 作为请求体
+    body: (a) => a.request,
+  },
+  download_query: {
+    method: "GET",
+    path: (a) => `/downloads/${encodeURIComponent(String(a.id))}`,
+  },
+  download_cancel: {
+    method: "DELETE",
+    path: (a) => `/downloads/${encodeURIComponent(String(a.id))}`,
+  },
 };
 
 /** Tauri 原生 invoke，动态导入避免浏览器环境加载失败 */

--- a/src/components/layout/TaskPill.vue
+++ b/src/components/layout/TaskPill.vue
@@ -131,7 +131,7 @@ const speedText = computed(() => (store.speed > 0 ? `${formatBytes(store.speed)}
 const sizeText = computed(() => {
   const t = store.currentTask;
   if (!t) return "--";
-  return `${formatBytes(t.downloaded)} / ${formatBytes(t.totalSize)}`;
+  return `${formatBytes(t.downloaded)} / ${formatBytes(t.total_size)}`;
 });
 
 /** 点一下开/关面板，完成了就标记已查看，把自动消失计时撅掉 */

--- a/src/components/views/create/useCreateServerPage.ts
+++ b/src/components/views/create/useCreateServerPage.ts
@@ -675,14 +675,14 @@ export function useCreateServerPage() {
           const { taskInfo: dlTask, start: dlStart } = downloadApi.useDownload();
           await dlStart({
             url: info.url,
-            savePath: tempDownloadPath,
-            threadCount: 32,
+            save_path: tempDownloadPath,
+            thread_count: 32,
           });
 
           // 等待下载完成
           await new Promise<void>((resolve, reject) => {
             const checkInterval = setInterval(() => {
-              if (dlTask.isFinished) {
+              if (dlTask.is_finished) {
                 clearInterval(checkInterval);
                 if (dlTask.status === "Completed") {
                   resolve();

--- a/src/components/views/create/useCreateServerPage.ts
+++ b/src/components/views/create/useCreateServerPage.ts
@@ -14,11 +14,12 @@ import { javaApi } from "@api/java";
 import { serverApi } from "@api/server";
 import { settingsApi } from "@api/settings";
 import { systemApi } from "@api/system";
-import { downloadServerApi, downloadApi } from "@api/downloader";
+import { downloadServerApi } from "@api/downloader";
 import { useToast } from "cmzya-modern-ui";
 import { useLoading } from "@composables/useAsync";
 import { i18n } from "@language";
 import { useServerStore } from "@stores/serverStore";
+import { useDownloadStore } from "@stores/downloadStore";
 import { useCreateServerDraftStore } from "@stores/createServerDraft.ts";
 import { isBrowserEnv } from "@api/tauri";
 
@@ -67,6 +68,7 @@ function logCreateServerDnd(message: string, payload?: unknown) {
 export function useCreateServerPage() {
   const router = useRouter();
   const serverstore = useServerStore();
+  const downloadStore = useDownloadStore();
   const toast = useToast();
   const { loading: javaLoading, start: startJavaLoading, stop: stopJavaLoading } = useLoading();
   const { loading: creating, start: startCreating, stop: stopCreating } = useLoading();
@@ -671,29 +673,29 @@ export function useCreateServerPage() {
           const fileName = info.fileName || "server.jar";
           tempDownloadPath = `${tempDir}/${fileName}`;
 
-          // 使用 downloadApi 下载
-          const { taskInfo: dlTask, start: dlStart } = downloadApi.useDownload();
-          await dlStart({
-            url: info.url,
-            save_path: tempDownloadPath,
-            thread_count: 32,
-          });
+          // 走全局下载 store，顶栏任务球才能显示下载进度
+          await downloadStore.startTask(
+            {
+              url: info.url,
+              save_path: tempDownloadPath,
+              thread_count: 32,
+            },
+            { filename: fileName, savePath: tempDownloadPath, origin: "server" },
+          );
 
           // 等待下载完成
           await new Promise<void>((resolve, reject) => {
             const checkInterval = setInterval(() => {
-              if (dlTask.is_finished) {
+              if (downloadStore.isFinished) {
                 clearInterval(checkInterval);
-                if (dlTask.status === "Completed") {
-                  resolve();
-                } else {
+                if (downloadStore.isError) {
                   reject(
                     new Error(
-                      typeof dlTask.status === "object" && "Error" in dlTask.status
-                        ? dlTask.status.Error
-                        : i18n.t("downloadServerView.status.failed"),
+                      downloadStore.taskError || i18n.t("downloadServerView.status.failed"),
                     ),
                   );
+                } else {
+                  resolve();
                 }
               }
             }, 300);

--- a/src/components/views/download/DownloadProgress.vue
+++ b/src/components/views/download/DownloadProgress.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
-import { i18n } from "@language";
 import { formatBytes } from "@utils/serverUtils";
 
 const props = defineProps<{
   taskInfo: {
     progress: number;
     downloaded: number;
-    totalSize: number;
-    isFinished: boolean;
+    total_size: number;
+    is_finished: boolean;
   };
   taskError: string | null;
   statusLabel: string;
@@ -18,12 +17,12 @@ const props = defineProps<{
   <div class="progress-wrapper">
     <cmz-progress
       :value="taskInfo.progress"
-      :color="taskError ? '#ef4444' : taskInfo.isFinished ? '#22c55e' : undefined"
+      :color="taskError ? '#ef4444' : taskInfo.is_finished ? '#22c55e' : undefined"
       :label="statusLabel"
     />
     <div class="progress-footer">
       <span class="size-text"
-        >{{ formatBytes(taskInfo.downloaded) }} / {{ formatBytes(taskInfo.totalSize) }}</span
+        >{{ formatBytes(taskInfo.downloaded) }} / {{ formatBytes(taskInfo.total_size) }}</span
       >
       <span class="percent-text">{{ taskInfo.progress.toFixed(1) }}%</span>
     </div>

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -52,11 +52,11 @@ export const useDownloadStore = defineStore("download", () => {
   // ========== Getters ==========
   /** 正在下载中，有任务 ID 且没完成 */
   const isDownloading = computed(
-    () => !!currentTask.value && currentTask.value.id !== "" && !currentTask.value.isFinished,
+    () => !!currentTask.value && currentTask.value.id !== "" && !currentTask.value.is_finished,
   );
 
   /** 任务结束了没，完成或出错都算 */
-  const isFinished = computed(() => !!currentTask.value?.isFinished);
+  const isFinished = computed(() => !!currentTask.value?.is_finished);
 
   /** 错误信息字符串，没错误返回 null */
   const taskError = computed(() => {
@@ -168,11 +168,11 @@ export const useDownloadStore = defineStore("download", () => {
     // 重置为新任务状态
     currentTask.value = {
       id: "",
-      totalSize: 0,
+      total_size: 0,
       downloaded: 0,
       progress: 0,
       status: "Pending",
-      isFinished: false,
+      is_finished: false,
     };
     taskOriginTab.value = meta.origin;
     filename.value = meta.filename;
@@ -197,8 +197,8 @@ export const useDownloadStore = defineStore("download", () => {
           return;
         }
         const task = currentTask.value;
-        if (!task || pollingInFlight || task.id !== id || task.isFinished) {
-          if (!task || task.id !== id || task.isFinished) stopPolling();
+        if (!task || pollingInFlight || task.id !== id || task.is_finished) {
+          if (!task || task.id !== id || task.is_finished) stopPolling();
           return;
         }
 
@@ -219,7 +219,7 @@ export const useDownloadStore = defineStore("download", () => {
           lastTimestamp = now;
 
           Object.assign(currentTask.value, data);
-          if (data.isFinished) {
+          if (data.is_finished) {
             currentTask.value.progress = 100;
             speed.value = 0;
             stopPolling();
@@ -230,10 +230,10 @@ export const useDownloadStore = defineStore("download", () => {
             session === activeSession &&
             currentTask.value &&
             currentTask.value.id === id &&
-            !currentTask.value.isFinished
+            !currentTask.value.is_finished
           ) {
             currentTask.value.status = { Error: i18n.t("downloader.connection_lost") };
-            currentTask.value.isFinished = true;
+            currentTask.value.is_finished = true;
             speed.value = 0;
             startAutoDismissTimer();
           }
@@ -245,7 +245,7 @@ export const useDownloadStore = defineStore("download", () => {
     } catch (err: any) {
       if (currentTask.value) {
         currentTask.value.status = { Error: err.toString() };
-        currentTask.value.isFinished = true;
+        currentTask.value.is_finished = true;
         startAutoDismissTimer();
       }
     }

--- a/src/views/DownloadView.vue
+++ b/src/views/DownloadView.vue
@@ -309,7 +309,7 @@ async function handleFileDownload() {
 
   try {
     await downloadStore.startTask(
-      { url: url.value, savePath: fullSavePath, threadCount: threadCountInt },
+      { url: url.value, save_path: fullSavePath, thread_count: threadCountInt },
       { filename: filename.value, savePath: fullSavePath, origin: "file" },
     );
 
@@ -333,8 +333,8 @@ async function handleServerDownload() {
     await downloadStore.startTask(
       {
         url: info.value.url,
-        savePath: targetPath,
-        threadCount: parseInt(serverThreadCount.value, 10),
+        save_path: targetPath,
+        thread_count: parseInt(serverThreadCount.value, 10),
       },
       { filename: serverFilename.value, savePath: targetPath, origin: "server" },
     );


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- 前端下载契约统一 snake_case，轮询状态判定恢复正常
- 新增 axum 下载 REST 接口：创建/查询/取消下载任务
- 前端 invoke 路由映射补齐下载命令，浏览器环境可用
- 错误映射补充下载契约分类

## Summary by Sourcery

在前端和后端之间集成端到端的下载任务管理，暴露 REST API 并统一客户端契约。

新特性：
- 添加用于创建、查询和取消下载任务的 REST 端点，这些任务由核心下载服务提供支持。
- 通过与现有 invoke 命令对应的 axum 路由映射，实现基于 HTTP 的下载操作。

缺陷修复：
- 修复下载轮询逻辑，使任务在完成或发生变更时能够正确停止，防止产生过期的轮询间隔和错误的状态更新。

增强优化：
- 将前端下载数据契约统一为 snake_case，以匹配后端接口，包括任务信息和选项字段。
- 扩展 HTTP 错误处理范围，以覆盖下载服务错误，并返回合适的状态码和错误标识符。
- 连接应用状态以向 HTTP 处理器暴露核心下载服务，并将下载进度集成到现有的 UI 组件和状态存储中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate end-to-end download task management between frontend and backend, exposing REST APIs and aligning client contracts.

New Features:
- Add REST endpoints for creating, querying, and cancelling download tasks backed by the core download service.
- Enable HTTP-based download operations via axum route mappings corresponding to existing invoke commands.

Bug Fixes:
- Fix download polling logic so tasks stop correctly when finished or changed, preventing stale intervals and erroneous status updates.

Enhancements:
- Standardize frontend download data contracts to snake_case to match backend interfaces, including task info and options fields.
- Extend HTTP error handling to cover download service errors with appropriate status codes and error identifiers.
- Wire the application state to expose the core download service for HTTP handlers and integrate download progress into existing UI components and store.

</details>