### PR TITLE
feat(desktop): 添加 desktop_open_folder Tauri 命令

### DIFF
--- a/src-tauri/src/desktop/dialog.rs
+++ b/src-tauri/src/desktop/dialog.rs
@@ -3,7 +3,7 @@
 //! 实现 system 模块的文件选择、保存与文件夹选择接口：
 //! `desktop_pick_jar_file` / `desktop_pick_archive_file` / `desktop_pick_startup_file` /
 //! `desktop_pick_server_executable` / `desktop_pick_java_file` / `desktop_pick_save_file` /
-//! `desktop_pick_folder` / `desktop_pick_image_file`。
+//! `desktop_pick_folder` / `desktop_pick_image_file` / `desktop_open_folder`。
 //!
 //! 对话框由 `tauri-plugin-dialog` 提供，采用回调 + 通道转发结果：
 //! 选中返回路径字符串，取消返回 `null`。
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::sync::mpsc;
 
 use tauri_plugin_dialog::DialogExt;
+use tauri_plugin_opener::OpenerExt;
 
 /// 打开系统文件选择器选择 JAR 文件。
 ///
@@ -206,4 +207,32 @@ pub fn desktop_pick_image_file(app: tauri::AppHandle) -> Result<Option<String>, 
         });
 
     rx.recv().map_err(|e| format!("Dialog error: {}", e))
+}
+
+/// 在系统文件管理器中打开指定文件夹路径。
+///
+/// 使用 `tauri-plugin-opener` 打开文件夹，成功返回 `true`，失败返回错误信息。
+#[tauri::command(rename_all = "snake_case")]
+pub fn desktop_open_folder(app: tauri::AppHandle, path: String) -> Result<bool, String> {
+    let path_buf = Path::new(&path);
+
+    if !path_buf.exists() {
+        return Err(format!("Path does not exist: {}", path));
+    }
+
+    if !path_buf.is_dir() {
+        return Err(format!("Path is not a directory: {}", path));
+    }
+
+    // open_path 需要实现 Into<String> 的类型，将 PathBuf 转为字符串
+    let path_str = path_buf
+        .to_str()
+        .ok_or_else(|| "Invalid path: contains non-UTF-8 characters".to_string())?
+        .to_string();
+
+    app.opener()
+        .open_path(path_str, None::<&str>)
+        .map_err(|e| format!("Failed to open folder: {}", e))?;
+
+    Ok(true)
 }

--- a/src-tauri/src/desktop/mod.rs
+++ b/src-tauri/src/desktop/mod.rs
@@ -12,9 +12,9 @@ pub mod tray;
 pub mod window_state;
 
 pub use dialog::{
-    desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
-    desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
-    desktop_pick_startup_file,
+    desktop_open_folder, desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file,
+    desktop_pick_jar_file, desktop_pick_java_file, desktop_pick_save_file,
+    desktop_pick_server_executable, desktop_pick_startup_file,
 };
 
 pub use auto_lightweight::AutoLightweightState;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -64,10 +64,10 @@ use adapter::tauri::commands::update_install::{
 use adapter::tauri::events::LogSenderState;
 use desktop::{
     AutoLightweightState, DesktopAppearanceState, MainWindowState, apply_acrylic,
-    desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file, desktop_pick_jar_file,
-    desktop_pick_java_file, desktop_pick_save_file, desktop_pick_server_executable,
-    desktop_pick_startup_file, hide_main_window, restore_main_window, set_window_material,
-    supports_liquid_glass, toggle_light_weight,
+    desktop_open_folder, desktop_pick_archive_file, desktop_pick_folder, desktop_pick_image_file,
+    desktop_pick_jar_file, desktop_pick_java_file, desktop_pick_save_file,
+    desktop_pick_server_executable, desktop_pick_startup_file, hide_main_window,
+    restore_main_window, set_window_material, supports_liquid_glass, toggle_light_weight,
 };
 
 fn window_state_flags() -> tauri_plugin_window_state::StateFlags {
@@ -104,6 +104,7 @@ fn main() {
         .manage(LogSenderState::new())
         .invoke_handler(tauri::generate_handler![
             //桌面端能力（由desktop/dialog提供）
+            desktop_open_folder,
             desktop_pick_archive_file,
             desktop_pick_folder,
             desktop_pick_image_file,

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -300,7 +300,7 @@ export const systemApi = {
     if (isUploadSupported()) {
       throw new Error("Docker环境不支持从浏览器直接打开本地文件夹");
     }
-    return tauriInvoke("open_folder", { path });
+    return tauriInvoke("desktop_open_folder", { path });
   },
 
   async getDefaultRunPath(): Promise<string> {


### PR DESCRIPTION
## Checklist

- [x] 已阅读 `docs/CONTRIBUTING.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

- dialog.rs: 实现 desktop_open_folder 命令，使用 tauri-plugin-opener 在系统文件管理器打开指定文件夹
- mod.rs: 重新导出新命令
- main.rs: 注册命令到 invoke_handler
- system.ts: 前端 API 调用名同步更新为 desktop_open_folder

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Sourcery 摘要

支持桌面客户端通过系统文件管理器打开经过验证的本地文件夹。

新功能：
- 添加桌面命令，以便在系统文件管理器中打开现有文件夹。

增强：
- 使前端系统 API 与新的桌面文件夹打开命令保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable desktop clients to open validated local folders through the system file manager.

New Features:
- Add a desktop command to open an existing folder in the system file manager.

Enhancements:
- Align the frontend system API with the new desktop folder-opening command.

</details>