### PR TITLE
feat: 开发者模式回归

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,22 +62,7 @@ interface ServerStartFallbackEventPayload {
   reason: string;
 }
 
-// ============================================================
-// TODO: 请在后端重构完成后恢复
-// 临时开关：禁用右键捕获（开发调试用）
-// 原因：右键行为依赖后端 developer_mode 设置，但后端正在重构、
-//       暂时无法提供设置，导致开发者模式下右键仍被错误拦截。
-// 恢复方式：后端重构完成后，将 TEMP_DISABLE_CONTEXT_MENU_CAPTURE
-//          改为 false（或直接删除此开关及相关 return 分支）即可。
-// ============================================================
-const TEMP_DISABLE_CONTEXT_MENU_CAPTURE = true;
-
 async function handleGlobalContextMenu(event: MouseEvent) {
-  // TODO: 请在后端重构完成后恢复（临时禁用右键捕获，见上方开关说明）
-  if (TEMP_DISABLE_CONTEXT_MENU_CAPTURE) {
-    return;
-  }
-
   // 在浏览器环境（Docker 模式）下，不阻止右键菜单，允许开发者工具
   if (isBrowserEnv()) {
     return;

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -547,28 +547,18 @@ export function applyDeveloperMode(enabled: boolean): void {
 
 /**
  * 阻止右键菜单
- *
- * TODO: 请在后端重构完成后恢复（临时置空，开发调试用）
- * 拦截逻辑依赖后端 developer_mode 设置，但后端正在重构、
- * 暂时无法提供设置，为避免开发者模式下右键仍被拦截，
- * 暂时屏蔽此逻辑。恢复 `e.preventDefault()` 即可。
  */
-function blockContextMenu(_e: Event): void {
-  // TODO: 请在后端重构完成后恢复
-  // e.preventDefault();
+function blockContextMenu(e: Event): void {
+  e.preventDefault();
 }
 
 /**
  * 阻止开发者工具快捷键
- *
- * TODO: 请在后端重构完成后恢复（临时置空，开发调试用）
- * 原因同上，恢复 `e.preventDefault()` 即可。
  */
-function blockDevTools(_e: KeyboardEvent): void {
-  // TODO: 请在后端重构完成后恢复
-  // if (e.key === "F12") {
-  //   e.preventDefault();
-  // }
+function blockDevTools(e: KeyboardEvent): void {
+  if (e.key === "F12") {
+    e.preventDefault();
+  }
 }
 
 /**


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

恢复开发者模式下对浏览器上下文菜单和 F12 快捷键的限制。

New Features:
- 重新启用全局右键菜单拦截。
- 恢复对 F12 开发者工具快捷键的阻止。

Enhancements:
- 移除用于临时禁用全局右键菜单捕获的前端开关及相关逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

恢复开发者模式下对浏览器上下文菜单和 F12 快捷键的限制。

New Features:
- 重新启用全局右键菜单拦截。
- 恢复对 F12 开发者工具快捷键的阻止。

Enhancements:
- 移除用于临时禁用全局右键菜单捕获的前端开关及相关逻辑。

</details>

新功能：
- 重新启用通过全局处理程序阻止浏览器上下文菜单（右键菜单）。
- 在主题工具中重新启用对基于 F12 的开发者工具快捷键的阻止。

增强：
- 在开发者模式行为已恢复的情况下，移除用于禁用全局上下文菜单捕获的临时前端开关。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

恢复开发者模式下对浏览器上下文菜单和 F12 快捷键的限制。

New Features:
- 重新启用全局右键菜单拦截。
- 恢复对 F12 开发者工具快捷键的阻止。

Enhancements:
- 移除用于临时禁用全局右键菜单捕获的前端开关及相关逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

恢复开发者模式下对浏览器上下文菜单和 F12 快捷键的限制。

New Features:
- 重新启用全局右键菜单拦截。
- 恢复对 F12 开发者工具快捷键的阻止。

Enhancements:
- 移除用于临时禁用全局右键菜单捕获的前端开关及相关逻辑。

</details>

</details>