### PR TITLE
fix: 修改生成备份ID和目录创建逻辑以处理错误

### DIFF
--- a/crates/extra/src/backup/manager.rs
+++ b/crates/extra/src/backup/manager.rs
@@ -136,7 +136,7 @@ impl BackupManager {
         fs::create_dir_all(&server_backup_dir)?;
 
         // 生成备份信息
-        let backup_id = Self::generate_backup_id()?;
+        let backup_id = Self::generate_backup_id();
         let created_at = Utc::now();
         let name = request
             .name

--- a/crates/extra/src/backup/manager.rs
+++ b/crates/extra/src/backup/manager.rs
@@ -136,7 +136,7 @@ impl BackupManager {
         fs::create_dir_all(&server_backup_dir)?;
 
         // 生成备份信息
-        let backup_id = Self::generate_backup_id();
+        let backup_id = Self::generate_backup_id()?;
         let created_at = Utc::now();
         let name = request
             .name
@@ -242,7 +242,11 @@ impl BackupManager {
                 fs::create_dir_all(&dest_path)?;
                 self.copy_dir_all(&source_path, &dest_path)?;
             } else {
-                fs::create_dir_all(dest_path.parent().unwrap())?;
+                let parent = dest_path.parent().ok_or_else(|| {
+                    error!("目标路径无父目录: {:?}", dest_path);
+                    BackupError::Validation(format!("目标路径无父目录: {:?}", dest_path))
+                })?;
+                fs::create_dir_all(parent)?;
                 fs::copy(&source_path, &dest_path)?;
             }
         }
@@ -407,7 +411,11 @@ impl BackupManager {
                 fs::create_dir_all(&dest_path)?;
                 self.copy_dir_all(&source_path, &dest_path)?;
             } else {
-                fs::create_dir_all(dest_path.parent().unwrap())?;
+                let parent = dest_path.parent().ok_or_else(|| {
+                    error!("目标路径无父目录: {:?}", dest_path);
+                    BackupError::Validation(format!("目标路径无父目录: {:?}", dest_path))
+                })?;
+                fs::create_dir_all(parent)?;
                 fs::copy(&source_path, &dest_path)?;
             }
         }


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [ ] 已阅读 `docs/CONTRIBUTING.md`
- [ ] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

改进备份目标路径的处理逻辑，在验证失败时返回明确的错误信息，而不是触发 panic。

Bug Fixes:
- 将“备份目标路径缺少父目录”的情况视为验证错误进行处理，避免因路径解析失败而导致 panic。

Enhancements:
- 为备份目标目录的验证过程增加错误诊断日志，并将错误信息传递回备份流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径处理，在验证失败时返回明确错误而不是发生 panic。

Bug Fixes:
- 将备份目标路径缺少父目录的情况作为验证错误处理，避免因路径解析失败而触发 panic。

Enhancements:
- 为备份目标目录验证增加错误诊断日志，并将错误传递回备份流程。

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径的处理逻辑，在验证失败时返回明确的错误信息，而不是触发 panic。

Bug Fixes:
- 将“备份目标路径缺少父目录”的情况视为验证错误进行处理，避免因路径解析失败而导致 panic。

Enhancements:
- 为备份目标目录的验证过程增加错误诊断日志，并将错误信息传递回备份流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径处理，在验证失败时返回明确错误而不是发生 panic。

Bug Fixes:
- 将备份目标路径缺少父目录的情况作为验证错误处理，避免因路径解析失败而触发 panic。

Enhancements:
- 为备份目标目录验证增加错误诊断日志，并将错误传递回备份流程。

</details>

</details>

Bug Fixes（错误修复）：
- 将系统时钟故障和目标父目录缺失视为备份验证错误进行处理，而不是触发 panic。

Enhancements（增强）：
- 在备份工作流中传递备份 ID 生成和目标目录验证的错误，并加入诊断日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径的处理逻辑，在验证失败时返回明确的错误信息，而不是触发 panic。

Bug Fixes:
- 将“备份目标路径缺少父目录”的情况视为验证错误进行处理，避免因路径解析失败而导致 panic。

Enhancements:
- 为备份目标目录的验证过程增加错误诊断日志，并将错误信息传递回备份流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径处理，在验证失败时返回明确错误而不是发生 panic。

Bug Fixes:
- 将备份目标路径缺少父目录的情况作为验证错误处理，避免因路径解析失败而触发 panic。

Enhancements:
- 为备份目标目录验证增加错误诊断日志，并将错误传递回备份流程。

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径的处理逻辑，在验证失败时返回明确的错误信息，而不是触发 panic。

Bug Fixes:
- 将“备份目标路径缺少父目录”的情况视为验证错误进行处理，避免因路径解析失败而导致 panic。

Enhancements:
- 为备份目标目录的验证过程增加错误诊断日志，并将错误信息传递回备份流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进备份目标路径处理，在验证失败时返回明确错误而不是发生 panic。

Bug Fixes:
- 将备份目标路径缺少父目录的情况作为验证错误处理，避免因路径解析失败而触发 panic。

Enhancements:
- 为备份目标目录验证增加错误诊断日志，并将错误传递回备份流程。

</details>

</details>

</details>