### PR TITLE
ci: 完善nightly-release检查，抽离actions和scripts

### DIFF
--- a/.github/actions/install-tauri-dependencies/action.yml
+++ b/.github/actions/install-tauri-dependencies/action.yml
@@ -1,0 +1,34 @@
+name: 安装 Linux Tauri 依赖
+description: 在 Ubuntu runner 上安装 Tauri 构建与测试所需的系统包
+
+inputs:
+  install-xdg-utils:
+    description: 是否额外安装发布构建所需的 xdg-utils
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: 安装系统依赖
+      shell: bash
+      env:
+        INSTALL_XDG_UTILS: ${{ inputs.install-xdg-utils }}
+      run: |
+        set -euo pipefail
+        packages=(
+          libwebkit2gtk-4.1-dev
+          libappindicator3-dev
+          librsvg2-dev
+          patchelf
+          nasm
+        )
+        if [[ "$INSTALL_XDG_UTILS" == "true" ]]; then
+          packages+=(xdg-utils)
+        elif [[ "$INSTALL_XDG_UTILS" != "false" ]]; then
+          echo "install-xdg-utils must be true or false" >&2
+          exit 2
+        fi
+
+        sudo apt-get update
+        sudo apt-get install -y "${packages[@]}"

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,42 @@
+name: 设置 pnpm 环境
+description: 安装 Node.js、启用固定版本的 pnpm，并恢复 pnpm store 缓存
+
+inputs:
+  node-version:
+    description: 要安装的 Node.js 版本
+    required: false
+    default: "lts/*"
+  pnpm-version:
+    description: 要通过 Corepack 激活的 pnpm 版本
+    required: false
+    default: "9.15.9"
+
+runs:
+  using: composite
+  steps:
+    - name: 安装 Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: 准备 pnpm
+      shell: bash
+      env:
+        PNPM_VERSION: ${{ inputs.pnpm-version }}
+      run: |
+        corepack enable
+        corepack prepare "pnpm@${PNPM_VERSION}" --activate
+
+    - name: 获取 pnpm store 路径
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: 缓存 pnpm 依赖
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-pnpm-
+          ${{ runner.os }}-pnpm-

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,55 @@
+name: 设置 Rust 环境
+description: 安装 Rust 工具链，并按需恢复或保存编译缓存
+
+inputs:
+  toolchain:
+    description: 要安装的 Rust 工具链
+    required: false
+    default: stable
+  components:
+    description: 逗号分隔的 Rust 组件
+    required: false
+    default: ""
+  targets:
+    description: 逗号分隔的 Rust 编译目标
+    required: false
+    default: ""
+  cache:
+    description: 是否启用 Rust 编译缓存
+    required: false
+    default: "false"
+  cache-save:
+    description: 是否在任务完成时保存 Rust 编译缓存
+    required: false
+    default: "true"
+  retry:
+    description: 工具链首次安装失败后是否重试
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: 安装 Rust 工具链
+      id: rust-setup
+      uses: dtolnay/rust-toolchain@stable
+      continue-on-error: ${{ inputs.retry == 'true' }}
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    - name: 重试安装 Rust 工具链
+      if: ${{ inputs.retry == 'true' && steps.rust-setup.outcome == 'failure' }}
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+
+    - name: 缓存 Rust 编译产物
+      if: ${{ inputs.cache == 'true' }}
+      uses: swatinem/rust-cache@v2
+      with:
+        workspaces: ". -> target"
+        save-if: ${{ inputs.cache-save == 'true' }}

--- a/.github/release-matrix.json
+++ b/.github/release-matrix.json
@@ -1,0 +1,58 @@
+{
+  "include": [
+    {
+      "platform": "macos-latest",
+      "name": "macOS ARM64",
+      "args": "--target aarch64-apple-darwin",
+      "rust_target": "aarch64-apple-darwin",
+      "asset_os": "macos",
+      "asset_arch": "arm64",
+      "asset_key": "macos-arm64"
+    },
+    {
+      "platform": "macos-15-intel",
+      "name": "macOS x64",
+      "args": "--target x86_64-apple-darwin",
+      "rust_target": "x86_64-apple-darwin",
+      "asset_os": "macos",
+      "asset_arch": "x64",
+      "asset_key": "macos-x64"
+    },
+    {
+      "platform": "ubuntu-22.04",
+      "name": "Linux x64",
+      "args": "",
+      "rust_target": "",
+      "asset_os": "linux",
+      "asset_arch": "x64",
+      "asset_key": "linux-x64"
+    },
+    {
+      "platform": "ubuntu-22.04-arm",
+      "name": "Linux ARM64",
+      "args": "",
+      "rust_target": "",
+      "asset_os": "linux",
+      "asset_arch": "arm64",
+      "asset_key": "linux-arm64"
+    },
+    {
+      "platform": "windows-latest",
+      "name": "Windows x64",
+      "args": "",
+      "rust_target": "",
+      "asset_os": "windows",
+      "asset_arch": "x64",
+      "asset_key": "windows-x64"
+    },
+    {
+      "platform": "windows-11-arm",
+      "name": "Windows ARM64",
+      "args": "",
+      "rust_target": "",
+      "asset_os": "windows",
+      "asset_arch": "arm64",
+      "asset_key": "windows-arm64"
+    }
+  ]
+}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,6 +39,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-application:
               - 'application/**'
@@ -46,6 +47,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-core:
               - 'crates/core/**'
@@ -53,6 +55,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-infra:
               - 'crates/infra/**'
@@ -60,6 +63,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-extra:
               - 'crates/extra/**'
@@ -67,6 +71,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-interface:
               - 'crates/interface/**'
@@ -74,6 +79,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-server:
               - 'server/**'
@@ -81,6 +87,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             backend-tauri:
               - 'src-tauri/**'
@@ -88,6 +95,7 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rustfmt.toml'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
             frontend:
               - 'src/**'
@@ -99,6 +107,7 @@ jobs:
               - 'index.html'
               - '.oxlintrc.json'
               - '.oxfmtrc.json'
+              - '.github/actions/**'
               - '.github/workflows/check.yml'
 
   backend-lint:
@@ -112,29 +121,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 安装系统依赖
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf nasm
+        uses: ./.github/actions/install-tauri-dependencies
 
-      - name: 安装 Rust 工具链
-        id: rust_setup
-        uses: dtolnay/rust-toolchain@stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
           components: rustfmt, clippy
-        continue-on-error: true
-
-      - name: 重试安装 Rust 工具链
-        if: ${{ steps.rust_setup.outcome == 'failure' }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-
-      - name: 缓存 Rust 编译产物
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
+          cache: "true"
+          retry: "true"
 
       - name: 检查代码格式 (Rust)
         run: cargo fmt --all -- --check
@@ -152,10 +146,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
 
       - name: 运行测试
         run: cargo test -p sealantern-application
@@ -170,10 +162,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
 
       - name: 运行测试
         run: cargo test -p sealantern-core --lib
@@ -190,10 +180,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
 
       - name: 运行测试
         run: cargo test -p sealantern-extra
@@ -208,10 +196,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
 
       - name: 运行测试
         run: cargo test -p sealantern-infra --all-features
@@ -226,10 +212,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
 
       - name: 运行测试
         run: cargo test -p sealantern-interface
@@ -244,10 +228,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
 
       - name: 运行测试
         run: cargo test -p sealantern-server
@@ -263,20 +245,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 安装系统依赖
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf nasm
+        uses: ./.github/actions/install-tauri-dependencies
 
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
+      - name: 设置 Rust 环境（缓存只恢复）
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: stable
-
-      - name: 缓存 Rust 编译产物（只恢复）
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
-          save-if: false
+          cache: "true"
+          cache-save: "false"
 
       - name: 运行测试
         run: cargo test --lib -p sealantern
@@ -316,23 +291,8 @@ jobs:
       - name: 检出代码
         uses: actions/checkout@v4
 
-      - name: 安装 Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-
-      - name: Prepare PNPM (固定版本)
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.15.9 --activate
-
-      - name: 缓存 pnpm 依赖
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+      - name: 设置 pnpm 环境
+        uses: ./.github/actions/setup-pnpm
 
       - name: 安装前端依赖
         run: |

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 env:
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
-      should_build: ${{ steps.hash-check.outputs.should_build }}
       tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
       release_name: ${{ steps.meta.outputs.release_name }}
@@ -39,28 +38,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: 检查 main 是否有新提交
-        id: hash-check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          CURRENT_SHA="$(git rev-parse HEAD)"
-          LAST_SUCCESS_SHA="$(
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/nightly-release.yml/runs?branch=${RELEASE_BRANCH}&status=success&per_page=1" \
-              --jq '.workflow_runs[0].head_sha // ""'
-          )"
-
-          if [ -n "$LAST_SUCCESS_SHA" ] && [ "$CURRENT_SHA" = "$LAST_SUCCESS_SHA" ]; then
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-            echo "main 提交未变化，跳过 Nightly 构建: $CURRENT_SHA"
-          else
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-            echo "检测到新的 main 提交，开始 Nightly 构建: ${LAST_SUCCESS_SHA:-无} -> $CURRENT_SHA"
-          fi
 
       - name: 生成 Nightly 标签与 Release 信息
         id: meta
@@ -103,35 +80,137 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-  publish-tauri-nightly:
-    name: 构建并发布 Nightly 桌面端
+  test-nightly:
+    name: 全量检查 (${{ matrix.name }})
     needs: validate-nightly
