### PR TITLE
feat(system): 新增按实例查询服务器资源占用接口

### DIFF
--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -1,4 +1,4 @@
-﻿//! 系统资源信息服务实现。
+//! 系统资源信息服务实现。
 //!
 //! 实现 [`sealantern_interface::SystemService`] 能力端口，组合 `infra` 的
 //! 平台系统采集能力（CPU / 内存 / 磁盘 / 网络 / 进程 / 目录占用），
@@ -40,10 +40,7 @@ impl CoreSystemService {
         instance_service: Arc<CoreInstanceService>,
         server_service: Arc<CoreServerService>,
     ) -> Self {
-        Self {
-            instance_service,
-            server_service,
-        }
+        Self { instance_service, server_service }
     }
     /// 采集整机资源快照，返回应用层主错误。
     ///

--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -1,4 +1,4 @@
-//! 系统资源信息服务实现。
+﻿//! 系统资源信息服务实现。
 //!
 //! 实现 [`sealantern_interface::SystemService`] 能力端口，组合 `infra` 的
 //! 平台系统采集能力（CPU / 内存 / 磁盘 / 网络 / 进程 / 目录占用），
@@ -7,31 +7,44 @@
 //! 错误分层：内部以应用层主错误 [`SystemError`] 为源头，暴露
 //! [`SystemService`] 时统一转为接口契约错误 [`SystemServiceError`]。
 
-use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use sealantern_infra::platform::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
-    collect_system_info, cpu_brand_name, directory_size, get_default_run_path, path_disk_capacity,
-    process_count,
+    collect_system_info, cpu_brand_name, get_default_run_path, process_count,
 };
+use sealantern_interface::server::ServerState;
 use sealantern_interface::system::{
-    CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
-    SystemSnapshot,
+    CpuInfo, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
+    ServerResourceUsage, SystemSnapshot,
 };
-use sealantern_interface::{SystemService, SystemServiceError};
+use sealantern_interface::{InstanceService, ServerService, SystemService, SystemServiceError};
 
 use crate::error::SystemError;
+use crate::service::{CoreInstanceService, CoreServerService};
 
 /// CPU 采样间隔：`sysinfo` 的 CPU 使用率是增量值，需间隔两次采样取后一次。
 const CPU_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
 
 /// 基于 `infra` 平台采集能力的系统资源信息服务实现。
-#[derive(Debug, Default)]
-pub struct CoreSystemService;
+pub struct CoreSystemService {
+    instance_service: Arc<CoreInstanceService>,
+    server_service: Arc<CoreServerService>,
+}
 
 impl CoreSystemService {
+    /// 构造系统资源信息服务。
+    pub fn new(
+        instance_service: Arc<CoreInstanceService>,
+        server_service: Arc<CoreServerService>,
+    ) -> Self {
+        Self {
+            instance_service,
+            server_service,
+        }
+    }
     /// 采集整机资源快照，返回应用层主错误。
     ///
     /// 同步的 sysinfo 采集经 `spawn_blocking` 调度到阻塞线程池，CPU 采样
@@ -164,34 +177,6 @@ impl CoreSystemService {
         })
     }
 
