### PR TITLE
fix: 修复 macos 代理未使用问题

### DIFF
--- a/crates/infra/src/platform/locations.rs
+++ b/crates/infra/src/platform/locations.rs
@@ -23,6 +23,7 @@ const APP_DIR_NAME: &str = "SeaLantern";
 const APP_DIR_NAME_LOWERCASE: &str = "sea-lantern";
 
 /// 回退方案使用的隐藏目录名（Linux `$HOME` 回退、Windows 非 MSI 最终回退）。
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 const APP_DIR_HIDDEN: &str = ".sea-lantern";
 
 /// Docker 容器内的数据目录。

--- a/crates/infra/src/platform/proxy.rs
+++ b/crates/infra/src/platform/proxy.rs
@@ -140,7 +140,54 @@ fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> 
     ))
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+#[cfg(target_os = "macos")]
+fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    let settings = sysproxy::Sysproxy::get_proxy_settings().map_err(|source| {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            error = %source,
+            "failed to read macOS system proxy settings"
+        );
+        SystemProxyReadError::Read { source }
+    })?;
+    snapshot_from_macos_settings(&settings)
+}
+
+#[cfg(target_os = "macos")]
+fn snapshot_from_macos_settings(
+    settings: &sysproxy::MacosProxySettings,
+) -> Result<SystemProxySnapshot, SystemProxyReadError> {
+    if settings.auto_config.enable || settings.auto_discovery {
+        tracing::warn!(
+            target: "sealantern.infra.platform.proxy",
+            pac_enabled = settings.auto_config.enable,
+            auto_discovery_enabled = settings.auto_discovery,
+            "automatic system proxy configuration cannot be represented safely"
+        );
+        return Err(SystemProxyReadError::UnsupportedProxyKind);
+    }
+
+    let http_proxy = enabled_proxy_url(&settings.http)?;
+    let https_proxy = enabled_proxy_url(&settings.https)?;
+    if http_proxy.is_none() && https_proxy.is_none() {
+        if settings.socks.enable {
+            tracing::warn!(
+                target: "sealantern.infra.platform.proxy",
+                "SOCKS-only system proxy configuration is unsupported"
+            );
+            return Err(SystemProxyReadError::UnsupportedProxyKind);
+        }
+        return Ok(SystemProxySnapshot::direct());
+    }
+
+    let (no_proxy, skipped) = convert_bypass_rules(&settings.bypass);
+    report_skipped_bypass_rules(skipped);
+    Ok(SystemProxySnapshot::from_routes(
+        ProxyRoutes::split(http_proxy, https_proxy).with_no_proxy(no_proxy),
+    ))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
 fn platform_system_proxy() -> Result<SystemProxySnapshot, SystemProxyReadError> {
     Err(SystemProxyReadError::UnsupportedPlatform)
 }
@@ -179,12 +226,20 @@ fn diagnostic_proxy_host(host: &str) -> &str {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn optional_proxy_url(host: &str, port: u16) -> Result<Option<String>, SystemProxyReadError> {
     if host.trim().is_empty() {
         return Ok(None);
     }
     proxy_url(host, port).map(Some)
+}
+
+#[cfg(target_os = "macos")]
+fn enabled_proxy_url(proxy: &sysproxy::Sysproxy) -> Result<Option<String>, SystemProxyReadError> {
+    if !proxy.enable {
+        return Ok(None);
+    }
+    optional_proxy_url(&proxy.host, proxy.port)
 }
 
 fn proxy_url(host: &str, port: u16) -> Result<String, SystemProxyReadError> {
@@ -305,6 +360,11 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    fn macos_settings() -> sysproxy::MacosProxySettings {
+        sysproxy::MacosProxySettings::default()
+    }
+
     #[test]
     fn disabled_system_proxy_is_direct() {
         let snapshot = snapshot_from_sysproxy(&sysproxy::Sysproxy::default()).unwrap();
@@ -321,6 +381,54 @@ mod tests {
         assert_eq!(snapshot.routes().http_proxy(), Some("http://127.0.0.1:7890"));
         assert_eq!(snapshot.routes().https_proxy(), Some("http://127.0.0.1:7890"));
         assert_eq!(snapshot.routes().no_proxy(), &["localhost", ".example.com"]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_static_proxies_preserve_routes_and_bypass_rules() {
+        let mut settings = macos_settings();
+        settings.http = enabled_proxy("127.0.0.1", 7890, "");
+        settings.https = enabled_proxy("127.0.0.1", 7891, "");
+        settings.bypass = "localhost,*.example.com".into();
+
+        let snapshot = snapshot_from_macos_settings(&settings).unwrap();
+
+        assert_eq!(snapshot.routes().http_proxy(), Some("http://127.0.0.1:7890"));
+        assert_eq!(snapshot.routes().https_proxy(), Some("http://127.0.0.1:7891"));
+        assert_eq!(snapshot.routes().no_proxy(), &["localhost", ".example.com"]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_direct_settings_produce_direct_snapshot() {
+        let snapshot = snapshot_from_macos_settings(&macos_settings()).unwrap();
+
+        assert_eq!(snapshot, SystemProxySnapshot::direct());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_socks_only_settings_are_rejected() {
+        let mut settings = macos_settings();
+        settings.socks = enabled_proxy("127.0.0.1", 7892, "");
+
+        let result = snapshot_from_macos_settings(&settings);
+
+        assert!(matches!(result, Err(SystemProxyReadError::UnsupportedProxyKind)));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_automatic_proxy_settings_are_rejected() {
+        let mut settings = macos_settings();
+        settings.auto_config = sysproxy::Autoproxy {
+            enable: true,
+            url: "https://example.com/proxy.pac".into(),
+        };
+
+        let result = snapshot_from_macos_settings(&settings);
+
+        assert!(matches!(result, Err(SystemProxyReadError::UnsupportedProxyKind)));
     }
 
     #[test]

--- a/crates/vendor/sysproxy/src/lib.rs
+++ b/crates/vendor/sysproxy/src/lib.rs
@@ -21,6 +21,24 @@ pub struct Autoproxy {
     pub enable: bool,
 }
 
+/// Static and automatic proxy settings for the active macOS network service.
+#[cfg(target_os = "macos")]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MacosProxySettings {
+    /// HTTP proxy endpoint and enabled state.
+    pub http: Sysproxy,
+    /// HTTPS proxy endpoint and enabled state.
+    pub https: Sysproxy,
+    /// SOCKS proxy endpoint and enabled state.
+    pub socks: Sysproxy,
+    /// Proxy bypass rules joined with commas.
+    pub bypass: String,
+    /// PAC URL and enabled state.
+    pub auto_config: Autoproxy,
+    /// Whether Web Proxy Auto-Discovery is enabled.
+    pub auto_discovery: bool,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("failed to parse string `{0}`")]

--- a/crates/vendor/sysproxy/src/macos.rs
+++ b/crates/vendor/sysproxy/src/macos.rs
@@ -1,4 +1,4 @@
-use crate::{Autoproxy, Error, Result, Sysproxy};
+use crate::{Autoproxy, Error, MacosProxySettings, Result, Sysproxy};
 use log::debug;
 use std::{
     borrow::Cow,
@@ -81,6 +81,24 @@ impl ProxyType {
 }
 
 impl Sysproxy {
+    /// Read all proxy kinds for the active network service without collapsing
+    /// them into a single endpoint.
+    #[inline]
+    pub fn get_proxy_settings() -> Result<MacosProxySettings> {
+        let service_uuid = get_active_network_service_uuid()?;
+        let scp = SCPreferences::default(&CFString::new("sysproxy-rs"));
+        let proxies_dict = get_proxies_by_service_uuid(&scp, &service_uuid)?;
+
+        Ok(MacosProxySettings {
+            http: parse_proxies_from_dict(&proxies_dict, ProxyType::Http)?,
+            https: parse_proxies_from_dict(&proxies_dict, ProxyType::Https)?,
+            socks: parse_proxies_from_dict(&proxies_dict, ProxyType::Socks)?,
+            bypass: parse_bypass_from_dict(&proxies_dict)?.join(","),
+            auto_config: parse_proxyauto_from_dict(&proxies_dict)?,
+            auto_discovery: read_bool_flag(&proxies_dict, "ProxyAutoDiscoveryEnable"),
+        })
+    }
+
     #[inline]
     pub fn get_system_proxy() -> Result<Sysproxy> {
         let service_uuid = get_active_network_service_uuid()?;

--- a/src-tauri/src/desktop/window_effect.rs
+++ b/src-tauri/src/desktop/window_effect.rs
@@ -29,9 +29,9 @@ pub fn apply_acrylic(app: tauri::AppHandle, enabled: bool) -> Result<(), String>
 
     #[cfg(target_os = "macos")]
     {
-        use window_vibrancy::{apply_vibrancy, clear_vibrancy, NSVisualEffectView};
+        use window_vibrancy::{apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial};
         if enabled {
-            apply_vibrancy(&window, NSVisualEffectView::Sidebar, None, None)
+            apply_vibrancy(&window, NSVisualEffectMaterial::Sidebar, None, None)
                 .map_err(|e| format!("apply vibrancy failed: {e}"))?;
         } else {
             clear_vibrancy(&window).map_err(|e| format!("clear vibrancy failed: {e}"))?;


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [x] 基础设施 (CI/CD/部署)

## 变更摘要

 如题。

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

实现正确的 macOS 系统代理集成，并更新相关的平台特定行为。

新特性：
- 支持读取并将 macOS 系统代理设置转换为内部代理快照。

错误修复：
- 确保正确处理 macOS 系统代理设置，而不是将其视为不受支持的平台。

增强改进：
- 使 macOS 可选代理 URL 处理方式与 Linux 保持一致，并为不受支持的 macOS 代理配置（仅 SOCKS 和自动 PAC）添加校验。
- 调整 macOS 窗口的“毛玻璃”效果以使用更新的 `NSVisualEffectMaterial` API。
- 将隐藏的应用数据目录常量限制为仅在 Windows 和 Linux 目标上使用。

测试：
- 添加涵盖静态代理、直接连接设置、仅 SOCKS 配置以及自动代理设置的 macOS 专用测试用例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement proper macOS system proxy integration and update related platform-specific behavior.

New Features:
- Support reading and converting macOS system proxy settings into internal proxy snapshots.

Bug Fixes:
- Ensure macOS system proxy settings are honored instead of being treated as an unsupported platform.

Enhancements:
- Align macOS optional proxy URL handling with Linux and add validation for unsupported macOS proxy configurations (SOCKS-only and automatic PAC).
- Adjust macOS window vibrancy to use the updated NSVisualEffectMaterial API.
- Restrict the hidden application data directory constant to Windows and Linux targets only.

Tests:
- Add macOS-specific tests covering static proxies, direct settings, SOCKS-only configurations, and automatic proxy settings.

</details>