-    if: ${{ needs.validate-nightly.outputs.should_build == 'true' }}
     permissions:
-      contents: write
+      contents: read
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: "macos-latest"
+            name: "macOS ARM64"
+          - platform: "macos-15-intel"
+            name: "macOS x64"
+          - platform: "ubuntu-22.04"
+            name: "Linux x64"
+          - platform: "ubuntu-22.04-arm"
+            name: "Linux ARM64"
+          - platform: "windows-latest"
+            name: "Windows x64"
+          - platform: "windows-11-arm"
+            name: "Windows ARM64"
+
+    runs-on: ${{ matrix.platform }}
+    env:
+      RUSTFLAGS: "--cfg ci_skip_validation"
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-nightly.outputs.source_sha }}
+
+      - name: 安装系统依赖 (Ubuntu 专用)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf nasm
+
+      - name: 安装 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: 准备 pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.15.9 --activate
+
+      - name: 缓存 pnpm 依赖
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-
+            ${{ runner.os }}-pnpm-
+
+      - name: 安装 Rust 工具链
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: 缓存 Rust 编译产物
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: 安装前端依赖
+        run: pnpm install --frozen-lockfile
+
+      - name: 运行前端全量检查
+        run: pnpm run fmt:check && pnpm run lint && pnpm run build:check
+
+      - name: 检查 Rust 格式
+        run: cargo fmt --all -- --check
+
+      - name: 运行 Rust Check
+        run: cargo check --workspace --all-targets
+
+      - name: 运行 Rust 全量测试
+        run: |
+          cargo test -p sealantern-application
+          cargo test -p sealantern-core --lib
+          cargo test -p sealantern-extra
+          cargo test -p sealantern-infra --all-features
+          cargo test -p sealantern-interface
+          cargo test -p sealantern-server
+          cargo test --lib -p sealantern
+
+  build-tauri-nightly:
+    name: 构建 Nightly (${{ matrix.name }})
+    needs:
+      - validate-nightly
+      - test-nightly
+    permissions:
+      contents: read
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: "macos-latest"
+            name: "macOS ARM64"
             args: "--target aarch64-apple-darwin"
             asset_arch: "arm64"
-          - platform: "macos-latest"
+            asset_key: "macos-arm64"
+          - platform: "macos-15-intel"
+            name: "macOS x64"
             args: "--target x86_64-apple-darwin"
             asset_arch: "x64"
+            asset_key: "macos-x64"
           - platform: "ubuntu-22.04"
+            name: "Linux x64"
             args: ""
             asset_arch: "x64"
+            asset_key: "linux-x64"
           - platform: "ubuntu-22.04-arm"
+            name: "Linux ARM64"
             args: ""
             asset_arch: "arm64"
+            asset_key: "linux-arm64"
           - platform: "windows-latest"
+            name: "Windows x64"
             args: ""
             asset_arch: "x64"
+            asset_key: "windows-x64"
           - platform: "windows-11-arm"
+            name: "Windows ARM64"
             args: ""
             asset_arch: "arm64"
+            asset_key: "windows-arm64"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -141,7 +220,7 @@ jobs:
           ref: ${{ needs.validate-nightly.outputs.source_sha }}
 
       - name: 安装系统依赖 (Ubuntu 专用)
-        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils nasm
@@ -151,15 +230,18 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: 准备 pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.15.9 --activate
 
       - name: 缓存 pnpm 依赖
         uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-
             ${{ runner.os }}-pnpm-
 
       - name: 安装 Rust 工具链 (默认目标)
@@ -177,68 +259,81 @@ jobs:
         with:
           workspaces: ". -> target"
 
-      - name: 安装前端依赖 (pnpm)
-        run: |
-          corepack prepare pnpm@9.15.9 --activate
-          pnpm install --frozen-lockfile
+      - name: 安装前端依赖
+        run: pnpm install --frozen-lockfile
 
-      - name: 构建并上传 Nightly 产物
+      - name: 构建 Tauri 产物
         uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ needs.validate-nightly.outputs.tag }}
-          releaseName: ${{ needs.validate-nightly.outputs.release_name }}
-          releaseBody: ${{ needs.validate-nightly.outputs.release_body }}
-          releaseDraft: false
-          prerelease: true
           args: ${{ matrix.args }} -c src-tauri/tauri.conf.json
 
-      - name: 打包 Windows 免安装版
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'windows-11-arm'
+      - name: 收集 Linux 发布产物
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ASSET_DIR="$RUNNER_TEMP/nightly-assets-${{ matrix.asset_key }}"
+          mkdir -p "$ASSET_DIR"
+
+          mapfile -t BUNDLE_FILES < <(
+            find target src-tauri/target -type f -path '*/bundle/*' \
+              \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) 2>/dev/null | sort -u
+          )
+          if [ ${#BUNDLE_FILES[@]} -eq 0 ]; then
+            echo "❌ 未找到 Linux 安装包"
+            exit 1
+          fi
+
+          for file in "${BUNDLE_FILES[@]}"; do
+            cp "$file" "$ASSET_DIR/"
+          done
+
+      - name: 收集并打包 Windows 发布产物
+        if: runner.os == 'Windows'
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.validate-nightly.outputs.tag }}
           VERSION: ${{ needs.validate-nightly.outputs.version }}
           ASSET_ARCH: ${{ matrix.asset_arch }}
+          ASSET_KEY: ${{ matrix.asset_key }}
         run: |
+          $assetDir = Join-Path $env:RUNNER_TEMP "nightly-assets-$env:ASSET_KEY"
+          New-Item -ItemType Directory -Path $assetDir | Out-Null
+
+          $bundleFiles = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object {
+              $_.FullName -match '\\bundle\\(msi|nsis)\\' -and
+              ($_.Extension -eq ".msi" -or $_.Extension -eq ".exe")
+            }
+          if (@($bundleFiles).Count -eq 0) {
+            throw "未找到 Windows 安装包。"
+          }
+          $bundleFiles | ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $assetDir }
+
           $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sealantern.exe" -ErrorAction SilentlyContinue |
             Where-Object { $_.FullName -match '\\release\\sealantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
             Select-Object -First 1 -ExpandProperty DirectoryName
-
           if (-not $releaseDir) {
             throw "未找到 Windows 可执行文件，无法打包免安装版。"
           }
 
-          $stageDir = Join-Path $env:RUNNER_TEMP "portable-windows-$env:ASSET_ARCH"
-          Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $stageDir | Out-Null
-
-          Copy-Item -LiteralPath (Join-Path $releaseDir "sealantern.exe") -Destination $stageDir
-
+          $portableDir = Join-Path $env:RUNNER_TEMP "portable-windows-$env:ASSET_ARCH"
+          New-Item -ItemType Directory -Path $portableDir | Out-Null
+          Copy-Item -LiteralPath (Join-Path $releaseDir "sealantern.exe") -Destination $portableDir
           Get-ChildItem -Path $releaseDir -File -Filter "*.dll" -ErrorAction SilentlyContinue |
-            ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $stageDir }
+            ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $portableDir }
+          Copy-Item -LiteralPath "LICENSE", "NOTICE" -Destination $portableDir
 
-          Copy-Item -LiteralPath "LICENSE", "NOTICE" -Destination $stageDir
+          $portablePath = Join-Path $assetDir "Sea.Lantern_${env:VERSION}_windows_${env:ASSET_ARCH}_portable.zip"
+          Compress-Archive -Path (Join-Path $portableDir '*') -DestinationPath $portablePath
 
-          $assetName = "Sea.Lantern_${env:VERSION}_windows_${env:ASSET_ARCH}_portable.zip"
-          $assetPath = Join-Path $env:RUNNER_TEMP $assetName
-          if (Test-Path $assetPath) {
-            Remove-Item -LiteralPath $assetPath -Force
-          }
-
-          Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $assetPath -Force
-          gh release upload $env:TAG $assetPath --clobber
-
-      - name: 打包 macOS 免安装版
-        if: matrix.platform == 'macos-latest'
+      - name: 收集并打包 macOS 发布产物
+        if: runner.os == 'macOS'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.validate-nightly.outputs.tag }}
           VERSION: ${{ needs.validate-nightly.outputs.version }}
           ASSET_ARCH: ${{ matrix.asset_arch }}
+          ASSET_KEY: ${{ matrix.asset_key }}
         run: |
           set -euo pipefail
 
@@ -248,68 +343,142 @@ jobs:
               SEARCH_ROOTS+=("$dir")
             fi
           done