-    /// 计算目录磁盘占用，返回应用层主错误。
-    ///
-    /// 目录遍历与容量查询是同步且可能耗时的操作，经 `spawn_blocking` 调度到
-    /// 阻塞线程池，避免阻塞异步运行时的核心线程。
-    async fn directory_usage_inner(path: &Path) -> Result<DirectoryUsage, SystemError> {
-        let path_owned = path.to_path_buf();
-        let (path, used, total, available) =
-            tokio::task::spawn_blocking(move || -> Result<_, SystemError> {
-                if !path_owned.exists() {
-                    return Err(SystemError::PathNotFound);
-                }
-
-                let used = directory_size(&path_owned);
-                let (total, available) = path_disk_capacity(&path_owned);
-                Ok((path_owned, used, total, available))
-            })
-            .await??;
-
-        let total_effective = if total > 0 { total } else { used.max(1) };
-        Ok(DirectoryUsage {
-            path,
-            used,
-            total: total_effective,
-            available,
-            usage: percent(used, total_effective),
-        })
-    }
-
     /// 解析默认运行路径，返回应用层主错误。
     async fn default_run_path_inner() -> Result<String, SystemError> {
         get_default_run_path()
@@ -211,16 +196,73 @@ impl SystemService for CoreSystemService {
         Self::snapshot_inner().await.map_err(Into::into)
     }
 
-    async fn process_usage(&self, pid: u32) -> Result<ProcessResourceUsage, SystemServiceError> {
-        Self::process_usage_inner(pid).await.map_err(Into::into)
-    }
-
-    async fn directory_usage(&self, path: &Path) -> Result<DirectoryUsage, SystemServiceError> {
-        Self::directory_usage_inner(path).await.map_err(Into::into)
-    }
-
     async fn default_run_path(&self) -> Result<String, SystemServiceError> {
         Self::default_run_path_inner().await.map_err(Into::into)
+    }
+
+    async fn server_resource_usage(
+        &self,
+        instance_id: &str,
+    ) -> Result<ServerResourceUsage, SystemServiceError> {
+        let instance_id = sealantern_core::instance::InstanceId::new(instance_id)
+            .map_err(|_| SystemServiceError::PathNotFound)?;
+
+        let instance = self
+            .instance_service
+            .find(&instance_id)
+            .await
+            .map_err(|_| SystemServiceError::OperationFailed)?
+            .ok_or(SystemServiceError::PathNotFound)?;
+
+        let snapshot = self
+            .server_service
+            .status(&instance_id)
+            .await
+            .map_err(|_| SystemServiceError::OperationFailed)?;
+
+        let status = state_to_string(snapshot.state);
+
+        // 未运行或无进程时返回空资源，不报错。
+        let usage = match snapshot.pid {
+            Some(pid) => Self::process_usage_inner(pid).await?,
+            None => ProcessResourceUsage {
+                pid: None,
+                cpu_usage: 0.0,
+                memory_used: 0,
+                memory_total: 0,
+                memory_usage: 0.0,
+            },
+        };
+        let full = Self::snapshot_inner().await?;
+
+        Ok(ServerResourceUsage {
+            server_id: instance.id.as_str().to_string(),
+            server_name: instance.name,
+            status,
+            pid: snapshot.pid,
+            cpu: CpuInfo {
+                name: full.cpu.name,
+                count: full.cpu.count,
+                usage: usage.cpu_usage.clamp(0.0, 100.0),
+            },
+            memory: MemoryInfo {
+                total: usage.memory_total,
+                used: usage.memory_used,
+                available: usage.memory_total.saturating_sub(usage.memory_used),
+                usage: usage.memory_usage.clamp(0.0, 100.0),
+            },
+            disk: full.disk,
+        })
+    }
+}
+
+/// 将服务器运行状态转为小写字符串（对齐前端 `status` 字段）。
+fn state_to_string(state: ServerState) -> String {
+    match state {
+        ServerState::Starting => "starting".to_string(),
+        ServerState::Running => "running".to_string(),
+        ServerState::Stopping => "stopping".to_string(),
+        ServerState::Stopped => "stopped".to_string(),
     }
 }
 
@@ -235,11 +277,30 @@ fn percent(used: u64, total: u64) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tempfile::tempdir;
+
     use super::*;
