### PR TITLE
fix(sidebar): 隐藏非开发者模式下的插件入口

### DIFF
--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -31,6 +31,21 @@ import {
 import logoSvg from "@assets/logo.svg";
 import { isMacOSPlatform } from "@utils/platform";
 
+/**
+ * TODO:在实现插件功能后恢复插件相关导航
+ *
+ * 当前：若未启用开发者模式 (settingsStore.settings.developer_mode)，隐藏所有插件相关导航：
+ *   - 静态导航项中的 "plugins" (/plugins, group="system")
+ *   - 插件管理导航 (pluginNavItems, 路径 /plugin/{plugin_id})
+ *   - 插件侧边栏项 (pluginStore.sidebarItems 相关)
+ *   - 导航分组中的 plugins-default 和 plugins-custom 组
+ *
+ * 恢复步骤：
+ * 1. 移除 navItems 计算属性中对 settingsStore.settings.developer_mode 的条件判断
+ * 2. 恢复 orderedNavGroups 中对 plugins-default 和 plugins-custom 组的渲染
+ * 3. 确认插件功能完整可用后，移除本 TODO:在实现插件功能后恢复插件相关导航 注释
+ */
+
 const iconMap: Record<string, LucideIcon> = {
   home: Home,
   plus: Plus,
@@ -219,30 +234,47 @@ const navItems = computed<NavItem[]>(() => {
     if (item.group === "server") result.push(item);
   }
 
-  // 3. 插件注册的导航项（在 main/server 和 system 之间）
-  const positioned = pluginStore.sidebarItems
-    .filter((i) => !i.isDefault && i.after)
-    .map(sidebarItemToNavItem);
+  // 3. 插件注册的导航项（在 main/server 和 system 之间）——仅开发者模式显示
+  if (settingsStore.settings.developer_mode) {
+    const positioned = pluginStore.sidebarItems
+      .filter((i) => !i.isDefault && i.after)
+      .map(sidebarItemToNavItem);
 
-  const unpositioned = pluginStore.sidebarItems
-    .filter((i) => !i.isDefault && !i.after)
-    .map(sidebarItemToNavItem);
+    const unpositioned = pluginStore.sidebarItems
+      .filter((i) => !i.isDefault && !i.after)
+      .map(sidebarItemToNavItem);
 
-  const defaultItems = pluginStore.sidebarItems
-    .filter((i) => i.isDefault)
-    .map(sidebarItemToNavItem);
+    const defaultItems = pluginStore.sidebarItems
+      .filter((i) => i.isDefault)
+      .map(sidebarItemToNavItem);
 
-  const handledPluginIds = new Set(pluginStore.sidebarItems.map((i) => i.pluginId));
-  const remainingPluginItems = pluginNavItems.value.filter(
-    (i) => !i.pluginId || !handledPluginIds.has(i.pluginId),
-  );
+    const handledPluginIds = new Set(pluginStore.sidebarItems.map((i) => i.pluginId));
+    const remainingPluginItems = pluginNavItems.value.filter(
+      (i) => !i.pluginId || !handledPluginIds.has(i.pluginId),
+    );
 
-  const pluginRegisteredItems = [...unpositioned, ...defaultItems, ...remainingPluginItems];
-  result.push(...pluginRegisteredItems);
+    const pluginRegisteredItems = [...unpositioned, ...defaultItems, ...remainingPluginItems];
+    result.push(...pluginRegisteredItems);
 
-  // 4. system 组：插件管理、联机、设置、帮助
+    // 处理有 after 定位的插件项（仅开发者模式）
+    for (const item of positioned) {
+      const targetIdx = result.findIndex((r) => r.name === item.after);
+      if (targetIdx !== -1) {
+        result.splice(targetIdx + 1, 0, item);
+      } else {
+        result.push(item);
+      }
+    }
+  }
+
+  // 4. system 组：插件管理、联机、设置、帮助——仅开发者模式显示插件管理
   for (const item of staticNavItems) {
-    if (item.group === "system") result.push(item);
+    if (item.group === "system") {
+      if (item.name === "plugins" && !settingsStore.settings.developer_mode) {
+        continue; // 跳过插件管理入口
+      }
+      result.push(item);
+    }
   }
 
   // 5. 开发者模式：仅当设置开启时展示测试工具入口
@@ -255,16 +287,6 @@ const navItems = computed<NavItem[]>(() => {
       label: i18n.t("common.dev_test"),
       group: "dev",
     });
-  }
-
-  // 处理有 after 定位的插件项
-  for (const item of positioned) {
-    const targetIdx = result.findIndex((r) => r.name === item.after);
-    if (targetIdx !== -1) {
-      result.splice(targetIdx + 1, 0, item);
-    } else {
-      result.push(item);
-    }
   }
 
   return result;
@@ -402,10 +424,18 @@ const orderedNavGroups = computed<NavGroup[]>(() => {
   for (const item of navItems.value) {
     const effectiveGroup = item.group;
     if (item.isPlugin && !item.after) {
-      // 插件自定义项单独成组
-      groups.push({ group: "plugins-custom", items: [item] });
-      currentGroup = null;
+      // 插件自定义项单独成组——仅开发者模式显示
+      if (settingsStore.settings.developer_mode) {
+        groups.push({ group: "plugins-custom", items: [item] });
+        currentGroup = null;
+      }
       continue;
+    }
+    if (effectiveGroup === "plugins-default" || effectiveGroup === "plugins-custom") {
+      // 插件默认/自定义分组仅在开发者模式下显示
+      if (!settingsStore.settings.developer_mode) {
+        continue;
+      }
     }
     if (!currentGroup || currentGroup.group !== effectiveGroup) {
       currentGroup = { group: effectiveGroup, items: [] };

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -43,7 +43,8 @@ import { isMacOSPlatform } from "@utils/platform";
  * 恢复步骤：
  * 1. 移除 navItems 计算属性中对 settingsStore.settings.developer_mode 的条件判断
  * 2. 恢复 orderedNavGroups 中对 plugins-default 和 plugins-custom 组的渲染
- * 3. 确认插件功能完整可用后，移除本 TODO:在实现插件功能后恢复插件相关导航 注释
+ * 3. 移除第 4 步新增的对静态 "plugins" 项的过滤条件
+ * 4. 确认插件功能完整可用后，移除本 TODO:在实现插件功能后恢复插件相关导航 注释
  */
 
 const iconMap: Record<string, LucideIcon> = {


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- navItems 中插件相关导航项（侧边栏项、插件管理入口）仅在开发者模式显示
- orderedNavGroups 中 plugins-default/plugins-custom 分组仅开发者模式显示

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Sourcery 总结

修复问题：
- 在非开发者模式下隐藏插件相关导航入口，避免用户访问尚未完整可用的插件功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 在禁用开发者模式时隐藏与插件相关的侧边栏和导航项，防止访问不完整的插件功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 在非开发者模式下隐藏插件侧边栏、插件管理入口及相关导航分组，避免用户访问尚未完整可用的插件功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 在非开发者模式下隐藏插件侧边栏、插件管理入口及相关导航分组，避免用户访问尚未完整可用的插件功能。

</details>

</details>

</details>