-
           if [ ${#SEARCH_ROOTS[@]} -eq 0 ]; then
-            echo "❌ 未找到 target 目录，无法打包 macOS 免安装版"
+            echo "❌ 未找到 target 目录"
             exit 1
           fi
+
+          ASSET_DIR="$RUNNER_TEMP/nightly-assets-$ASSET_KEY"
+          mkdir -p "$ASSET_DIR"
+
+          DMG_FILES=()
+          while IFS= read -r file; do
+            DMG_FILES+=("$file")
+          done < <(find "${SEARCH_ROOTS[@]}" -type f -name '*.dmg' -path '*/bundle/*' 2>/dev/null | sort -u)
+          if [ ${#DMG_FILES[@]} -eq 0 ]; then
+            echo "❌ 未找到 macOS DMG 安装包"
+            exit 1
+          fi
+          for file in "${DMG_FILES[@]}"; do
+            cp "$file" "$ASSET_DIR/"
+          done
 
           APP_PATH="$(find "${SEARCH_ROOTS[@]}" -type d -name '*.app' -path '*/bundle/*' 2>/dev/null | head -n 1 || true)"
           APP_ARCHIVE_PATH=""
           if [ -z "$APP_PATH" ]; then
             APP_ARCHIVE_PATH="$(find "${SEARCH_ROOTS[@]}" -type f -name '*.app.tar.gz' -path '*/bundle/*' 2>/dev/null | head -n 1 || true)"
           fi
-
           if [ -z "$APP_PATH" ] && [ -z "$APP_ARCHIVE_PATH" ]; then
-            echo "❌ 未找到 macOS .app 或 .app.tar.gz 产物，无法打包免安装版"
-            echo "已发现的 bundle 路径:"
-            find "${SEARCH_ROOTS[@]}" -path '*/bundle/*' 2>/dev/null | sort || true
+            echo "❌ 未找到 macOS .app 或 .app.tar.gz 产物"
             exit 1
           fi
 
-          STAGE_DIR="$RUNNER_TEMP/portable-macos-$ASSET_ARCH"
-          rm -rf "$STAGE_DIR"
-          mkdir -p "$STAGE_DIR"
-
+          PORTABLE_DIR="$RUNNER_TEMP/portable-macos-$ASSET_ARCH"
+          mkdir -p "$PORTABLE_DIR"
           if [ -n "$APP_PATH" ]; then
-            cp -R "$APP_PATH" "$STAGE_DIR/"
+            cp -R "$APP_PATH" "$PORTABLE_DIR/"
             APP_BASENAME="$(basename "$APP_PATH")"
           else
-            tar -C "$STAGE_DIR" -xzf "$APP_ARCHIVE_PATH"
-            EXTRACTED_APP_PATH="$(find "$STAGE_DIR" -maxdepth 2 -type d -name '*.app' 2>/dev/null | head -n 1 || true)"
+            tar -C "$PORTABLE_DIR" -xzf "$APP_ARCHIVE_PATH"
+            EXTRACTED_APP_PATH="$(find "$PORTABLE_DIR" -maxdepth 2 -type d -name '*.app' 2>/dev/null | head -n 1 || true)"
             if [ -z "$EXTRACTED_APP_PATH" ]; then
-              echo "❌ 已找到 $APP_ARCHIVE_PATH，但解压后未发现 .app 目录"
-              find "$STAGE_DIR" -maxdepth 2 2>/dev/null | sort || true
+              echo "❌ 解压后未发现 .app 目录"
               exit 1
             fi
             APP_BASENAME="$(basename "$EXTRACTED_APP_PATH")"
           fi
 
-          cp LICENSE NOTICE "$STAGE_DIR/"
+          cp LICENSE NOTICE "$PORTABLE_DIR/"
+          PORTABLE_PATH="$ASSET_DIR/Sea.Lantern_${VERSION}_macos_${ASSET_ARCH}_portable.tar.gz"
+          tar -C "$PORTABLE_DIR" -czf "$PORTABLE_PATH" "$APP_BASENAME" LICENSE NOTICE
 
-          ASSET_NAME="Sea.Lantern_${VERSION}_macos_${ASSET_ARCH}_portable.tar.gz"
-          ASSET_PATH="$RUNNER_TEMP/$ASSET_NAME"
-          tar -C "$STAGE_DIR" -czf "$ASSET_PATH" "$APP_BASENAME" LICENSE NOTICE
+      - name: 上传本平台构建产物到工作流
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-assets-${{ matrix.asset_key }}
+          path: ${{ runner.temp }}/nightly-assets-${{ matrix.asset_key }}/*
+          if-no-files-found: error
+          retention-days: 3
 
-          gh release upload "$TAG" "$ASSET_PATH" --clobber
+  publish-nightly:
+    name: 汇总并发布 Nightly
+    needs:
+      - validate-nightly
+      - build-tauri-nightly
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: 下载全部平台构建产物
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-assets-*
+          path: release-assets
+
+      - name: 校验发布产物
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t ASSETS < <(find release-assets -type f | sort)
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "❌ 没有可发布的构建产物"
+            exit 1
+          fi
+
+          DUPLICATES="$(printf '%s\n' "${ASSETS[@]##*/}" | sort | uniq -d)"
+          if [ -n "$DUPLICATES" ]; then
+            echo "❌ 不同平台产生了同名文件，无法安全汇总发布:"
+            echo "$DUPLICATES"
+            exit 1
+          fi
+
+          printf '待发布产物 (%s 个):\n' "${#ASSETS[@]}"
+          printf '  %s\n' "${ASSETS[@]}"
+
+      - name: 一次性创建或更新 Nightly Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate-nightly.outputs.tag }}
+          RELEASE_NAME: ${{ needs.validate-nightly.outputs.release_name }}
+          RELEASE_BODY: ${{ needs.validate-nightly.outputs.release_body }}
+          SOURCE_SHA: ${{ needs.validate-nightly.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t ASSETS < <(find release-assets -type f | sort)
+          NOTES_FILE="$RUNNER_TEMP/nightly-release-notes.md"
+          printf '%s\n' "$RELEASE_BODY" > "$NOTES_FILE"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$RELEASE_NAME" \
+              --notes-file "$NOTES_FILE" \
+              --prerelease
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          else
+            gh release create "$TAG" "${ASSETS[@]}" \
+              --target "$SOURCE_SHA" \
+              --title "$RELEASE_NAME" \
+              --notes-file "$NOTES_FILE" \
+              --prerelease
+          fi
 
   cleanup-old-nightly:
     name: 清理旧 Nightly 发布
     needs:
       - validate-nightly
-      - publish-tauri-nightly
-    if: >-
-      always() &&
-      needs.validate-nightly.outputs.should_build == 'true'
+      - publish-nightly
     runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
-      - name: 删除当前日期之外的旧 Nightly Release
+      - name: 删除当前 Nightly 之外的旧发布
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_TAG: ${{ needs.validate-nightly.outputs.tag }}
-          PUBLISH_RESULT: ${{ needs.publish-tauri-nightly.result }}
         run: |
           set -euo pipefail
 
@@ -319,7 +488,7 @@ jobs:
 
           deleted=0
           for tag in "${NIGHTLY_TAGS[@]}"; do
-            if [ "$tag" = "$CURRENT_TAG" ] && [ "$PUBLISH_RESULT" = "success" ]; then
+            if [ "$tag" = "$CURRENT_TAG" ]; then
               continue
             fi
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
       tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
       release_name: ${{ steps.meta.outputs.release_name }}
@@ -38,6 +39,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: 生成共享平台矩阵
+        id: matrix
+        run: |
+          set -euo pipefail
+          jq -e '
+            .include as $rows |
+            ($rows | type == "array" and length > 0) and
+            ([$rows[].asset_key] | length == (unique | length)) and
+            (all($rows[];
+              (.platform | type == "string" and length > 0) and
+              (.name | type == "string" and length > 0) and
+              (.args | type == "string") and
+              (.rust_target | type == "string") and
+              (.asset_os == "linux" or .asset_os == "macos" or .asset_os == "windows") and
+              (.asset_arch == "x64" or .asset_arch == "arm64") and
+              (.asset_key | test("^[a-z0-9-]+$"))
+            ))
+          ' .github/release-matrix.json >/dev/null
+          MATRIX="$(jq -c . .github/release-matrix.json)"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: 生成 Nightly 标签与 Release 信息
         id: meta
@@ -88,20 +110,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: "macos-latest"
-            name: "macOS ARM64"
-          - platform: "macos-15-intel"
-            name: "macOS x64"
-          - platform: "ubuntu-22.04"
-            name: "Linux x64"
-          - platform: "ubuntu-22.04-arm"
-            name: "Linux ARM64"
-          - platform: "windows-latest"
-            name: "Windows x64"
-          - platform: "windows-11-arm"
-            name: "Windows ARM64"
+      matrix: ${{ fromJSON(needs.validate-nightly.outputs.matrix) }}
 
     runs-on: ${{ matrix.platform }}
     env:
@@ -114,38 +123,16 @@ jobs:
 
       - name: 安装系统依赖 (Ubuntu 专用)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf nasm
+        uses: ./.github/actions/install-tauri-dependencies
 
-      - name: 安装 Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
+      - name: 设置 pnpm 环境
+        uses: ./.github/actions/setup-pnpm
 
-      - name: 准备 pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.15.9 --activate
-
-      - name: 缓存 pnpm 依赖
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pnpm-
-            ${{ runner.os }}-pnpm-
-
-      - name: 安装 Rust 工具链
-        uses: dtolnay/rust-toolchain@stable
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
-
-      - name: 缓存 Rust 编译产物
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
+          cache: "true"
 
       - name: 安装前端依赖
         run: pnpm install --frozen-lockfile
@@ -179,38 +166,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: "macos-latest"
-            name: "macOS ARM64"
-            args: "--target aarch64-apple-darwin"
-            asset_arch: "arm64"
-            asset_key: "macos-arm64"
-          - platform: "macos-15-intel"
-            name: "macOS x64"
-            args: "--target x86_64-apple-darwin"
-            asset_arch: "x64"
-            asset_key: "macos-x64"
-          - platform: "ubuntu-22.04"
-            name: "Linux x64"
-            args: ""
-            asset_arch: "x64"
-            asset_key: "linux-x64"
-          - platform: "ubuntu-22.04-arm"
-            name: "Linux ARM64"
-            args: ""
-            asset_arch: "arm64"
-            asset_key: "linux-arm64"
-          - platform: "windows-latest"
-            name: "Windows x64"
-            args: ""
-            asset_arch: "x64"
-            asset_key: "windows-x64"
-          - platform: "windows-11-arm"
-            name: "Windows ARM64"
-            args: ""
-            asset_arch: "arm64"
-            asset_key: "windows-arm64"
+      matrix: ${{ fromJSON(needs.validate-nightly.outputs.matrix) }}
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -221,43 +177,18 @@ jobs:
 
       - name: 安装系统依赖 (Ubuntu 专用)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils nasm
-
-      - name: 安装 Node.js
-        uses: actions/setup-node@v4
+        uses: ./.github/actions/install-tauri-dependencies
         with:
-          node-version: "lts/*"
+          install-xdg-utils: "true"
 
-      - name: 准备 pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@9.15.9 --activate
+      - name: 设置 pnpm 环境
+        uses: ./.github/actions/setup-pnpm
 
-      - name: 缓存 pnpm 依赖
-        uses: actions/cache@v4
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
         with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pnpm-
-            ${{ runner.os }}-pnpm-
-
-      - name: 安装 Rust 工具链 (默认目标)
-        if: ${{ matrix.args == '' }}
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: 安装 Rust 工具链 (macOS 目标)
-        if: ${{ matrix.args != '' }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-
-      - name: 缓存 Rust 编译产物
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
+          targets: ${{ matrix.rust_target }}
+          cache: "true"
 
       - name: 安装前端依赖
         run: pnpm install --frozen-lockfile
@@ -267,27 +198,17 @@ jobs:
         with:
           args: ${{ matrix.args }} -c src-tauri/tauri.conf.json
 
-      - name: 收集 Linux 发布产物
-        if: runner.os == 'Linux'
+      - name: 收集 Unix 发布产物
+        if: runner.os != 'Windows'
         shell: bash
+        env:
+          ASSET_OS: ${{ matrix.asset_os }}
+          VERSION: ${{ needs.validate-nightly.outputs.version }}
+          ASSET_ARCH: ${{ matrix.asset_arch }}
+          ASSET_KEY: ${{ matrix.asset_key }}
         run: |
-          set -euo pipefail
-
-          ASSET_DIR="$RUNNER_TEMP/nightly-assets-${{ matrix.asset_key }}"
-          mkdir -p "$ASSET_DIR"
-
-          mapfile -t BUNDLE_FILES < <(
-            find target src-tauri/target -type f -path '*/bundle/*' \
-              \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \) 2>/dev/null | sort -u
-          )
-          if [ ${#BUNDLE_FILES[@]} -eq 0 ]; then
-            echo "❌ 未找到 Linux 安装包"
-            exit 1
-          fi
-
-          for file in "${BUNDLE_FILES[@]}"; do
-            cp "$file" "$ASSET_DIR/"
-          done
+          bash scripts/ci/collect-assets.sh \
+            "$ASSET_OS" "$VERSION" "$ASSET_ARCH" "$ASSET_KEY"
 
       - name: 收集并打包 Windows 发布产物
         if: runner.os == 'Windows'
@@ -297,106 +218,18 @@ jobs:
           ASSET_ARCH: ${{ matrix.asset_arch }}
           ASSET_KEY: ${{ matrix.asset_key }}
         run: |
-          $assetDir = Join-Path $env:RUNNER_TEMP "nightly-assets-$env:ASSET_KEY"
-          New-Item -ItemType Directory -Path $assetDir | Out-Null
-
-          $bundleFiles = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -ErrorAction SilentlyContinue |
-            Where-Object {
-              $_.FullName -match '\\bundle\\(msi|nsis)\\' -and
-              ($_.Extension -eq ".msi" -or $_.Extension -eq ".exe")
-            }
-          if (@($bundleFiles).Count -eq 0) {
-            throw "未找到 Windows 安装包。"
+          $params = @{
+            Version = $env:VERSION
+            AssetArch = $env:ASSET_ARCH
+            AssetKey = $env:ASSET_KEY
           }
-          $bundleFiles | ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $assetDir }
-
-          $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sealantern.exe" -ErrorAction SilentlyContinue |
-            Where-Object { $_.FullName -match '\\release\\sealantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
-            Select-Object -First 1 -ExpandProperty DirectoryName
-          if (-not $releaseDir) {
-            throw "未找到 Windows 可执行文件，无法打包免安装版。"
-          }
-
-          $portableDir = Join-Path $env:RUNNER_TEMP "portable-windows-$env:ASSET_ARCH"
-          New-Item -ItemType Directory -Path $portableDir | Out-Null
-          Copy-Item -LiteralPath (Join-Path $releaseDir "sealantern.exe") -Destination $portableDir
-          Get-ChildItem -Path $releaseDir -File -Filter "*.dll" -ErrorAction SilentlyContinue |
-            ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $portableDir }
-          Copy-Item -LiteralPath "LICENSE", "NOTICE" -Destination $portableDir
-
-          $portablePath = Join-Path $assetDir "Sea.Lantern_${env:VERSION}_windows_${env:ASSET_ARCH}_portable.zip"
-          Compress-Archive -Path (Join-Path $portableDir '*') -DestinationPath $portablePath
-
-      - name: 收集并打包 macOS 发布产物
-        if: runner.os == 'macOS'
-        shell: bash
-        env:
-          VERSION: ${{ needs.validate-nightly.outputs.version }}
-          ASSET_ARCH: ${{ matrix.asset_arch }}
-          ASSET_KEY: ${{ matrix.asset_key }}
-        run: |
-          set -euo pipefail
-
-          SEARCH_ROOTS=()
-          for dir in target src-tauri/target; do
-            if [ -d "$dir" ]; then
-              SEARCH_ROOTS+=("$dir")
-            fi
-          done
-          if [ ${#SEARCH_ROOTS[@]} -eq 0 ]; then
-            echo "❌ 未找到 target 目录"
-            exit 1
-          fi
-
-          ASSET_DIR="$RUNNER_TEMP/nightly-assets-$ASSET_KEY"
-          mkdir -p "$ASSET_DIR"
-
-          DMG_FILES=()
-          while IFS= read -r file; do
-            DMG_FILES+=("$file")
-          done < <(find "${SEARCH_ROOTS[@]}" -type f -name '*.dmg' -path '*/bundle/*' 2>/dev/null | sort -u)
-          if [ ${#DMG_FILES[@]} -eq 0 ]; then
-            echo "❌ 未找到 macOS DMG 安装包"
-            exit 1
-          fi
-          for file in "${DMG_FILES[@]}"; do
-            cp "$file" "$ASSET_DIR/"
-          done
-
-          APP_PATH="$(find "${SEARCH_ROOTS[@]}" -type d -name '*.app' -path '*/bundle/*' 2>/dev/null | head -n 1 || true)"
-          APP_ARCHIVE_PATH=""
-          if [ -z "$APP_PATH" ]; then
-            APP_ARCHIVE_PATH="$(find "${SEARCH_ROOTS[@]}" -type f -name '*.app.tar.gz' -path '*/bundle/*' 2>/dev/null | head -n 1 || true)"
-          fi
-          if [ -z "$APP_PATH" ] && [ -z "$APP_ARCHIVE_PATH" ]; then
-            echo "❌ 未找到 macOS .app 或 .app.tar.gz 产物"
-            exit 1
-          fi
-
-          PORTABLE_DIR="$RUNNER_TEMP/portable-macos-$ASSET_ARCH"
-          mkdir -p "$PORTABLE_DIR"
-          if [ -n "$APP_PATH" ]; then
-            cp -R "$APP_PATH" "$PORTABLE_DIR/"
-            APP_BASENAME="$(basename "$APP_PATH")"
-          else
-            tar -C "$PORTABLE_DIR" -xzf "$APP_ARCHIVE_PATH"
-            EXTRACTED_APP_PATH="$(find "$PORTABLE_DIR" -maxdepth 2 -type d -name '*.app' 2>/dev/null | head -n 1 || true)"
-            if [ -z "$EXTRACTED_APP_PATH" ]; then
-              echo "❌ 解压后未发现 .app 目录"
-              exit 1
-            fi
-            APP_BASENAME="$(basename "$EXTRACTED_APP_PATH")"
-          fi
-
-          cp LICENSE NOTICE "$PORTABLE_DIR/"
-          PORTABLE_PATH="$ASSET_DIR/Sea.Lantern_${VERSION}_macos_${ASSET_ARCH}_portable.tar.gz"
-          tar -C "$PORTABLE_DIR" -czf "$PORTABLE_PATH" "$APP_BASENAME" LICENSE NOTICE
+          & ./scripts/ci/collect-assets.ps1 @params
 
       - name: 上传本平台构建产物到工作流
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-assets-${{ matrix.asset_key }}
-          path: ${{ runner.temp }}/nightly-assets-${{ matrix.asset_key }}/*
+          name: release-assets-${{ matrix.asset_key }}
+          path: ${{ runner.temp }}/release-assets-${{ matrix.asset_key }}/*
           if-no-files-found: error
           retention-days: 3
 
@@ -410,67 +243,36 @@ jobs:
       actions: read
       contents: write
     steps:
+      - name: 检出发布脚本
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate-nightly.outputs.source_sha }}
+
       - name: 下载全部平台构建产物
         uses: actions/download-artifact@v4
         with:
-          pattern: nightly-assets-*
+          pattern: release-assets-*
           path: release-assets
 
-      - name: 校验发布产物
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mapfile -t ASSETS < <(find release-assets -type f | sort)
-          if [ ${#ASSETS[@]} -eq 0 ]; then
-            echo "❌ 没有可发布的构建产物"
-            exit 1
-          fi
-
-          DUPLICATES="$(printf '%s\n' "${ASSETS[@]##*/}" | sort | uniq -d)"
-          if [ -n "$DUPLICATES" ]; then
-            echo "❌ 不同平台产生了同名文件，无法安全汇总发布:"
-            echo "$DUPLICATES"
-            exit 1
-          fi
-
-          printf '待发布产物 (%s 个):\n' "${#ASSETS[@]}"
-          printf '  %s\n' "${ASSETS[@]}"
-
-      - name: 一次性创建或更新 Nightly Release
+      - name: 校验并直接发布 Nightly Release
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_JSON: ${{ needs.validate-nightly.outputs.matrix }}
           TAG: ${{ needs.validate-nightly.outputs.tag }}
           RELEASE_NAME: ${{ needs.validate-nightly.outputs.release_name }}
           RELEASE_BODY: ${{ needs.validate-nightly.outputs.release_body }}
           SOURCE_SHA: ${{ needs.validate-nightly.outputs.source_sha }}
         run: |
-          set -euo pipefail
-
-          mapfile -t ASSETS < <(find release-assets -type f | sort)
-          NOTES_FILE="$RUNNER_TEMP/nightly-release-notes.md"
-          printf '%s\n' "$RELEASE_BODY" > "$NOTES_FILE"
-
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" \
-              --title "$RELEASE_NAME" \
-              --notes-file "$NOTES_FILE" \
-              --prerelease
-            gh release upload "$TAG" "${ASSETS[@]}" --clobber
-          else
-            gh release create "$TAG" "${ASSETS[@]}" \
-              --target "$SOURCE_SHA" \
-              --title "$RELEASE_NAME" \
-              --notes-file "$NOTES_FILE" \
-              --prerelease
-          fi
+          bash scripts/ci/publish-assets.sh \
+            release-assets "$TAG" "$RELEASE_NAME" "$SOURCE_SHA" false true true
 
   cleanup-old-nightly:
     name: 清理旧 Nightly 发布
     needs:
       - validate-nightly
       - publish-nightly
+    if: ${{ needs.publish-nightly.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
       tag: ${{ steps.meta.outputs.tag }}
       version: ${{ steps.meta.outputs.version }}
       prerelease: ${{ steps.meta.outputs.prerelease }}
@@ -30,6 +31,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: 生成共享平台矩阵
+        id: matrix
+        run: |
+          set -euo pipefail
+          jq -e '
+            .include as $rows |
+            ($rows | type == "array" and length > 0) and
+            ([$rows[].asset_key] | length == (unique | length)) and
+            (all($rows[];
+              (.platform | type == "string" and length > 0) and
+              (.name | type == "string" and length > 0) and
+              (.args | type == "string") and
+              (.rust_target | type == "string") and
+              (.asset_os == "linux" or .asset_os == "macos" or .asset_os == "windows") and
+              (.asset_arch == "x64" or .asset_arch == "arm64") and
+              (.asset_key | test("^[a-z0-9-]+$"))
+            ))
+          ' .github/release-matrix.json >/dev/null
+          MATRIX="$(jq -c . .github/release-matrix.json)"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: 校验 Tag 指向 main 分支提交
         run: |
@@ -114,38 +136,15 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
           echo "✅ 发布版本: $VERSION"
 
-  publish-tauri:
-    name: 构建并发布桌面端
+  build-tauri:
+    name: 构建 ${{ matrix.name }}
     needs: validate-tag
     permissions:
-      contents: write
+      contents: read
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - platform: "macos-latest"
-            args: "--target aarch64-apple-darwin"
-            asset_arch: "arm64"
-          - platform: "macos-latest"
-            args: "--target x86_64-apple-darwin"
-            asset_arch: "x64"
-          - platform: "ubuntu-22.04"
-            args: ""
-            arch: "amd64"
-            asset_arch: "x64"
-          - platform: "ubuntu-22.04-arm"
-            args: ""
-            arch: "arm64"
-            asset_arch: "arm64"
-          - platform: "windows-latest"
-            args: ""
-            arch: "amd64"
-            asset_arch: "x64"
-          - platform: "windows-11-arm"
-            args: ""
-            arch: "arm64"
-            asset_arch: "arm64"
+      matrix: ${{ fromJSON(needs.validate-tag.outputs.matrix) }}
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -153,154 +152,91 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 安装系统依赖 (Ubuntu 专用)
-        if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils nasm
-
-      - name: 安装 Node.js
-        uses: actions/setup-node@v4
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/install-tauri-dependencies
         with:
-          node-version: "lts/*"
+          install-xdg-utils: "true"
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: 设置 pnpm 环境
+        uses: ./.github/actions/setup-pnpm
 
-      - name: 缓存 pnpm 依赖
-        uses: actions/cache@v4
+      - name: 设置 Rust 环境
+        uses: ./.github/actions/setup-rust
         with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          targets: ${{ matrix.rust_target }}
+          cache: "true"
 
-      - name: 安装 Rust 工具链 (默认目标)
-        if: ${{ matrix.args == '' }}
-        uses: dtolnay/rust-toolchain@stable
+      - name: 安装前端依赖
+        run: pnpm install --frozen-lockfile
 
-      - name: 安装 Rust 工具链 (macOS 目标)
-        if: ${{ matrix.args != '' }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
-
-      - name: 缓存 Rust 编译产物
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
-
-      - name: 安装前端依赖 (pnpm)
-        run: |
-          corepack prepare pnpm@9.15.9 --activate
-          pnpm install --frozen-lockfile
-
-      - name: 构建并发布
+      - name: 构建 Tauri 产物
         uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ needs.validate-tag.outputs.tag }}
-          releaseName: ${{ needs.validate-tag.outputs.release_name }}
-          releaseBody: ${{ needs.validate-tag.outputs.release_body }}
-          releaseDraft: true
-          prerelease: ${{ needs.validate-tag.outputs.prerelease }}
           args: ${{ matrix.args }} -c src-tauri/tauri.conf.json
 
-      - name: 打包 Windows 免安装版
-        if: matrix.platform == 'windows-latest' || matrix.platform == 'windows-11-arm'
-        shell: pwsh
+      - name: 收集 Unix 发布产物
+        if: runner.os != 'Windows'
+        shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.validate-tag.outputs.tag }}
+          ASSET_OS: ${{ matrix.asset_os }}
           VERSION: ${{ needs.validate-tag.outputs.version }}
           ASSET_ARCH: ${{ matrix.asset_arch }}
+          ASSET_KEY: ${{ matrix.asset_key }}
         run: |
-          $releaseDir = Get-ChildItem -Path "target", "src-tauri/target" -Recurse -File -Filter "sealantern.exe" -ErrorAction SilentlyContinue |
-            Where-Object { $_.FullName -match '\\release\\sealantern\.exe$' -and $_.FullName -notmatch '\\bundle\\' } |
-            Select-Object -First 1 -ExpandProperty DirectoryName
+          bash scripts/ci/collect-assets.sh \
+            "$ASSET_OS" "$VERSION" "$ASSET_ARCH" "$ASSET_KEY"
 
-          if (-not $releaseDir) {
-            throw "未找到 Windows 可执行文件，无法打包免安装版。"
+      - name: 收集 Windows 发布产物
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+          ASSET_ARCH: ${{ matrix.asset_arch }}
+          ASSET_KEY: ${{ matrix.asset_key }}
+        run: |
+          $params = @{
+            Version = $env:VERSION
+            AssetArch = $env:ASSET_ARCH
+            AssetKey = $env:ASSET_KEY
           }
+          & ./scripts/ci/collect-assets.ps1 @params
 
-          $stageDir = Join-Path $env:RUNNER_TEMP "portable-windows-$env:ASSET_ARCH"
-          Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $stageDir | Out-Null
+      - name: 上传本平台构建产物到工作流
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ matrix.asset_key }}
+          path: ${{ runner.temp }}/release-assets-${{ matrix.asset_key }}/*
+          if-no-files-found: error
+          retention-days: 3
 
-          Copy-Item -LiteralPath (Join-Path $releaseDir "sealantern.exe") -Destination $stageDir
+  publish-release:
+    name: 汇总正式发布草稿
+    needs:
+      - validate-tag
+      - build-tauri
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: 检出发布脚本
+        uses: actions/checkout@v4
 
-          Get-ChildItem -Path $releaseDir -File -Filter "*.dll" -ErrorAction SilentlyContinue |
-            ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $stageDir }
+      - name: 下载全部平台构建产物
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-assets-*
+          path: release-assets
 
-          Copy-Item -LiteralPath "LICENSE", "NOTICE" -Destination $stageDir
-
-          $assetName = "Sea.Lantern_${env:VERSION}_windows_${env:ASSET_ARCH}_portable.zip"
-          $assetPath = Join-Path $env:RUNNER_TEMP $assetName
-          if (Test-Path $assetPath) {
-            Remove-Item -LiteralPath $assetPath -Force
-          }
-
-          Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $assetPath -Force
-          gh release upload $env:TAG $assetPath --clobber
-
-      - name: 打包 macOS 免安装版
-        if: matrix.platform == 'macos-latest'
+      - name: 校验并创建正式发布草稿
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_JSON: ${{ needs.validate-tag.outputs.matrix }}
           TAG: ${{ needs.validate-tag.outputs.tag }}
-          VERSION: ${{ needs.validate-tag.outputs.version }}
-          ASSET_ARCH: ${{ matrix.asset_arch }}
+          RELEASE_NAME: ${{ needs.validate-tag.outputs.release_name }}
+          RELEASE_BODY: ${{ needs.validate-tag.outputs.release_body }}
+          PRERELEASE: ${{ needs.validate-tag.outputs.prerelease }}
         run: |
-          set -euo pipefail
-
-          SEARCH_ROOTS=()
-          for dir in target src-tauri/target; do
-            if [ -d "$dir" ]; then
-              SEARCH_ROOTS+=("$dir")
-            fi
-          done
-
-          if [ ${#SEARCH_ROOTS[@]} -eq 0 ]; then
-            echo "❌ 未找到 target 目录，无法打包 macOS 免安装版"
-            exit 1
-          fi
-
-          APP_PATH="$(find "${SEARCH_ROOTS[@]}" -type d -name '*.app' -path '*/bundle/*' 2>/dev/null | head -n 1 || true)"
-          APP_ARCHIVE_PATH=""
-          if [ -z "$APP_PATH" ]; then
-            APP_ARCHIVE_PATH="$(find "${SEARCH_ROOTS[@]}" -type f -name '*.app.tar.gz' -path '*/bundle/*' 2>/dev/null | head -n 1 || true)"
-          fi
-
-          if [ -z "$APP_PATH" ] && [ -z "$APP_ARCHIVE_PATH" ]; then
-            echo "❌ 未找到 macOS .app 或 .app.tar.gz 产物，无法打包免安装版"
-            echo "已发现的 bundle 路径:"
-            find "${SEARCH_ROOTS[@]}" -path '*/bundle/*' 2>/dev/null | sort || true
-            exit 1
-          fi
-
-          STAGE_DIR="$RUNNER_TEMP/portable-macos-$ASSET_ARCH"
-          rm -rf "$STAGE_DIR"
-          mkdir -p "$STAGE_DIR"
-
-          if [ -n "$APP_PATH" ]; then
-            cp -R "$APP_PATH" "$STAGE_DIR/"
-            APP_BASENAME="$(basename "$APP_PATH")"
-          else
-            tar -C "$STAGE_DIR" -xzf "$APP_ARCHIVE_PATH"
-            EXTRACTED_APP_PATH="$(find "$STAGE_DIR" -maxdepth 1 -type d -name '*.app' 2>/dev/null | head -n 1 || true)"
-            if [ -z "$EXTRACTED_APP_PATH" ]; then
-              echo "❌ 已找到 $APP_ARCHIVE_PATH，但解压后未发现 .app 目录"
-              find "$STAGE_DIR" -maxdepth 2 2>/dev/null | sort || true
-              exit 1
-            fi
-            APP_BASENAME="$(basename "$EXTRACTED_APP_PATH")"
-          fi
-
-          cp LICENSE NOTICE "$STAGE_DIR/"
-
-          ASSET_NAME="Sea.Lantern_${VERSION}_macos_${ASSET_ARCH}_portable.tar.gz"
-          ASSET_PATH="$RUNNER_TEMP/$ASSET_NAME"
-          tar -C "$STAGE_DIR" -czf "$ASSET_PATH" "$APP_BASENAME" LICENSE NOTICE
-
-          gh release upload "$TAG" "$ASSET_PATH" --clobber
+          bash scripts/ci/publish-assets.sh \
+            release-assets "$TAG" "$RELEASE_NAME" "$GITHUB_SHA" true "$PRERELEASE" false

--- a/scripts/ci/collect-assets.ps1
+++ b/scripts/ci/collect-assets.ps1
@@ -1,0 +1,114 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9A-Za-z.+-]+$')]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('x64', 'arm64')]
+    [string]$AssetArch,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[a-z0-9-]+$')]
+    [string]$AssetKey
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$repoDir = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+
+if (-not $env:RUNNER_TEMP) {
+    throw 'RUNNER_TEMP is not set.'
+}
+
+$searchRoots = @('target', 'src-tauri/target') |
+    ForEach-Object { Join-Path $repoDir $_ } |
+    Where-Object { Test-Path -LiteralPath $_ -PathType Container }
+if ($searchRoots.Count -eq 0) {
+    throw 'No target directory was found.'
+}
+
+$assetDir = Join-Path $env:RUNNER_TEMP "release-assets-$AssetKey"
+$portableDir = Join-Path $env:RUNNER_TEMP "portable-$AssetKey"
+if ((Test-Path -LiteralPath $assetDir) -or (Test-Path -LiteralPath $portableDir)) {
+    throw "Staging directory already exists for $AssetKey."
+}
+New-Item -ItemType Directory -Path $assetDir, $portableDir | Out-Null
+
+function Find-UniqueBundle {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Description,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BundleDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Extension
+    )
+
+    $escapedDirectory = [regex]::Escape("\bundle\$BundleDirectory\")
+    $bundleCandidates = @(
+        Get-ChildItem -Path $searchRoots -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.FullName -match $escapedDirectory -and
+                $_.Extension -eq $Extension -and
+                $_.Name.Contains($Version, [System.StringComparison]::Ordinal)
+            }
+    )
+    if ($bundleCandidates.Count -ne 1) {
+        $paths = ($bundleCandidates | ForEach-Object FullName) -join [Environment]::NewLine
+        throw "Expected exactly one $Description for version $Version, found $($bundleCandidates.Count).`n$paths"
+    }
+    return $bundleCandidates[0]
+}
+
+function Copy-StagedAsset {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.FileInfo]$Source
+    )
+
+    $architecturePattern = if ($AssetArch -eq 'x64') {
+        '(x64|amd64|x86_64)'
+    } else {
+        '(arm64|aarch64)'
+    }
+    if ($Source.Name -notmatch $architecturePattern) {
+        throw "$AssetArch asset name is missing an architecture marker: $($Source.Name)"
+    }
+
+    $destination = Join-Path $assetDir $Source.Name
+    if (Test-Path -LiteralPath $destination) {
+        throw "Duplicate staged asset name: $($Source.Name)"
+    }
+    Copy-Item -LiteralPath $Source.FullName -Destination $destination
+}
+
+$msiBundle = Find-UniqueBundle -Description 'Windows MSI bundle' -BundleDirectory 'msi' -Extension '.msi'
+$nsisBundle = Find-UniqueBundle -Description 'Windows NSIS bundle' -BundleDirectory 'nsis' -Extension '.exe'
+Copy-StagedAsset -Source $msiBundle
+Copy-StagedAsset -Source $nsisBundle
+
+$releaseExecutables = @(
+    Get-ChildItem -Path $searchRoots -Recurse -File -Filter 'sealantern.exe' -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.FullName -match '\\release\\sealantern\.exe$' -and
+            $_.FullName -notmatch '\\bundle\\'
+        }
+)
+if ($releaseExecutables.Count -ne 1) {
+    $paths = ($releaseExecutables | ForEach-Object FullName) -join [Environment]::NewLine
+    throw "Expected exactly one Windows executable, found $($releaseExecutables.Count).`n$paths"
+}
+
+$releaseDir = $releaseExecutables[0].DirectoryName
+Copy-Item -LiteralPath $releaseExecutables[0].FullName -Destination $portableDir
+Get-ChildItem -Path $releaseDir -File -Filter '*.dll' -ErrorAction SilentlyContinue |
+    ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $portableDir }
+Copy-Item -LiteralPath (Join-Path $repoDir 'LICENSE'), (Join-Path $repoDir 'NOTICE') -Destination $portableDir
+
+$portablePath = Join-Path $assetDir "Sea.Lantern_${Version}_windows_${AssetArch}_portable.zip"
+Compress-Archive -Path (Join-Path $portableDir '*') -DestinationPath $portablePath
+
+Write-Host "Staged Windows $AssetArch assets:"
+Get-ChildItem -Path $assetDir -File | Sort-Object Name | ForEach-Object FullName

--- a/scripts/ci/collect-assets.sh
+++ b/scripts/ci/collect-assets.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 4 ]]; then
+    echo "usage: collect-assets.sh <linux|macos> <version> <asset-arch> <asset-key>" >&2
+    exit 2
+fi
+
+readonly platform="$1"
+readonly version="$2"
+readonly asset_arch="$3"
+readonly asset_key="$4"
+readonly script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_dir="$(cd -- "${script_dir}/../.." && pwd)"
+
+if [[ "${platform}" != "linux" && "${platform}" != "macos" ]]; then
+    echo "unsupported platform: ${platform}" >&2
+    exit 2
+fi
+if [[ ! "${version}" =~ ^[0-9A-Za-z.+-]+$ ]]; then
+    echo "invalid version: ${version}" >&2
+    exit 2
+fi
+if [[ ! "${asset_arch}" =~ ^(x64|arm64)$ ]]; then
+    echo "invalid asset architecture: ${asset_arch}" >&2
+    exit 2
+fi
+if [[ ! "${asset_key}" =~ ^[a-z0-9-]+$ ]]; then
+    echo "invalid asset key: ${asset_key}" >&2
+    exit 2
+fi
+if [[ -z "${RUNNER_TEMP:-}" ]]; then
+    echo "RUNNER_TEMP is not set" >&2
+    exit 1
+fi
+
+readonly asset_dir="${RUNNER_TEMP}/release-assets-${asset_key}"
+readonly portable_dir="${RUNNER_TEMP}/portable-${asset_key}"
+search_roots=()
+
+for candidate in "${repo_dir}/target" "${repo_dir}/src-tauri/target"; do
+    if [[ -d "${candidate}" ]]; then
+        search_roots+=("${candidate}")
+    fi
+done
+if [[ "${#search_roots[@]}" -eq 0 ]]; then
+    echo "no target directory was found" >&2
+    exit 1
+fi
+if [[ -e "${asset_dir}" || -e "${portable_dir}" ]]; then
+    echo "staging directory already exists for ${asset_key}" >&2
+    exit 1
+fi
+mkdir -p "${asset_dir}" "${portable_dir}"
+
+stage_asset() {
+    local source_path="$1"
+    local source_name="$(basename "${source_path}")"
+    local destination_path="${asset_dir}/${source_name}"
+
+    if [[ ! -f "${source_path}" ]]; then
+        echo "asset is not a regular file: ${source_path}" >&2
+        exit 1
+    fi
+    case "${asset_arch}" in
+        x64)
+            if [[ ! "${source_name}" =~ (x64|amd64|x86_64) ]]; then
+                echo "x64 asset name is missing an architecture marker: ${source_name}" >&2
+                exit 1
+            fi
+            ;;
+        arm64)
+            if [[ ! "${source_name}" =~ (arm64|aarch64) ]]; then
+                echo "ARM64 asset name is missing an architecture marker: ${source_name}" >&2
+                exit 1
+            fi
+            ;;
+    esac
+    if [[ -e "${destination_path}" ]]; then
+        echo "duplicate staged asset name: ${source_name}" >&2
+        exit 1
+    fi
+    cp "${source_path}" "${destination_path}"
+}
+
+find_unique_file() {
+    local description="$1"
+    local name_pattern="$2"
+    local path_pattern="$3"
+    local require_version="${4:-true}"
+    local candidate
+    local -a matches=()
+
+    while IFS= read -r -d '' candidate; do
+        if [[ "${require_version}" == "false" || "$(basename "${candidate}")" == *"${version}"* ]]; then
+            matches+=("${candidate}")
+        fi
+    done < <(
+        find "${search_roots[@]}" -type f -name "${name_pattern}" -path "${path_pattern}" -print0 2>/dev/null
+    )
+
+    if [[ "${#matches[@]}" -ne 1 ]]; then
+        echo "expected exactly one ${description} for version ${version}, found ${#matches[@]}" >&2
+        if [[ "${#matches[@]}" -gt 0 ]]; then
+            printf '  %s\n' "${matches[@]}" >&2
+        fi
+        exit 1
+    fi
+    unique_file="${matches[0]}"
+}
+
+collect_linux_assets() {
+    find_unique_file "AppImage bundle" "*.AppImage" "*/bundle/appimage/*"
+    stage_asset "${unique_file}"
+    find_unique_file "Debian bundle" "*.deb" "*/bundle/deb/*"
+    stage_asset "${unique_file}"
+    find_unique_file "RPM bundle" "*.rpm" "*/bundle/rpm/*"
+    stage_asset "${unique_file}"
+}
+
+find_unique_app() {
+    local candidate
+    local -a apps=()
+
+    while IFS= read -r -d '' candidate; do
+        apps+=("${candidate}")
+    done < <(find "${search_roots[@]}" -type d -name '*.app' -path '*/bundle/macos/*.app' -print0 2>/dev/null)
+
+    if [[ "${#apps[@]}" -eq 0 ]]; then
+        return 1
+    fi
+    if [[ "${#apps[@]}" -gt 1 ]]; then
+        echo "expected exactly one macOS app bundle, found ${#apps[@]}" >&2
+        printf '  %s\n' "${apps[@]}" >&2
+        exit 1
+    fi
+    unique_app="${apps[0]}"
+}
+
+collect_macos_assets() {
+    local app_basename
+    local candidate
+    local extracted_app
+    local portable_path
+    local root_app
+    local -a extracted_apps=()
+
+    find_unique_file "macOS DMG bundle" "*.dmg" "*/bundle/dmg/*"
+    stage_asset "${unique_file}"
+
+    if find_unique_app; then
+        cp -R "${unique_app}" "${portable_dir}/"
+        app_basename="$(basename "${unique_app}")"
+    else
+        find_unique_file "macOS app archive" "*.app.tar.gz" "*/bundle/macos/*" false
+        tar -C "${portable_dir}" -xzf "${unique_file}"
+        while IFS= read -r -d '' candidate; do
+            extracted_apps+=("${candidate}")
+        done < <(find "${portable_dir}" -type d -name '*.app' -prune -print0)
+        if [[ "${#extracted_apps[@]}" -ne 1 ]]; then
+            echo "expected exactly one app bundle in the macOS app archive, found ${#extracted_apps[@]}" >&2
+            if [[ "${#extracted_apps[@]}" -gt 0 ]]; then
+                printf '  %s\n' "${extracted_apps[@]}" >&2
+            fi
+            exit 1
+        fi
+
+        extracted_app="${extracted_apps[0]}"
+        app_basename="$(basename "${extracted_app}")"
+        root_app="${portable_dir}/${app_basename}"
+        if [[ "${extracted_app}" != "${root_app}" ]]; then
+            if [[ -e "${root_app}" ]]; then
+                echo "cannot normalize the extracted app bundle because ${root_app} already exists" >&2
+                exit 1
+            fi
+            mv "${extracted_app}" "${root_app}"
+        fi
+    fi
+
+    cp "${repo_dir}/LICENSE" "${repo_dir}/NOTICE" "${portable_dir}/"
+    portable_path="${asset_dir}/Sea.Lantern_${version}_macos_${asset_arch}_portable.tar.gz"
+    tar -C "${portable_dir}" -czf "${portable_path}" "${app_basename}" LICENSE NOTICE
+}
+
+cd "${repo_dir}"
+case "${platform}" in
+    linux) collect_linux_assets ;;
+    macos) collect_macos_assets ;;
+esac
+
+echo "staged ${platform} ${asset_arch} assets:"
+find "${asset_dir}" -maxdepth 1 -type f -print | sort

--- a/scripts/ci/publish-assets.sh
+++ b/scripts/ci/publish-assets.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 7 ]]; then
+    echo "usage: publish-assets.sh <assets-dir> <tag> <release-name> <source-sha> <draft> <prerelease> <cleanup-tag-on-failure>" >&2
+    exit 2
+fi
+
+readonly assets_dir="$1"
+readonly tag="$2"
+readonly release_name="$3"
+readonly source_sha="$4"
+readonly draft="$5"
+readonly prerelease="$6"
+readonly cleanup_tag_on_failure="$7"
+
+if [[ "${draft}" != "true" && "${draft}" != "false" ]]; then
+    echo "draft must be true or false" >&2
+    exit 2
+fi
+if [[ "${prerelease}" != "true" && "${prerelease}" != "false" ]]; then
+    echo "prerelease must be true or false" >&2
+    exit 2
+fi
+if [[ "${cleanup_tag_on_failure}" != "true" && "${cleanup_tag_on_failure}" != "false" ]]; then
+    echo "cleanup-tag-on-failure must be true or false" >&2
+    exit 2
+fi
+
+for command_name in basename find gh grep jq mktemp rm sed sort uniq wc; do
+    if ! command -v "${command_name}" >/dev/null 2>&1; then
+        echo "required command not found: ${command_name}" >&2
+        exit 1
+    fi
+done
+if [[ ! -d "${assets_dir}" ]]; then
+    echo "assets directory not found: ${assets_dir}" >&2
+    exit 1
+fi
+if [[ -z "${GH_TOKEN:-}" || -z "${MATRIX_JSON:-}" ]]; then
+    echo "GH_TOKEN and MATRIX_JSON must be set" >&2
+    exit 1
+fi
+if ! jq -e '.include | type == "array" and length > 0' <<<"${MATRIX_JSON}" >/dev/null; then
+    echo "MATRIX_JSON does not contain a valid include matrix" >&2
+    exit 1
+fi
+
+mapfile -t expected_keys < <(jq -r '.include[].asset_key' <<<"${MATRIX_JSON}" | sort)
+if [[ "${#expected_keys[@]}" -ne "$(printf '%s\n' "${expected_keys[@]}" | uniq | wc -l)" ]]; then
+    echo "the platform matrix contains duplicate asset keys" >&2
+    exit 1
+fi
+
+for asset_key in "${expected_keys[@]}"; do
+    artifact_dir="${assets_dir}/release-assets-${asset_key}"
+    if [[ ! -d "${artifact_dir}" ]]; then
+        echo "missing workflow artifact directory: release-assets-${asset_key}" >&2
+        exit 1
+    fi
+    if ! find "${artifact_dir}" -maxdepth 1 -type f -print -quit | grep -q .; then
+        echo "workflow artifact is empty: release-assets-${asset_key}" >&2
+        exit 1
+    fi
+done
+
+while IFS= read -r artifact_dir; do
+    actual_key="$(basename -- "${artifact_dir}")"
+    actual_key="${actual_key#release-assets-}"
+    if ! jq -e --arg key "${actual_key}" '.include | any(.asset_key == $key)' \
+        <<<"${MATRIX_JSON}" >/dev/null; then
+        echo "unexpected workflow artifact directory: $(basename -- "${artifact_dir}")" >&2
+        exit 1
+    fi
+done < <(find "${assets_dir}" -mindepth 1 -maxdepth 1 -type d -name 'release-assets-*' | sort)
+
+mapfile -t assets < <(find "${assets_dir}" -mindepth 2 -maxdepth 2 -type f | sort)
+if [[ "${#assets[@]}" -eq 0 ]]; then
+    echo "no release assets were found" >&2
+    exit 1
+fi
+
+duplicates="$(printf '%s\n' "${assets[@]##*/}" | sort | uniq -d)"
+if [[ -n "${duplicates}" ]]; then
+    echo "duplicate release asset names were found:" >&2
+    while IFS= read -r duplicate; do
+        [[ -z "${duplicate}" ]] && continue
+        echo "  ${duplicate}" >&2
+        find "${assets_dir}" -type f -name "${duplicate}" -print | sed 's/^/    /' >&2
+    done <<<"${duplicates}"
+    exit 1
+fi
+
+notes_file="$(mktemp "${RUNNER_TEMP:-/tmp}/release-notes.XXXXXX.md")"
+cleanup() {
+    rm -f -- "${notes_file}"
+}
+trap cleanup EXIT
+printf '%s\n' "${RELEASE_BODY:-}" >"${notes_file}"
+
+printf 'publishing %s assets:\n' "${#assets[@]}"
+printf '  %s\n' "${assets[@]}"
+
+if release_json="$(gh release view "${tag}" --json isDraft 2>/dev/null)"; then
+    existing_draft="$(jq -r '.isDraft' <<<"${release_json}")"
+    if [[ "${draft}" == "true" && "${existing_draft}" != "true" ]]; then
+        echo "refusing to turn an existing published release back into a draft: ${tag}" >&2
+        exit 1
+    fi
+
+    gh release edit "${tag}" \
+        --title "${release_name}" \
+        --notes-file "${notes_file}" \
+        --prerelease="${prerelease}"
+    gh release upload "${tag}" "${assets[@]}" --clobber
+    if [[ "${existing_draft}" == "true" && "${draft}" == "false" ]]; then
+        gh release edit "${tag}" --draft=false --prerelease="${prerelease}"
+    fi
+else
+    release_flags=()
+    if [[ "${draft}" == "true" ]]; then
+        release_flags+=(--draft)
+    fi
+    if [[ "${prerelease}" == "true" ]]; then
+        release_flags+=(--prerelease)
+    fi
+    if ! gh release create "${tag}" "${assets[@]}" \
+        --target "${source_sha}" \
+        --title "${release_name}" \
+        --notes-file "${notes_file}" \
+        "${release_flags[@]}"; then
+        echo "release creation failed; removing any partial release or tag for ${tag}" >&2
+        cleanup_flags=(-y)
+        if [[ "${cleanup_tag_on_failure}" == "true" ]]; then
+            cleanup_flags+=(--cleanup-tag)
+        fi
+        gh release delete "${tag}" "${cleanup_flags[@]}" >/dev/null 2>&1 || true
+        exit 1
+    fi
+fi


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

nightly-release在构建之前添加了全平台测试矩阵，这样我们就可以通过手动触发来debug。

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

引入共享的跨平台构建矩阵和资产发布脚本，并围绕可复用的组合 Action 与基于构建产物的发布聚合，重构夜构与正式发布的工作流。

Build:
- 添加可复用的组合 Action，用于设置带可选缓存/重试的 Rust 工具链、配置带缓存存储的 pnpm，以及安装 Ubuntu 上的 Tauri 依赖。
- 引入以 JSON 定义的发布矩阵，同时用于夜构和打标签的发布工作流，以驱动平台/目标配置。
- 用共享脚本替代内联打包逻辑，这些脚本收集各平台特定的构建产物并通过 GitHub Releases 发布，确保资产集合和名称得到校验。

CI:
- 添加一个 test-nightly 任务，在夜构之前在共享的多平台矩阵上运行完整的前端和 Rust 检查。
- 将夜构和打标签发布拆分为独立的构建和发布任务：先按平台收集构建产物，再将其聚合到单个 GitHub Release 或草稿中。
- 将默认工作流权限降低为非发布任务的只读权限，并简化夜构清理逻辑以仅保留当前标签。
- 更新主检查工作流以使用共享的 Rust、pnpm 和 Linux 依赖安装 Action，并将对此类 Action 的变更视为触发后端/前端检查的条件。

Tests:
- 确保夜间 CI 在构建发布产物之前，针对 Linux、macOS 和 Windows 矩阵运行完整的 Rust 测试套件和前端检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a shared cross-platform build matrix and asset publishing scripts, and restructure nightly and release workflows around reusable composite actions and artifact-based release aggregation.

Build:
- Add reusable composite actions for setting up Rust toolchains with optional caching/retry, configuring pnpm with cached stores, and installing Ubuntu Tauri dependencies.
- Introduce a JSON-defined release matrix used by both nightly and tagged release workflows to drive platform/target configuration.
- Replace inline packaging logic with shared scripts that collect platform-specific build artifacts and publish them via GitHub Releases, ensuring validation of asset sets and names.

CI:
- Add a test-nightly job that runs full frontend and Rust checks on a shared multi-platform matrix before nightly builds.
- Split nightly and tagged releases into separate build and publish jobs that collect per-platform artifacts and then aggregate them into a single GitHub Release or draft.
- Reduce default workflow permissions to read-only for non-publishing jobs and simplify nightly cleanup to keep only the current tag.
- Update the main check workflow to use shared Rust, pnpm, and Linux dependency setup actions and to treat changes to these actions as triggering backend/frontend checks.

Tests:
- Ensure nightly CI runs full Rust test suites and frontend checks across Linux, macOS, and Windows matrices prior to building release artifacts.

</details>

CI：
- 引入 `test-nightly` 任务，在夜间构建之前，在多平台矩阵上运行完整的前端和 Rust 检查与测试。
- 将夜间构建拆分为 `build-tauri-nightly` 和 `publish-nightly` 任务，分别收集各平台的构建产物并上传到工作流，然后聚合为单个 GitHub Release。
- 在夜间流水线中统一 Linux、macOS 和 Windows 运行器上的缓存策略、pnpm 设置以及依赖安装方式。
- 调整 GitHub 工作流权限，将非发布任务的权限从 `contents: write` 降为 `contents: read`，并简化旧夜间版本的清理逻辑，仅依赖当前标签进行清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入共享的跨平台构建矩阵和资产发布脚本，并围绕可复用的组合 Action 与基于构建产物的发布聚合，重构夜构与正式发布的工作流。

Build:
- 添加可复用的组合 Action，用于设置带可选缓存/重试的 Rust 工具链、配置带缓存存储的 pnpm，以及安装 Ubuntu 上的 Tauri 依赖。
- 引入以 JSON 定义的发布矩阵，同时用于夜构和打标签的发布工作流，以驱动平台/目标配置。
- 用共享脚本替代内联打包逻辑，这些脚本收集各平台特定的构建产物并通过 GitHub Releases 发布，确保资产集合和名称得到校验。

CI:
- 添加一个 test-nightly 任务，在夜构之前在共享的多平台矩阵上运行完整的前端和 Rust 检查。
- 将夜构和打标签发布拆分为独立的构建和发布任务：先按平台收集构建产物，再将其聚合到单个 GitHub Release 或草稿中。
- 将默认工作流权限降低为非发布任务的只读权限，并简化夜构清理逻辑以仅保留当前标签。
- 更新主检查工作流以使用共享的 Rust、pnpm 和 Linux 依赖安装 Action，并将对此类 Action 的变更视为触发后端/前端检查的条件。

Tests:
- 确保夜间 CI 在构建发布产物之前，针对 Linux、macOS 和 Windows 矩阵运行完整的 Rust 测试套件和前端检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a shared cross-platform build matrix and asset publishing scripts, and restructure nightly and release workflows around reusable composite actions and artifact-based release aggregation.

Build:
- Add reusable composite actions for setting up Rust toolchains with optional caching/retry, configuring pnpm with cached stores, and installing Ubuntu Tauri dependencies.
- Introduce a JSON-defined release matrix used by both nightly and tagged release workflows to drive platform/target configuration.
- Replace inline packaging logic with shared scripts that collect platform-specific build artifacts and publish them via GitHub Releases, ensuring validation of asset sets and names.

CI:
- Add a test-nightly job that runs full frontend and Rust checks on a shared multi-platform matrix before nightly builds.
- Split nightly and tagged releases into separate build and publish jobs that collect per-platform artifacts and then aggregate them into a single GitHub Release or draft.
- Reduce default workflow permissions to read-only for non-publishing jobs and simplify nightly cleanup to keep only the current tag.
- Update the main check workflow to use shared Rust, pnpm, and Linux dependency setup actions and to treat changes to these actions as triggering backend/frontend checks.

Tests:
- Ensure nightly CI runs full Rust test suites and frontend checks across Linux, macOS, and Windows matrices prior to building release artifacts.

</details>

</details>