### PR TITLE
ci: 添加 Onlyfile 统一本地检查命令

### DIFF
--- a/Onlyfile
+++ b/Onlyfile
@@ -1,0 +1,62 @@
+// Onlyfile (Version: 0.0.7)
+//
+// 详情请见：https://github.com/KercyDing/only
+// 安装：`cargo install only`，详见 Repo README
+// vscode 插件：kercyding.onlyfile
+//
+// 项目终端执行 `only` 来查看所有命令
+
+# 启动开发模式
+dev():
+    pnpm tauri dev
+
+# 构建应用
+build():
+    pnpm tauri build
+
+# 格式化并检查前端
+front_check():
+    pnpm fmt:check
+    pnpm lint
+    pnpm build:check
+
+# 格式化并检查后端
+back_check():
+    cargo fmt --all -- --check
+    cargo check --workspace --all-targets
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# 执行全部检查
+check() & front_check & back_check:
+    echo "格式化和检查完成"
+
+# 运行测试
+test() ? @has("cargo-nextest"):
+    cargo nextest run --no-fail-fast
+
+test():
+    cargo test --all-targets --workspace
+
+# 运行本地 CI
+ci() & check & test:
+    echo "本地 CI 成功"
+
+# 清理构建产物
+clean():
+    rm -rf node_modules dist
+    echo "前端已清除"
+    cargo clean
+    echo "后端已清除"
+
+# 查看项目版本号
+show():
+    pnpm sv
+
+# 发版(仅Admin可用)
+publish(version):
+    pnpm cv {{ version }}
+    pnpm notice
+    only ci
+    git commit -am "chore: 升级到 {{ version }}"
+    git tag {{ version }}
+    git push --atomic origin HEAD {{ version }}

--- a/README-en.md
+++ b/README-en.md
@@ -63,11 +63,12 @@ The host-neutral `application` crate provides shared business orchestration. `sr
 
 Make sure the following tools are installed before you begin:
 
-| Dependency | Version |
-| ---------- | ------- |
-| Node.js    | 24 LTS  |
-| Rust       | stable  |
-| pnpm       | 9.15.9  |
+| Dependency      | Version |
+| --------------- | ------- |
+| Node.js         | 24 LTS  |
+| Rust            | stable  |
+| pnpm            | 9.15.9  |
+| Only (optional) | 0.0.7+  |
 
 For help setting up your development environment, see the [environment setup guide](https://docs.ideaflash.cn/en/dev/environment).
 
@@ -99,9 +100,29 @@ pnpm docker:dev
 
 Linux developers may need to install additional system dependencies required by Tauri. See the [Tauri prerequisites for Linux](https://tauri.app/start/prerequisites/#linux) for details.
 
+The repository includes an [`Onlyfile`](Onlyfile) that provides consistent commands for common development, build, and check tasks. Install [Only](https://github.com/KercyDing/only) when needed:
+
+```bash
+cargo install only
+```
+
+After installation, list all available tasks from the repository root:
+
+```bash
+only
+```
+
+Common commands include `only dev`, `only build`, `only check`, `only test`, and `only ci`.
+
 ### Code Quality Checks
 
-Before submitting changes, we **recommend** running the following checks:
+Before submitting changes, we **recommend** running the complete local CI suite:
+
+```bash
+only ci
+```
+
+This runs the frontend and backend static checks along with the full test suite. If Only is not installed, run the following commands separately:
 
 <details><summary>Frontend checks</summary>
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@
 
 开发前需要准备：
 
-| 依赖    | 版本   |
-| ------- | ------ |
-| Node.js | 24 LTS |
-| Rust    | stable |
-| pnpm    | 9.15.9 |
+| 依赖         | 版本   |
+| ------------ | ------ |
+| Node.js      | 24 LTS |
+| Rust         | stable |
+| pnpm         | 9.15.9 |
+| Only（可选） | 0.0.7+ |
 
 如果你还没有配置开发环境，可以先查看 [环境配置](https://docs.ideaflash.cn/zh/dev/environment)。
 
@@ -96,9 +97,29 @@ pnpm docker:dev
 
 如果你在 Linux 上开发，可能需要先安装 Tauri 相关系统依赖。具体请看 [Tauri Linux 前置要求](https://tauri.app/zh-cn/start/prerequisites/#linux)。
 
+仓库根目录提供了 [`Onlyfile`](Onlyfile)，用于统一常用的开发、构建和检查命令。可以按需安装 [Only](https://github.com/KercyDing/only)：
+
+```bash
+cargo install only
+```
+
+安装后，在项目根目录运行以下命令查看所有可用任务：
+
+```bash
+only
+```
+
+常用命令包括 `only dev`、`only build`、`only check`、`only test` 和 `only ci`。
+
 ### 代码检查
 
-提交代码前，我们**建议**运行以下命令来检查代码质量：
+提交代码前，我们**建议**运行完整的本地 CI：
+
+```bash
+only ci
+```
+
+该命令会执行前后端静态检查和全部测试；如果没有安装 Only，也可以分别运行以下命令：
 
 <details><summary>前端检查</summary>
 


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

添加本地 Onlyfile，方便开发人员开发。

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

在仓库级别引入一个 Onlyfile，以统一本地开发和 CI 命令，并在英文和中文 README 中记录其使用方法。

新功能：
- 添加一个 Onlyfile，为常见的开发、构建、检查、测试和 CI 工作流程提供统一命令。

改进：
- 在英文 README 中将 Only 记录为可选依赖，并描述常用的 Onlyfile 命令。
- 更新中文 README，将 Only 列为可选依赖，并解释推荐的基于 Onlyfile 的本地 CI 使用方式。

文档：
- 在英文和中文 README 中阐明使用 `only ci` 的推荐本地 CI 工作流程，以及在未安装 Only 时的备用方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a repository-level Onlyfile to standardize local development and CI commands and document its usage in both English and Chinese READMEs.

New Features:
- Add an Onlyfile providing unified commands for common development, build, check, test, and CI workflows.

Enhancements:
- Document Only as an optional dependency and describe common Onlyfile commands in the English README.
- Update the Chinese README to include Only as an optional dependency and explain recommended Onlyfile-based local CI usage.

Documentation:
- Clarify recommended local CI workflow using `only ci` and fallbacks when Only is not installed in both English and Chinese READMEs.

</details>