### PR TITLE
feat: 前端调试功能（__listen）

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,8 +64,11 @@ if (import.meta.env.DEV) {
     console.error("Unhandled Promise:", event.reason);
   });
 
-  // DEV 模式下将 invoke 挂载到 window，方便在浏览器控制台手动调用 Tauri 命令。
+  // DEV 模式下将 invoke 与 listen 挂载到 window，方便在浏览器控制台手动调用 Tauri 命令，并监听 Tauri 事件。
   // 例如触发崩溃报告测试：await window.__invoke("debug_panic")
+  // 例如监听服务器日志事件：
+  // let unlisten = await __listen("server-log-line", (event) => {console.log(event)});
+  // 使用 await unlisten(); 以取消监听。
   // 注意：此挂载仅在开发模式下存在，生产包中不会包含。
   (window as any).__invoke = invoke;
   (window as any).__listen = listen;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import App from "@src/App.vue";
 import router from "@src/router";
 import pinia from "@src/stores";
@@ -67,6 +68,7 @@ if (import.meta.env.DEV) {
   // 例如触发崩溃报告测试：await window.__invoke("debug_panic")
   // 注意：此挂载仅在开发模式下存在，生产包中不会包含。
   (window as any).__invoke = invoke;
+  (window as any).__listen = listen;
 }
 
 app.use(pinia);


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Sourcery 总结

新功能：
- 在开发模式下向前端暴露事件监听调试能力，便于通过 `window.__listen` 订阅 Tauri 事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- 在开发模式下向前端暴露 Tauri 事件监听能力，便于通过浏览器控制台订阅和取消订阅事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- 在开发模式下向前端暴露 Tauri 事件监听能力，便于通过浏览器控制台订阅和取消订阅事件。

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- 在开发模式下向前端暴露 Tauri 事件监听能力，便于通过浏览器控制台订阅和取消订阅事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- 在开发模式下向前端暴露 Tauri 事件监听能力，便于通过浏览器控制台订阅和取消订阅事件。

</details>

</details>

</details>