+
+    /// 构造测试用系统服务（临时实例目录 + 独立 server 服务）。
+    async fn test_service() -> CoreSystemService {
+        let dir = tempdir().expect("create temp dir");
+        let instance = Arc::new(
+            CoreInstanceService::with_path(dir.path().join("instances.json"))
+                .await
+                .expect("create instance service"),
+        );
+        let server = Arc::new(CoreServerService::new(
+            instance.clone(),
+            Arc::new(crate::service::CoreSettingsService::new()),
+        ));
+        CoreSystemService::new(instance, server)
+    }
 
     #[tokio::test]
     async fn snapshot_reports_realistic_values() {
-        let service = CoreSystemService;
+        let service = test_service().await;
         let snapshot = service.system_snapshot().await.expect("snapshot");
 
         assert!(!snapshot.os.is_empty());
@@ -250,38 +311,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_process_usage_is_reported() {
-        let service = CoreSystemService;
-        let usage = service
-            .process_usage(std::process::id())
-            .await
-            .expect("process usage");
-
-        assert!(usage.pid.is_some());
-        assert!(usage.cpu_usage >= 0.0 && usage.cpu_usage <= 100.0);
-    }
-
-    #[tokio::test]
-    async fn missing_process_returns_none_pid() {
-        let service = CoreSystemService;
-        let usage = service.process_usage(u32::MAX).await.expect("usage");
-
-        assert_eq!(usage.pid, None);
-    }
-
-    #[tokio::test]
-    async fn missing_directory_reports_path_not_found() {
-        let service = CoreSystemService;
-        let result = service
-            .directory_usage(Path::new("/nonexistent/sl-path"))
-            .await;
-
-        assert_eq!(result, Err(SystemServiceError::PathNotFound));
-    }
-
-    #[tokio::test]
     async fn default_run_path_resolves_to_sea_lantern_dir() {
-        let service = CoreSystemService;
+        let service = test_service().await;
         let path = service.default_run_path().await.expect("default run path");
 
         let name = std::path::Path::new(&path)

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -87,6 +87,10 @@ impl AppServices {
                 download: Arc::new(CoreDownloadService::new()),
                 console: Arc::new(CoreConsoleService::new(instance.clone())),
                 cron: Arc::new(CoreCronTaskService::new(server.clone())),
+                system: Arc::new(CoreSystemService::new(
+                    instance.clone(),
+                    server.clone(),
+                )),
                 server,
                 instance,
                 java: Arc::new(CoreJavaService),
@@ -95,7 +99,6 @@ impl AppServices {
                 provisioning: Arc::new(CoreProvisioningService),
                 settings,
                 proxy_monitoring: Arc::new(ProxyMonitoringService::new()),
-                system: Arc::new(CoreSystemService),
                 update: Arc::new(CoreUpdateCheckService::new()),
                 update_install: Arc::new(CoreUpdateInstallService),
                 plugin: tokio::sync::OnceCell::new(),

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -87,10 +87,7 @@ impl AppServices {
                 download: Arc::new(CoreDownloadService::new()),
                 console: Arc::new(CoreConsoleService::new(instance.clone())),
                 cron: Arc::new(CoreCronTaskService::new(server.clone())),
-                system: Arc::new(CoreSystemService::new(
-                    instance.clone(),
-                    server.clone(),
-                )),
+                system: Arc::new(CoreSystemService::new(instance.clone(), server.clone())),
                 server,
                 instance,
                 java: Arc::new(CoreJavaService),

--- a/crates/interface/src/system/mod.rs
+++ b/crates/interface/src/system/mod.rs
@@ -8,6 +8,6 @@ mod service;
 
 pub use models::{
     CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
-    SystemSnapshot,
+    ServerResourceUsage, SystemSnapshot,
 };
 pub use service::SystemService;

--- a/crates/interface/src/system/models.rs
+++ b/crates/interface/src/system/models.rs
@@ -136,3 +136,23 @@ pub struct DirectoryUsage {
     /// 使用率（0.0 - 100.0）。
     pub usage: f32,
 }
+
+/// 单服务器资源占用（宿主消费的契约模型，按实例标识查询）。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ServerResourceUsage {
+    /// 实例标识。
+    pub server_id: String,
+    /// 实例名称。
+    pub server_name: String,
+    /// 运行状态（`ServerState` 的小写字符串，如 `running` / `stopped`）。
+    pub status: String,
+    /// 进程 ID；未运行时为 `None`。
+    pub pid: Option<u32>,
+    /// CPU 资源。
+    pub cpu: CpuInfo,
+    /// 内存资源。
+    pub memory: MemoryInfo,
+    /// 磁盘汇总（总量/已用/可用为全部分区求和）。
+    pub disk: DiskSummary,
+}

--- a/crates/interface/src/system/service.rs
+++ b/crates/interface/src/system/service.rs
@@ -1,12 +1,10 @@
 //! 系统资源信息服务端口。
 
-use std::path::Path;
-
 use async_trait::async_trait;
 
 use crate::error::SystemServiceError;
 
-use super::models::{DirectoryUsage, ProcessResourceUsage, SystemSnapshot};
+use super::models::{ServerResourceUsage, SystemSnapshot};
 
 /// 系统资源信息宿主能力端口。
 ///
@@ -19,16 +17,16 @@ pub trait SystemService: Send + Sync {
     /// CPU 使用率为采样时刻瞬时值，调用方如需平滑值应自行间隔采样。
     async fn system_snapshot(&self) -> Result<SystemSnapshot, SystemServiceError>;
 
-    /// 采集指定进程的资源使用。
-    ///
-    /// 进程不存在或无权访问时返回 `pid = None` 的空结果。
-    async fn process_usage(&self, pid: u32) -> Result<ProcessResourceUsage, SystemServiceError>;
-
-    /// 计算目录磁盘占用。
-    async fn directory_usage(&self, path: &Path) -> Result<DirectoryUsage, SystemServiceError>;
-
     /// 获取默认运行路径。
     ///
     /// 路径优先级：标准数据目录 → 文档目录 → 当前工作目录。
     async fn default_run_path(&self) -> Result<String, SystemServiceError>;
+
+    /// 按实例标识采集服务器资源占用。
+    ///
+    /// 未运行或进程不存在时返回 `pid = None` 的空资源结果。
+    async fn server_resource_usage(
+        &self,
+        instance_id: &str,
+    ) -> Result<ServerResourceUsage, SystemServiceError>;
 }

--- a/server/src/adapter/http/handlers/mod.rs
+++ b/server/src/adapter/http/handlers/mod.rs
@@ -26,5 +26,5 @@ pub use server::{
     stop_server,
 };
 pub use settings::settings_overview;
-pub use system::{default_run_path, directory_usage, process_usage, system_snapshot};
+pub use system::{default_run_path, server_resource_usage, system_snapshot};
 pub use update::check_update;

--- a/server/src/adapter/http/handlers/system.rs
+++ b/server/src/adapter/http/handlers/system.rs
@@ -1,13 +1,13 @@
 //! 系统资源信息 REST handler。
 //!
-//! 提供系统资源快照、进程资源与目录磁盘占用接口，薄转发到
+//! 提供系统资源快照、默认运行路径与服务器资源占用接口，薄转发到
 //! [`CoreSystemService`](sealantern_application::service::CoreSystemService)
 //! 并收敛错误为 [`HttpError`](super::super::error::HttpError)。
 
 use axum::extract::{Path, State};
 use axum::Json;
 
-use sealantern_interface::system::{DirectoryUsage, ProcessResourceUsage, SystemSnapshot};
+use sealantern_interface::system::{ServerResourceUsage, SystemSnapshot};
 use sealantern_interface::SystemService;
 
 use super::super::error::HttpError;
@@ -25,41 +25,24 @@ pub async fn system_snapshot(
         .map_err(HttpError::from)
 }
 
-/// `GET /api/system/process/{pid}` — 采集指定进程的资源使用。
-pub async fn process_usage(
-    State(state): State<AppState>,
-    Path(pid): Path<u32>,
-) -> Result<Json<ProcessResourceUsage>, HttpError> {
-    state
-        .system()
-        .process_usage(pid)
-        .await
-        .map(Json)
-        .map_err(HttpError::from)
-}
-
-/// `GET /api/system/directory/*path` — 计算指定目录的磁盘占用。
-///
-/// 路径使用通配符捕获，支持任意多段路径
-/// （如 `/api/system/directory/var/log`、`/api/system/directory/C:%5Cservers%5Cserver-a`）。
-pub async fn directory_usage(
-    State(state): State<AppState>,
-    Path(path): Path<String>,
-) -> Result<Json<DirectoryUsage>, HttpError> {
-    let path = std::path::Path::new(&path);
-    state
-        .system()
-        .directory_usage(path)
-        .await
-        .map(Json)
-        .map_err(HttpError::from)
-}
-
 /// `GET /api/system/default-run-path` — 获取默认运行路径。
 pub async fn default_run_path(State(state): State<AppState>) -> Result<Json<String>, HttpError> {
     state
         .system()
         .default_run_path()
+        .await
+        .map(Json)
+        .map_err(HttpError::from)
+}
+
+/// `GET /api/system/servers/{instance_id}/usage` — 按实例标识采集服务器资源占用。
+pub async fn server_resource_usage(
+    State(state): State<AppState>,
+    Path(instance_id): Path<String>,
+) -> Result<Json<ServerResourceUsage>, HttpError> {
+    state
+        .system()
+        .server_resource_usage(&instance_id)
         .await
         .map(Json)
         .map_err(HttpError::from)

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -66,9 +66,11 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
 
     let system_routes = Router::new()
         .route("/system", get(handlers::system_snapshot))
-        .route("/system/process/{pid}", get(handlers::process_usage))
-        .route("/system/directory/{*path}", get(handlers::directory_usage))
-        .route("/system/default-run-path", get(handlers::default_run_path));
+        .route("/system/default-run-path", get(handlers::default_run_path))
+        .route(
+            "/system/servers/{instance_id}/usage",
+            get(handlers::server_resource_usage),
+        );
 
     let cron_routes = Router::new()
         .route("/cron-tasks", get(handlers::list_cron_tasks))

--- a/server/src/adapter/http/router.rs
+++ b/server/src/adapter/http/router.rs
@@ -67,10 +67,7 @@ pub fn build_router(services: AppServices, config: ViteConfig) -> Router {
     let system_routes = Router::new()
         .route("/system", get(handlers::system_snapshot))
         .route("/system/default-run-path", get(handlers::default_run_path))
-        .route(
-            "/system/servers/{instance_id}/usage",
-            get(handlers::server_resource_usage),
-        );
+        .route("/system/servers/{instance_id}/usage", get(handlers::server_resource_usage));
 
     let cron_routes = Router::new()
         .route("/cron-tasks", get(handlers::list_cron_tasks))

--- a/src-tauri/src/adapter/tauri/commands/system.rs
+++ b/src-tauri/src/adapter/tauri/commands/system.rs
@@ -7,12 +7,11 @@
 //! 错误统一为接口契约错误 [`SystemServiceError`]，可序列化回前端，
 //! 不携带底层敏感细节。
 
-use std::path::Path;
 use std::sync::Arc;
 
 use sealantern_application::service::CoreSystemService;
 use sealantern_application::services::AppServices;
-use sealantern_interface::system::{DirectoryUsage, ProcessResourceUsage, SystemSnapshot};
+use sealantern_interface::system::{ServerResourceUsage, SystemSnapshot};
 use sealantern_interface::{SystemService, SystemServiceError};
 
 /// 获取全局系统资源信息服务句柄（惰性初始化容器）。
@@ -30,25 +29,18 @@ pub async fn get_system_snapshot() -> Result<SystemSnapshot, SystemServiceError>
     service.system_snapshot().await
 }
 
-/// 采集指定进程的资源使用。
-///
-/// 进程不存在或无权访问时返回 `pid = null` 的空结果。
-#[tauri::command(rename_all = "snake_case")]
-pub async fn get_process_usage(pid: u32) -> Result<ProcessResourceUsage, SystemServiceError> {
-    let service = system_service().await?;
-    service.process_usage(pid).await
-}
-
-/// 计算指定目录的磁盘占用。
-#[tauri::command(rename_all = "snake_case")]
-pub async fn get_directory_usage(path: String) -> Result<DirectoryUsage, SystemServiceError> {
-    let service = system_service().await?;
-    service.directory_usage(Path::new(&path)).await
-}
-
 /// 获取默认运行路径。
 #[tauri::command(rename_all = "snake_case")]
 pub async fn get_default_run_path() -> Result<String, SystemServiceError> {
     let service = system_service().await?;
     service.default_run_path().await
+}
+
+/// 按实例标识采集服务器资源占用。
+#[tauri::command(rename_all = "snake_case")]
+pub async fn get_server_resource_usage(
+    instance_id: String,
+) -> Result<ServerResourceUsage, SystemServiceError> {
+    let service = system_service().await?;
+    service.server_resource_usage(&instance_id).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,7 +44,7 @@ use adapter::tauri::commands::settings::{
     update_settings, update_settings_partial,
 };
 use adapter::tauri::commands::system::{
-    get_default_run_path, get_directory_usage, get_process_usage, get_system_snapshot,
+    get_default_run_path, get_server_resource_usage, get_system_snapshot,
 };
 use adapter::tauri::commands::update::check_update;
 use adapter::tauri::commands::update_install::{
@@ -97,8 +97,7 @@ pub fn run() {
             get_server_logs,
             //系统资源能力（由adapter/tauri/commands接入application）
             get_default_run_path,
-            get_directory_usage,
-            get_process_usage,
+            get_server_resource_usage,
             get_system_snapshot,
             //日志分享能力（上传到 mclo.gs）
             share_logs,
@@ -239,8 +238,7 @@ mod tests {
         "set_cron_task_enabled",
         "update_cron_task",
         "get_default_run_path",
-        "get_directory_usage",
-        "get_process_usage",
+        "get_server_resource_usage",
         "get_system_snapshot",
         "create_instance",
         "delete_instance",

--- a/src/api/invoke.ts
+++ b/src/api/invoke.ts
@@ -71,13 +71,10 @@ const axumRouteMap: Record<string, AxumRoute> = {
     body: (a) => ({ command: a.command }),
   },
   get_system_snapshot: { method: "GET", path: () => "/system" },
-  get_process_usage: {
+  get_default_run_path: { method: "GET", path: () => "/system/default-run-path" },
+  get_server_resource_usage: {
     method: "GET",
-    path: (a) => `/system/process/${encodeURIComponent(String(a.pid))}`,
-  },
-  get_directory_usage: {
-    method: "GET",
-    path: (a) => `/system/directory/${encodeURIComponent(String(a.path))}`,
+    path: (a) => `/system/servers/${encodeURIComponent(String(a.instanceId))}/usage`,
   },
   list_cron_tasks: { method: "GET", path: () => "/cron-tasks" },
   create_cron_task: { method: "POST", path: () => "/cron-tasks", body: (a) => a.draft },

--- a/src/api/invoke.ts
+++ b/src/api/invoke.ts
@@ -74,7 +74,8 @@ const axumRouteMap: Record<string, AxumRoute> = {
   get_default_run_path: { method: "GET", path: () => "/system/default-run-path" },
   get_server_resource_usage: {
     method: "GET",
-    path: (a) => `/system/servers/${encodeURIComponent(String(a.instanceId))}/usage`,
+    // 参数名与 Tauri 命令契约保持一致（instance_id）
+    path: (a) => `/system/servers/${encodeURIComponent(String(a.instance_id))}/usage`,
   },
   list_cron_tasks: { method: "GET", path: () => "/cron-tasks" },
   create_cron_task: { method: "POST", path: () => "/cron-tasks", body: (a) => a.draft },

--- a/src/api/rpc.ts
+++ b/src/api/rpc.ts
@@ -65,8 +65,6 @@ const tauriCommandMap: Record<string, string> = {
   "server.console.send": "send_server_command",
   // 系统资源
   "system.snapshot": "get_system_snapshot",
-  "system.processUsage": "get_process_usage",
-  "system.directoryUsage": "get_directory_usage",
   // 定时任务
   "cron.list": "list_cron_tasks",
   "cron.create": "create_cron_task",

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -198,7 +198,8 @@ export const systemApi = {
   },
 
   async getServerResourceUsage(serverId: string): Promise<ServerResourceUsage> {
-    return tauriInvoke("get_server_resource_usage", { serverId });
+    // 后端命令参数为 instance_id，走统一 invoke 入口，Tauri 与 Axum 模式契约一致
+    return invoke<ServerResourceUsage>("get_server_resource_usage", { instance_id: serverId });
   },
 
   async pickJarFile(): Promise<string | null> {


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- 系统服务支持按实例标识查询资源占用，前端无需再持有进程 PID
- 移除 process_usage / directory_usage 对外接口，收敛为按实例的单一入口
- tauri 与 axum 全链路接入，前端路由映射同步

## Summary by Sourcery

向系统服务中添加基于实例的服务器资源使用查询，并移除基于 PID 和目录的资源端点。

New Features:
- 暴露统一的 `ServerResourceUsage` 模型，用于按服务器实例报告 CPU、内存和磁盘使用情况，以及状态和 PID。
- 引入 `SystemService` API，以实例 ID 查询服务器资源使用情况，并通过应用层、HTTP（axum）处理器、Tauri 命令以及前端路由映射进行贯通。

Enhancements:
- 重构 `CoreSystemService` 以依赖实例服务和服务器服务，使其能够按实例进行状态感知的资源聚合。
- 通过移除 `process_usage` 和 `directory_usage` 方法，改为使用以实例为中心的 `server_resource_usage` API，简化系统服务的接口表面。

Tests:
- 更新系统服务测试，以使用由实例/服务器服务构造的 `CoreSystemService`，并移除已弃用的进程和目录资源使用 API 的相关测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add instance-based server resource usage querying to the system service and remove PID- and directory-based resource endpoints.

New Features:
- Expose a unified ServerResourceUsage model that reports CPU, memory and disk usage per server instance along with status and PID.
- Introduce a SystemService API to query server resource usage by instance ID, wired through application, HTTP (axum) handlers, Tauri commands, and front-end route mapping.

Enhancements:
- Refactor CoreSystemService to depend on instance and server services, enabling status-aware resource aggregation per instance.
- Simplify the system service surface by removing process_usage and directory_usage methods in favor of the instance-focused server_resource_usage API.

Tests:
- Update system service tests to use a constructed CoreSystemService with instance/server services and remove tests for deprecated process and directory usage APIs.

</details>