### PR TITLE
fix import modpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5351,6 +5351,7 @@ dependencies = [
  "sha2 0.10.9",
  "tokio",
  "tracing",
+ "uuid",
  "zip",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 tracing = "0.1"
+uuid = { version = "1", features = ["v4"] }
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]

--- a/crates/core/src/provisioning/import_modpack.rs
+++ b/crates/core/src/provisioning/import_modpack.rs
@@ -44,7 +44,7 @@ pub fn infer_source_type(path: &Path) -> SourceType {
 
 /// 整合包导入请求。
 #[derive(Debug, Clone, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 pub struct ImportModpackRequest {
     /// 实例名称。
     pub name: String,

--- a/crates/core/src/provisioning/import_modpack.rs
+++ b/crates/core/src/provisioning/import_modpack.rs
@@ -8,6 +8,8 @@
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use uuid::Uuid;
+
 use crate::instance::{InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
 
 /// 来源类型枚举。
@@ -112,15 +114,6 @@ pub struct ImportModpackResult {
     pub spec: InstanceSpec,
 }
 
-/// 生成实例 ID（时间戳毫秒）。
-fn generate_instance_id() -> String {
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
-    format!("{}", ts)
-}
-
 /// 构建实例规格。
 ///
 /// 根据 import 请求和有效的目录路径构建 `InstanceSpec`。
@@ -129,7 +122,7 @@ pub fn build_instance_spec(
     directory: &Path,
     startup_target: Option<PathBuf>,
 ) -> Result<InstanceSpec, ImportModpackError> {
-    let id = generate_instance_id();
+    let id = Uuid::new_v4().to_string();
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())

--- a/crates/core/src/provisioning/import_modpack.rs
+++ b/crates/core/src/provisioning/import_modpack.rs
@@ -1,0 +1,240 @@
+//! 整合包导入核心逻辑。
+//!
+//! 支持三种来源：
+//! - zip/tar.gz/tgz 压缩包：解压到 run_path
+//! - jar 单文件：复制到 run_path
+//! - 文件夹：直接引用原路径
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::instance::{InstanceError, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+
+/// 来源类型枚举。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceType {
+    /// zip/tar.gz/tgz 压缩包。
+    Archive,
+    /// 单个 jar 文件。
+    JarFile,
+    /// 已存在的文件夹。
+    Folder,
+}
+
+/// 根据路径扩展名推断来源类型。
+pub fn infer_source_type(path: &Path) -> SourceType {
+    let path_str = path.to_string_lossy().to_lowercase();
+
+    // .tar.gz 和 .tgz 必须先判断
+    if path_str.ends_with(".tar.gz") || path_str.ends_with(".tgz") {
+        return SourceType::Archive;
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_lowercase());
+
+    match ext.as_deref() {
+        Some("zip") => SourceType::Archive,
+        Some("jar") => SourceType::JarFile,
+        _ => SourceType::Folder,
+    }
+}
+
+/// 整合包导入请求。
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ImportModpackRequest {
+    /// 实例名称。
+    pub name: String,
+    /// 整合包来源（zip 路径或文件夹路径）。
+    pub modpack_path: PathBuf,
+    /// Java 可执行文件路径。
+    pub java_path: PathBuf,
+    /// 最大内存（MiB）。
+    pub max_memory: u32,
+    /// 最小内存（MiB）。
+    pub min_memory: u32,
+    /// 监听端口。
+    pub port: u16,
+    /// 启动模式。
+    pub startup_mode: String,
+    /// 启动目标文件路径（相对于 run_path）。
+    pub startup_file_path: Option<PathBuf>,
+    /// 核心类型（paper、forge 等）。
+    pub core_type: Option<String>,
+    /// Minecraft 版本。
+    pub mc_version: Option<String>,
+    /// 自定义启动命令。
+    pub custom_command: Option<String>,
+    /// 目标运行目录。
+    pub run_path: PathBuf,
+}
+
+/// 整合包导入错误。
+#[derive(Debug, Clone)]
+pub enum ImportModpackError {
+    /// 无效的启动模式。
+    InvalidStartupMode(String),
+    /// 无效的实例 ID。
+    InvalidInstanceId(InstanceError),
+    /// 解压失败。
+    ExtractFailed(String),
+    /// 创建目录失败。
+    CreateDirectoryFailed(String),
+    /// 复制文件失败。
+    CopyFailed(String),
+}
+
+impl std::fmt::Display for ImportModpackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidStartupMode(msg) => write!(f, "invalid startup mode: {msg}"),
+            Self::InvalidInstanceId(err) => write!(f, "invalid instance ID: {err}"),
+            Self::ExtractFailed(msg) => write!(f, "failed to extract archive: {msg}"),
+            Self::CreateDirectoryFailed(msg) => write!(f, "failed to create directory: {msg}"),
+            Self::CopyFailed(msg) => write!(f, "failed to copy file: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ImportModpackError {}
+
+/// 导入结果，包含有效的实例目录和启动目标。
+#[derive(Debug, Clone)]
+pub struct ImportModpackResult {
+    /// 有效的实例目录。
+    pub directory: PathBuf,
+    /// 启动目标路径。
+    pub startup_target: Option<PathBuf>,
+    /// 构建好的实例规格。
+    pub spec: InstanceSpec,
+}
+
+/// 生成实例 ID（时间戳毫秒）。
+fn generate_instance_id() -> String {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    format!("{}", ts)
+}
+
+/// 构建实例规格。
+///
+/// 根据 import 请求和有效的目录路径构建 `InstanceSpec`。
+pub fn build_instance_spec(
+    request: &ImportModpackRequest,
+    directory: &Path,
+    startup_target: Option<PathBuf>,
+) -> Result<InstanceSpec, ImportModpackError> {
+    let id = generate_instance_id();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let startup_mode = StartupMode::parse(&request.startup_mode)
+        .map_err(|error| ImportModpackError::InvalidStartupMode(error.to_string()))?;
+
+    let id = InstanceId::new(id).map_err(ImportModpackError::InvalidInstanceId)?;
+
+    Ok(InstanceSpec {
+        id,
+        name: request.name.clone(),
+        aliases: Vec::new(),
+        core_type: request.core_type.clone().unwrap_or_default(),
+        core_version: String::new(),
+        game_version: request.mc_version.clone().unwrap_or_default(),
+        directory: directory.to_path_buf(),
+        port: request.port,
+        max_memory_mib: request.max_memory,
+        min_memory_mib: request.min_memory,
+        created_at_unix_secs: now,
+        last_started_at_unix_secs: None,
+        server_metadata: None,
+        launch: LocalLaunch {
+            startup_mode,
+            startup_target,
+            custom_command: request.custom_command.clone(),
+            custom_executable: None,
+            custom_arguments: Vec::new(),
+            java_executable: Some(request.java_path.clone()),
+            jvm_arguments: Vec::new(),
+        },
+    })
+}
+
+/// 规划整合包导入。
+///
+/// 根据来源类型计算目标目录和启动目标，返回构建好的 `InstanceSpec`。
+/// 此函数不执行任何文件系统操作，仅做规划。
+pub fn plan_import_modpack(
+    request: &ImportModpackRequest,
+) -> Result<ImportModpackResult, ImportModpackError> {
+    let source_type = infer_source_type(&request.modpack_path);
+
+    let (directory, startup_target) = match source_type {
+        SourceType::Archive => {
+            // 解压到 run_path（调用者负责实际解压）
+            let target = request
+                .startup_file_path
+                .as_ref()
+                .map(|p| request.run_path.join(p));
+            (request.run_path.clone(), target)
+        }
+        SourceType::JarFile => {
+            // 复制 jar 到 run_path（调用者负责实际复制）
+            let jar_name = request
+                .modpack_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("server.jar");
+            let dest_path = request.run_path.join(jar_name);
+            (request.run_path.clone(), Some(dest_path))
+        }
+        SourceType::Folder => {
+            // 直接引用原目录
+            let target = request
+                .startup_file_path
+                .as_ref()
+                .map(|p| request.modpack_path.join(p));
+            (request.modpack_path.clone(), target)
+        }
+    };
+
+    let spec = build_instance_spec(request, &directory, startup_target.clone())?;
+
+    Ok(ImportModpackResult { directory, startup_target, spec })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_source_type_detects_zip() {
+        assert_eq!(infer_source_type(Path::new("/path/to/modpack.zip")), SourceType::Archive);
+    }
+
+    #[test]
+    fn infer_source_type_detects_jar() {
+        assert_eq!(infer_source_type(Path::new("/path/to/server.jar")), SourceType::JarFile);
+    }
+
+    #[test]
+    fn infer_source_type_detects_tar_gz() {
+        assert_eq!(infer_source_type(Path::new("/path/to/modpack.tar.gz")), SourceType::Archive);
+    }
+
+    #[test]
+    fn infer_source_type_detects_tgz() {
+        assert_eq!(infer_source_type(Path::new("/path/to/modpack.tgz")), SourceType::Archive);
+    }
+
+    #[test]
+    fn infer_source_type_detects_folder() {
+        assert_eq!(infer_source_type(Path::new("/path/to/server-folder")), SourceType::Folder);
+    }
+}

--- a/crates/core/src/provisioning/lib.rs
+++ b/crates/core/src/provisioning/lib.rs
@@ -3,6 +3,7 @@ pub mod core_parsing;
 pub mod create;
 pub mod existing;
 pub mod import_metadata;
+pub mod import_modpack;
 mod launch_adapter;
 pub mod modpack;
 pub mod run_dir;
@@ -24,6 +25,10 @@ pub use import_metadata::{
     ImportLaunchCandidate, LaunchProfilePolicy, ServerInspectionProjection,
     ServerInspectionProjectionOptions, apply_server_inspection,
     apply_server_inspection_with_options, inspect_and_apply_import_metadata,
+};
+pub use import_modpack::{
+    ImportModpackError, ImportModpackRequest, ImportModpackResult, SourceType, build_instance_spec,
+    infer_source_type, plan_import_modpack,
 };
 pub use modpack::{
     ModpackProvisionError, ModpackProvisionPlan, ModpackProvisionRequest, plan_modpack,

--- a/src-tauri/src/adapter/tauri/commands/instance.rs
+++ b/src-tauri/src/adapter/tauri/commands/instance.rs
@@ -7,17 +7,16 @@
 //! 错误统一为接口契约错误 [`InstanceServiceError`]，可序列化回前端，
 //! 不携带底层敏感细节。
 
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use sealantern_application::error::InstanceError;
 use sealantern_application::service::CoreInstanceService;
 use sealantern_application::services::AppServices;
-use sealantern_core::instance::{Instance, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
+use sealantern_core::instance::{Instance, InstanceId, InstanceSpec};
 use sealantern_core::provisioning::{
     ImportExistingServerError as CoreImportError, ImportExistingServerRequest,
-    SourceDirectoryError, build_import_spec, plan_existing_instance, source_directories_equal,
+    ImportModpackRequest, SourceDirectoryError, SourceType, build_import_spec, infer_source_type,
+    plan_existing_instance, plan_import_modpack, source_directories_equal,
     validate_source_directory,
 };
 use sealantern_infra::archive::extract_zip;
@@ -175,72 +174,6 @@ fn import_error(code: &'static str, message: impl Into<String>) -> ImportExistin
     }
 }
 
-// ============================================================================
-// import_modpack 命令实现
-// ============================================================================
-
-/// 来源类型枚举。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SourceType {
-    /// zip/tar.gz/tgz 压缩包。
-    Archive,
-    /// 单个 jar 文件。
-    JarFile,
-    /// 已存在的文件夹。
-    Folder,
-}
-
-/// 根据路径扩展名推断来源类型。
-fn infer_source_type(path: &std::path::Path) -> SourceType {
-    let path_str = path.to_string_lossy().to_lowercase();
-
-    // .tar.gz 和 .tgz 必须先判断
-    if path_str.ends_with(".tar.gz") || path_str.ends_with(".tgz") {
-        return SourceType::Archive;
-    }
-
-    let ext = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .map(|s| s.to_lowercase());
-
-    match ext.as_deref() {
-        Some("zip") => SourceType::Archive,
-        Some("jar") => SourceType::JarFile,
-        _ => SourceType::Folder,
-    }
-}
-
-/// 整合包导入请求。
-#[derive(Debug, Clone, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub struct ImportModpackRequest {
-    /// 实例名称。
-    pub name: String,
-    /// 整合包来源（zip 路径或文件夹路径）。
-    pub modpack_path: PathBuf,
-    /// Java 可执行文件路径。
-    pub java_path: PathBuf,
-    /// 最大内存（MiB）。
-    pub max_memory: u32,
-    /// 最小内存（MiB）。
-    pub min_memory: u32,
-    /// 监听端口。
-    pub port: u16,
-    /// 启动模式。
-    pub startup_mode: String,
-    /// 启动目标文件路径（相对于 run_path）。
-    pub startup_file_path: Option<PathBuf>,
-    /// 核心类型（paper、forge 等）。
-    pub core_type: Option<String>,
-    /// Minecraft 版本。
-    pub mc_version: Option<String>,
-    /// 自定义启动命令。
-    pub custom_command: Option<String>,
-    /// 目标运行目录。
-    pub run_path: PathBuf,
-}
-
 /// 整合包导入失败时返回给前端的错误。
 #[derive(Debug, serde::Serialize)]
 pub struct ImportModpackError {
@@ -266,61 +199,6 @@ fn modpack_error(code: &'static str, message: impl Into<String>) -> ImportModpac
     }
 }
 
-/// 生成实例 ID（时间戳毫秒）。
-fn generate_instance_id() -> String {
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
-    format!("{}", ts)
-}
-
-/// 构建 InstanceSpec。
-fn build_instance_spec(
-    request: &ImportModpackRequest,
-    directory: &std::path::Path,
-    startup_target: Option<PathBuf>,
-) -> Result<InstanceSpec, ImportModpackError> {
-    let id = generate_instance_id();
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
-    let startup_mode = StartupMode::parse(&request.startup_mode).map_err(|error| {
-        modpack_error("invalid_startup_mode", format!("invalid startup mode: {error}"))
-    })?;
-
-    let id = InstanceId::new(id).map_err(|error| {
-        modpack_error("invalid_instance_id", format!("failed to create instance ID: {error}"))
-    })?;
-
-    Ok(InstanceSpec {
-        id,
-        name: request.name.clone(),
-        aliases: Vec::new(),
-        core_type: request.core_type.clone().unwrap_or_default(),
-        core_version: String::new(),
-        game_version: request.mc_version.clone().unwrap_or_default(),
-        directory: directory.to_path_buf(),
-        port: request.port,
-        max_memory_mib: request.max_memory,
-        min_memory_mib: request.min_memory,
-        created_at_unix_secs: now,
-        last_started_at_unix_secs: None,
-        server_metadata: None,
-        launch: LocalLaunch {
-            startup_mode,
-            startup_target,
-            custom_command: request.custom_command.clone(),
-            custom_executable: None,
-            custom_arguments: Vec::new(),
-            java_executable: Some(request.java_path.clone()),
-            jvm_arguments: Vec::new(),
-        },
-    })
-}
-
 /// 导入整合包或服务器文件夹。
 ///
 /// 支持三种来源：
@@ -329,60 +207,57 @@ fn build_instance_spec(
 /// - 文件夹：直接引用原路径
 #[tauri::command(rename_all = "snake_case")]
 pub async fn import_modpack(request: ImportModpackRequest) -> Result<Instance, ImportModpackError> {
+    use sealantern_core::provisioning::ImportModpackError as CoreError;
+
     // 1. 判断来源类型
     let source_type = infer_source_type(&request.modpack_path);
 
-    // 2. 根据类型处理文件
-    let (effective_directory, startup_target) = match source_type {
+    // 2. 规划导入（构建 InstanceSpec）
+    let result = plan_import_modpack(&request).map_err(|error| match error {
+        CoreError::InvalidStartupMode(msg) => {
+            modpack_error("invalid_startup_mode", format!("invalid startup mode: {msg}"))
+        }
+        CoreError::InvalidInstanceId(err) => {
+            modpack_error("invalid_instance_id", format!("failed to create instance ID: {err}"))
+        }
+        CoreError::ExtractFailed(msg) => modpack_error("extract_failed", msg),
+        CoreError::CreateDirectoryFailed(msg) => modpack_error("create_directory_failed", msg),
+        CoreError::CopyFailed(msg) => modpack_error("copy_failed", msg),
+    })?;
+
+    // 3. 执行文件操作（根据来源类型）
+    match source_type {
         SourceType::Archive => {
             // 解压 zip/tar.gz 到 run_path
-            extract_zip(&request.modpack_path, &request.run_path).map_err(|error| {
+            extract_zip(&request.modpack_path, &result.directory).map_err(|error| {
                 modpack_error("extract_failed", format!("failed to extract archive: {error}"))
             })?;
-            let target = request
-                .startup_file_path
-                .as_ref()
-                .map(|p| request.run_path.join(p));
-            (request.run_path.clone(), target)
         }
         SourceType::JarFile => {
             // 创建 run_path 目录并复制 jar
-            std::fs::create_dir_all(&request.run_path).map_err(|error| {
+            std::fs::create_dir_all(&result.directory).map_err(|error| {
                 modpack_error(
                     "create_directory_failed",
                     format!("failed to create run directory: {error}"),
                 )
             })?;
-            let jar_name = request
-                .modpack_path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("server.jar");
-            let dest_path = request.run_path.join(jar_name);
-            std::fs::copy(&request.modpack_path, &dest_path).map_err(|error| {
-                modpack_error("copy_jar_failed", format!("failed to copy jar file: {error}"))
-            })?;
-            (request.run_path.clone(), Some(dest_path))
+            if let Some(ref dest_path) = result.startup_target {
+                std::fs::copy(&request.modpack_path, dest_path).map_err(|error| {
+                    modpack_error("copy_jar_failed", format!("failed to copy jar file: {error}"))
+                })?;
+            }
         }
         SourceType::Folder => {
-            // 直接引用原目录
-            let target = request
-                .startup_file_path
-                .as_ref()
-                .map(|p| request.modpack_path.join(p));
-            (request.modpack_path.clone(), target)
+            // 直接引用原目录，无需文件操作
         }
-    };
-
-    // 3. 构建 InstanceSpec
-    let spec = build_instance_spec(&request, &effective_directory, startup_target)?;
+    }
 
     // 4. 创建实例
     let service = instance_service()
         .await
         .map_err(|error| modpack_error("service_unavailable", error.to_string()))?;
     service
-        .create(spec)
+        .create(result.spec)
         .await
         .map_err(|error| modpack_error("create_failed", error.to_string()))
 }

--- a/src-tauri/src/adapter/tauri/commands/instance.rs
+++ b/src-tauri/src/adapter/tauri/commands/instance.rs
@@ -205,7 +205,7 @@ fn modpack_error(code: &'static str, message: impl Into<String>) -> ImportModpac
 /// - zip/tar.gz/tgz 压缩包：解压到 run_path
 /// - jar 单文件：复制到 run_path
 /// - 文件夹：直接引用原路径
-#[tauri::command(rename_all = "snake_case")]
+#[tauri::command(rename_all = "camelCase")]
 pub async fn import_modpack(request: ImportModpackRequest) -> Result<Instance, ImportModpackError> {
     use sealantern_core::provisioning::ImportModpackError as CoreError;
 

--- a/src-tauri/src/adapter/tauri/commands/instance.rs
+++ b/src-tauri/src/adapter/tauri/commands/instance.rs
@@ -7,17 +7,20 @@
 //! 错误统一为接口契约错误 [`InstanceServiceError`]，可序列化回前端，
 //! 不携带底层敏感细节。
 
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use sealantern_application::error::InstanceError;
 use sealantern_application::service::CoreInstanceService;
 use sealantern_application::services::AppServices;
-use sealantern_core::instance::{Instance, InstanceId, InstanceSpec};
+use sealantern_core::instance::{Instance, InstanceId, InstanceSpec, LocalLaunch, StartupMode};
 use sealantern_core::provisioning::{
     ImportExistingServerError as CoreImportError, ImportExistingServerRequest,
     SourceDirectoryError, build_import_spec, plan_existing_instance, source_directories_equal,
     validate_source_directory,
 };
+use sealantern_infra::archive::extract_zip;
 use sealantern_interface::{InstanceService, InstanceServiceError};
 
 /// 获取全局实例管理服务句柄（惰性初始化容器）。
@@ -170,4 +173,216 @@ fn import_error(code: &'static str, message: impl Into<String>) -> ImportExistin
         code: code.to_string(),
         message: message.into(),
     }
+}
+
+// ============================================================================
+// import_modpack 命令实现
+// ============================================================================
+
+/// 来源类型枚举。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SourceType {
+    /// zip/tar.gz/tgz 压缩包。
+    Archive,
+    /// 单个 jar 文件。
+    JarFile,
+    /// 已存在的文件夹。
+    Folder,
+}
+
+/// 根据路径扩展名推断来源类型。
+fn infer_source_type(path: &std::path::Path) -> SourceType {
+    let path_str = path.to_string_lossy().to_lowercase();
+
+    // .tar.gz 和 .tgz 必须先判断
+    if path_str.ends_with(".tar.gz") || path_str.ends_with(".tgz") {
+        return SourceType::Archive;
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_lowercase());
+
+    match ext.as_deref() {
+        Some("zip") => SourceType::Archive,
+        Some("jar") => SourceType::JarFile,
+        _ => SourceType::Folder,
+    }
+}
+
+/// 整合包导入请求。
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ImportModpackRequest {
+    /// 实例名称。
+    pub name: String,
+    /// 整合包来源（zip 路径或文件夹路径）。
+    pub modpack_path: PathBuf,
+    /// Java 可执行文件路径。
+    pub java_path: PathBuf,
+    /// 最大内存（MiB）。
+    pub max_memory: u32,
+    /// 最小内存（MiB）。
+    pub min_memory: u32,
+    /// 监听端口。
+    pub port: u16,
+    /// 启动模式。
+    pub startup_mode: String,
+    /// 启动目标文件路径（相对于 run_path）。
+    pub startup_file_path: Option<PathBuf>,
+    /// 核心类型（paper、forge 等）。
+    pub core_type: Option<String>,
+    /// Minecraft 版本。
+    pub mc_version: Option<String>,
+    /// 自定义启动命令。
+    pub custom_command: Option<String>,
+    /// 目标运行目录。
+    pub run_path: PathBuf,
+}
+
+/// 整合包导入失败时返回给前端的错误。
+#[derive(Debug, serde::Serialize)]
+pub struct ImportModpackError {
+    /// 稳定错误码（机器可读）。
+    pub code: String,
+    /// 人类可读消息。
+    pub message: String,
+}
+
+impl std::fmt::Display for ImportModpackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ImportModpackError {}
+
+/// 构造一个带稳定错误码的整合包导入错误。
+fn modpack_error(code: &'static str, message: impl Into<String>) -> ImportModpackError {
+    ImportModpackError {
+        code: code.to_string(),
+        message: message.into(),
+    }
+}
+
+/// 生成实例 ID（时间戳毫秒）。
+fn generate_instance_id() -> String {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    format!("{}", ts)
+}
+
+/// 构建 InstanceSpec。
+fn build_instance_spec(
+    request: &ImportModpackRequest,
+    directory: &std::path::Path,
+    startup_target: Option<PathBuf>,
+) -> Result<InstanceSpec, ImportModpackError> {
+    let id = generate_instance_id();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let startup_mode = StartupMode::parse(&request.startup_mode).map_err(|error| {
+        modpack_error("invalid_startup_mode", format!("invalid startup mode: {error}"))
+    })?;
+
+    let id = InstanceId::new(id).map_err(|error| {
+        modpack_error("invalid_instance_id", format!("failed to create instance ID: {error}"))
+    })?;
+
+    Ok(InstanceSpec {
+        id,
+        name: request.name.clone(),
+        aliases: Vec::new(),
+        core_type: request.core_type.clone().unwrap_or_default(),
+        core_version: String::new(),
+        game_version: request.mc_version.clone().unwrap_or_default(),
+        directory: directory.to_path_buf(),
+        port: request.port,
+        max_memory_mib: request.max_memory,
+        min_memory_mib: request.min_memory,
+        created_at_unix_secs: now,
+        last_started_at_unix_secs: None,
+        server_metadata: None,
+        launch: LocalLaunch {
+            startup_mode,
+            startup_target,
+            custom_command: request.custom_command.clone(),
+            custom_executable: None,
+            custom_arguments: Vec::new(),
+            java_executable: Some(request.java_path.clone()),
+            jvm_arguments: Vec::new(),
+        },
+    })
+}
+
+/// 导入整合包或服务器文件夹。
+///
+/// 支持三种来源：
+/// - zip/tar.gz/tgz 压缩包：解压到 run_path
+/// - jar 单文件：复制到 run_path
+/// - 文件夹：直接引用原路径
+#[tauri::command(rename_all = "snake_case")]
+pub async fn import_modpack(request: ImportModpackRequest) -> Result<Instance, ImportModpackError> {
+    // 1. 判断来源类型
+    let source_type = infer_source_type(&request.modpack_path);
+
+    // 2. 根据类型处理文件
+    let (effective_directory, startup_target) = match source_type {
+        SourceType::Archive => {
+            // 解压 zip/tar.gz 到 run_path
+            extract_zip(&request.modpack_path, &request.run_path).map_err(|error| {
+                modpack_error("extract_failed", format!("failed to extract archive: {error}"))
+            })?;
+            let target = request
+                .startup_file_path
+                .as_ref()
+                .map(|p| request.run_path.join(p));
+            (request.run_path.clone(), target)
+        }
+        SourceType::JarFile => {
+            // 创建 run_path 目录并复制 jar
+            std::fs::create_dir_all(&request.run_path).map_err(|error| {
+                modpack_error(
+                    "create_directory_failed",
+                    format!("failed to create run directory: {error}"),
+                )
+            })?;
+            let jar_name = request
+                .modpack_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("server.jar");
+            let dest_path = request.run_path.join(jar_name);
+            std::fs::copy(&request.modpack_path, &dest_path).map_err(|error| {
+                modpack_error("copy_jar_failed", format!("failed to copy jar file: {error}"))
+            })?;
+            (request.run_path.clone(), Some(dest_path))
+        }
+        SourceType::Folder => {
+            // 直接引用原目录
+            let target = request
+                .startup_file_path
+                .as_ref()
+                .map(|p| request.modpack_path.join(p));
+            (request.modpack_path.clone(), target)
+        }
+    };
+
+    // 3. 构建 InstanceSpec
+    let spec = build_instance_spec(&request, &effective_directory, startup_target)?;
+
+    // 4. 创建实例
+    let service = instance_service()
+        .await
+        .map_err(|error| modpack_error("service_unavailable", error.to_string()))?;
+    service
+        .create(spec)
+        .await
+        .map_err(|error| modpack_error("create_failed", error.to_string()))
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,8 +18,8 @@ use adapter::tauri::commands::cron::{
 };
 use adapter::tauri::commands::download::{download_cancel, download_create, download_query};
 use adapter::tauri::commands::instance::{
-    create_instance, delete_instance, get_instance, import_existing_server, list_instances,
-    rename_instance, update_instance_path,
+    create_instance, delete_instance, get_instance, import_existing_server, import_modpack,
+    list_instances, rename_instance, update_instance_path,
 };
 use adapter::tauri::commands::java::{java_detect, java_validate};
 use adapter::tauri::commands::logging::share_logs;
@@ -136,6 +136,7 @@ fn main() {
             delete_instance,
             get_instance,
             import_existing_server,
+            import_modpack,
             list_instances,
             rename_instance,
             update_instance_path,
@@ -290,6 +291,7 @@ mod tests {
         "rename_instance",
         "update_instance_path",
         "import_existing_server",
+        "import_modpack",
         "online_tunnel_host",
         "online_tunnel_join",
         "online_tunnel_status",

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -336,19 +336,21 @@ export const serverApi = {
     mcVersion?: string;
   }): Promise<ServerInstance> {
     return tauriInvoke("import_modpack", {
-      name: params.name,
-      modpackPath: params.modpackPath,
-      javaPath: params.javaPath,
-      maxMemory: params.maxMemory,
-      minMemory: params.minMemory,
-      port: params.port,
-      startupMode: params.startupMode,
-      onlineMode: params.onlineMode,
-      customCommand: params.customCommand,
-      runPath: params.runPath,
-      startupFilePath: params.startupFilePath,
-      coreType: params.coreType,
-      mcVersion: params.mcVersion,
+      request: {
+        name: params.name,
+        modpackPath: params.modpackPath,
+        javaPath: params.javaPath,
+        maxMemory: params.maxMemory,
+        minMemory: params.minMemory,
+        port: params.port,
+        startupMode: params.startupMode,
+        onlineMode: params.onlineMode,
+        customCommand: params.customCommand,
+        runPath: params.runPath,
+        startupFilePath: params.startupFilePath,
+        coreType: params.coreType,
+        mcVersion: params.mcVersion,
+      },
     });
   },
 


### PR DESCRIPTION
- **feat(import): 添加导入整合包命令实现**
- **feat(import): 添加整合包导入核心逻辑及相关功能**
- **fix(import): 修改导入请求的序列化格式为 camelCase**

<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [ ] 已阅读 `docs/CONTRIBUTING.md`
- [ ] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

添加对将整合包（modpack）作为实例导入的支持，包括核心规划逻辑以及连接到前端 API 的 Tauri 命令。

新功能：
- 引入整合包导入的核心配置逻辑，支持归档文件、jar 文件以及已有文件夹作为来源。
- 暴露一个新的 Tauri 命令用于导入整合包并创建实例，并向前端返回结构化错误信息。

错误修复：
- 调整 Tauri 的 `import_modpack` 命令，使其使用来自前端的 camelCase 请求序列化格式。

改进：
- 从核心配置库中重新导出新的整合包导入配置类型和辅助工具，以便更广泛地复用。
- 扩展实例命令的连接逻辑和主 Tauri 命令列表，将新的整合包导入能力包含在内。

测试：
- 为在确定整合包导入来源格式时的来源类型推断添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for importing modpacks as instances, including core planning logic and a Tauri command wired to the frontend API.

New Features:
- Introduce modpack import core provisioning logic supporting archive, jar file, and existing folder sources.
- Expose a new Tauri command to import modpacks and create instances, returning structured errors to the frontend.

Bug Fixes:
- Adjust the Tauri import_modpack command to use camelCase request serialization from the frontend.

Enhancements:
- Re-export new modpack import provisioning types and helpers from the core provisioning library for broader reuse.
- Extend instance command wiring and main Tauri command list to include the new modpack import capability.

Tests:
- Add unit tests for source type inference when determining modpack import source formats.

</details>