### PR TITLE
feat(config): harden persistence and startup migration

### DIFF
--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -100,6 +100,7 @@ impl AppServices {
     /// 独立服务图的构造器，不是进程级共享入口。构造后的句柄应通过宿主
     /// 状态显式传给 handler / command，而不是在业务代码中重复构造。
     pub async fn build() -> Result<Self, InstanceError> {
+        sealantern_feature::config::data_migration::run_startup_migration().await;
         let services = Self::from_inner(CoreInstanceService::new().await?);
         services.start_background_services().await;
         Ok(services)

--- a/application/src/services.rs
+++ b/application/src/services.rs
@@ -100,7 +100,7 @@ impl AppServices {
     /// 独立服务图的构造器，不是进程级共享入口。构造后的句柄应通过宿主
     /// 状态显式传给 handler / command，而不是在业务代码中重复构造。
     pub async fn build() -> Result<Self, InstanceError> {
-        sealantern_feature::config::data_migration::run_startup_migration().await;
+        sealantern_feature::config::data_migration::run_startup_migration().await?;
         let services = Self::from_inner(CoreInstanceService::new().await?);
         services.start_background_services().await;
         Ok(services)

--- a/crates/feature/src/config/data_migration.rs
+++ b/crates/feature/src/config/data_migration.rs
@@ -13,9 +13,11 @@
 use std::path::{Path, PathBuf};
 
 use crate::observability;
+use sealantern_infra::fs::{DataLimit, FileLock, read_string_limited};
 use sealantern_infra::platform::get_app_data_dir;
 
 const APP_DATA_LOCATOR_FILE: &str = "data_dir.json";
+const LOCATOR_READ_LIMIT: DataLimit = DataLimit::new(64 * 1024);
 
 /// 迁移过程的条目统计。
 #[derive(Debug, Default, Clone, Copy)]
@@ -40,37 +42,58 @@ struct MigrationStats {
 pub async fn run_startup_migration() {
     let default_dir = get_app_data_dir();
     let locator_path = default_dir.join(APP_DATA_LOCATOR_FILE);
+    run_startup_migration_at(&locator_path, &default_dir).await;
+}
+
+async fn run_startup_migration_at(locator_path: &Path, default_dir: &Path) {
+    // Tauri 和 HTTP 宿主可能同时启动，定位器锁覆盖检测、搬迁和清理全过程。
+    let _lock = match lock_locator(locator_path).await {
+        Ok(lock) => lock,
+        Err(error) => {
+            observability::config_migration_failed(&error);
+            return;
+        }
+    };
 
     if !locator_path.exists() {
         return;
     }
 
     // 读取定位器中的旧数据目录
-    let old_dir = match read_locator(&locator_path).await {
+    let old_dir = match read_locator(locator_path).await {
         Some(dir) if dir != default_dir => dir,
         None => {
-            observability::config_locator_unreadable(&locator_path);
+            observability::config_locator_unreadable(locator_path);
             return;
         }
         _ => {
             // 定位器指向的就是默认目录，不需要迁移，清理文件即可
-            if let Err(e) = std::fs::remove_file(&locator_path) {
-                observability::config_locator_cleanup_failed(&locator_path, &e);
+            if let Err(e) = tokio::fs::remove_file(locator_path).await {
+                observability::config_locator_cleanup_failed(locator_path, &e);
             }
             return;
         }
     };
 
-    observability::config_migration_started(&old_dir, &default_dir);
+    if !old_dir.exists() {
+        observability::config_migration_failed(&format!(
+            "旧数据目录 '{}' 不存在，保留定位器文件 '{}'",
+            old_dir.display(),
+            locator_path.display()
+        ));
+        return;
+    }
+
+    observability::config_migration_started(&old_dir, default_dir);
 
     // 搬迁数据：将旧目录下的内容复制到默认目录
-    match migrate_data_dir(&old_dir, &default_dir).await {
+    match migrate_data_dir(&old_dir, default_dir).await {
         Ok(stats) => {
             observability::config_migration_summary(stats.files_copied, stats.dirs_copied);
 
             // 删除定位器文件
-            if let Err(e) = std::fs::remove_file(&locator_path) {
-                observability::config_locator_cleanup_failed(&locator_path, &e);
+            if let Err(e) = tokio::fs::remove_file(locator_path).await {
+                observability::config_locator_cleanup_failed(locator_path, &e);
             } else {
                 observability::config_migration_completed();
             }
@@ -83,7 +106,7 @@ pub async fn run_startup_migration() {
 
 /// 从定位器文件读取自定义路径
 async fn read_locator(path: &Path) -> Option<PathBuf> {
-    let content = tokio::fs::read_to_string(path).await.ok()?;
+    let content = read_string_limited(path, LOCATOR_READ_LIMIT).await.ok()?;
     let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
     let dir = parsed.get("data_dir")?.as_str()?;
     let trimmed = dir.trim();
@@ -92,6 +115,14 @@ async fn read_locator(path: &Path) -> Option<PathBuf> {
     } else {
         Some(PathBuf::from(trimmed))
     }
+}
+
+async fn lock_locator(path: &Path) -> Result<FileLock, String> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || FileLock::try_acquire(path))
+        .await
+        .map_err(|error| format!("获取数据目录定位器锁失败: {error}"))?
+        .map_err(|error| error.to_string())
 }
 
 /// 搬迁数据目录内容（重命名源目录 + 复制 + 清理迁移源）。
@@ -105,14 +136,12 @@ async fn read_locator(path: &Path) -> Option<PathBuf> {
 /// 5. 复制成功则清理迁移源（清理失败仅告警，数据已完整迁移）；
 ///    复制失败则回滚重命名，保留旧目录原样（回滚失败必须告警）。
 async fn migrate_data_dir(src: &Path, dst: &Path) -> Result<MigrationStats, String> {
-    let mut stats = MigrationStats::default();
-
     // 崩溃残留恢复：上次迁移中断时 src 可能已被重命名走，先恢复原名再继续，
     // 否则上层会误判"无需迁移"并删除定位器，导致旧数据永久失联
     recover_interrupted_migration(src).await?;
 
     if !src.exists() {
-        return Ok(stats); // 旧目录不存在，无需搬迁
+        return Err(format!("旧数据目录 '{}' 不存在，无法完成迁移", src.display()));
     }
 
     // S1: 源/目标不能存在包含关系，否则递归复制会膨胀、删除会误删数据树
@@ -144,15 +173,13 @@ async fn migrate_data_dir(src: &Path, dst: &Path) -> Result<MigrationStats, Stri
     // 从迁移源复制到目标
     match copy_dir_recursive(staged.clone(), dst.to_path_buf()).await {
         Ok(sub) => {
-            stats = sub;
-
             // 复制成功，清理迁移源；清理失败不影响迁移结果（数据已在目标），
             // 仅告警，残留目录留待下次启动时由残留恢复逻辑处理
             if let Err(e) = tokio::fs::remove_dir_all(&staged).await {
                 observability::config_migration_cleanup_failed(&staged, &e);
             }
 
-            Ok(stats)
+            Ok(sub)
         }
         Err(e) => {
             // 复制失败：回滚重命名，保留旧目录原样；回滚失败必须告警，
@@ -264,4 +291,66 @@ fn copy_dir_recursive(
 
         Ok(stats)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn startup_migration_moves_files_and_removes_locator() {
+        let root = tempfile::tempdir().expect("temporary migration directory should be created");
+        let default_dir = root.path().join("default");
+        let old_dir = root.path().join("old");
+        let locator = default_dir.join(APP_DATA_LOCATOR_FILE);
+        tokio::fs::create_dir_all(&old_dir)
+            .await
+            .expect("old data directory should be created");
+        tokio::fs::write(old_dir.join("settings.json"), "{\"ok\":true}")
+            .await
+            .expect("old data should be written");
+        tokio::fs::create_dir_all(&default_dir)
+            .await
+            .expect("default data directory should be created");
+        tokio::fs::write(
+            &locator,
+            serde_json::to_vec(&serde_json::json!({ "data_dir": old_dir }))
+                .expect("locator should be encoded"),
+        )
+        .await
+        .expect("locator should be written");
+
+        run_startup_migration_at(&locator, &default_dir).await;
+
+        assert_eq!(
+            tokio::fs::read_to_string(default_dir.join("settings.json"))
+                .await
+                .expect("migrated data should be readable"),
+            "{\"ok\":true}"
+        );
+        assert!(!locator.exists(), "completed migration should remove locator");
+        assert!(!old_dir.exists(), "completed migration should clean old directory");
+    }
+
+    #[tokio::test]
+    async fn missing_migration_source_keeps_locator() {
+        let root = tempfile::tempdir().expect("temporary migration directory should be created");
+        let default_dir = root.path().join("default");
+        let old_dir = root.path().join("missing");
+        let locator = default_dir.join(APP_DATA_LOCATOR_FILE);
+        tokio::fs::create_dir_all(&default_dir)
+            .await
+            .expect("default data directory should be created");
+        tokio::fs::write(
+            &locator,
+            serde_json::to_vec(&serde_json::json!({ "data_dir": old_dir }))
+                .expect("locator should be encoded"),
+        )
+        .await
+        .expect("locator should be written");
+
+        run_startup_migration_at(&locator, &default_dir).await;
+
+        assert!(locator.exists(), "missing source should not discard locator");
+    }
 }

--- a/crates/feature/src/config/data_migration.rs
+++ b/crates/feature/src/config/data_migration.rs
@@ -13,11 +13,13 @@
 use std::path::{Path, PathBuf};
 
 use crate::observability;
-use sealantern_infra::fs::{DataLimit, FileLock, read_string_limited};
+use sealantern_infra::fs::{DataLimit, FileLock, FsError, read_string_limited};
 use sealantern_infra::platform::get_app_data_dir;
 
 const APP_DATA_LOCATOR_FILE: &str = "data_dir.json";
 const LOCATOR_READ_LIMIT: DataLimit = DataLimit::new(64 * 1024);
+const LOCATOR_LOCK_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
+const LOCATOR_LOCK_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// 迁移过程的条目统计。
 #[derive(Debug, Default, Clone, Copy)]
@@ -39,24 +41,25 @@ struct MigrationStats {
 /// 环境变量 `SEALANTERN_DATA_DIR` 不受此迁移影响（优先级更高）。
 ///
 /// 迁移使用异步文件 I/O，避免大数据目录阻塞启动线程。
-pub async fn run_startup_migration() {
+pub async fn run_startup_migration() -> Result<(), FsError> {
     let default_dir = get_app_data_dir();
     let locator_path = default_dir.join(APP_DATA_LOCATOR_FILE);
-    run_startup_migration_at(&locator_path, &default_dir).await;
+    run_startup_migration_at(&locator_path, &default_dir).await
 }
 
-async fn run_startup_migration_at(locator_path: &Path, default_dir: &Path) {
+async fn run_startup_migration_at(locator_path: &Path, default_dir: &Path) -> Result<(), FsError> {
     // Tauri 和 HTTP 宿主可能同时启动，定位器锁覆盖检测、搬迁和清理全过程。
-    let _lock = match lock_locator(locator_path).await {
+    // 锁竞争必须等待，不能让调用方在迁移完成前加载默认配置。
+    let _lock = match lock_locator_with_retry(locator_path).await {
         Ok(lock) => lock,
         Err(error) => {
             observability::config_migration_failed(&error);
-            return;
+            return Err(error);
         }
     };
 
     if !locator_path.exists() {
-        return;
+        return Ok(());
     }
 
     // 读取定位器中的旧数据目录
@@ -64,14 +67,14 @@ async fn run_startup_migration_at(locator_path: &Path, default_dir: &Path) {
         Some(dir) if dir != default_dir => dir,
         None => {
             observability::config_locator_unreadable(locator_path);
-            return;
+            return Ok(());
         }
         _ => {
             // 定位器指向的就是默认目录，不需要迁移，清理文件即可
             if let Err(e) = tokio::fs::remove_file(locator_path).await {
                 observability::config_locator_cleanup_failed(locator_path, &e);
             }
-            return;
+            return Ok(());
         }
     };
 
@@ -81,7 +84,7 @@ async fn run_startup_migration_at(locator_path: &Path, default_dir: &Path) {
             old_dir.display(),
             locator_path.display()
         ));
-        return;
+        return Ok(());
     }
 
     observability::config_migration_started(&old_dir, default_dir);
@@ -102,6 +105,8 @@ async fn run_startup_migration_at(locator_path: &Path, default_dir: &Path) {
             observability::config_migration_failed(&e);
         }
     }
+
+    Ok(())
 }
 
 /// 从定位器文件读取自定义路径
@@ -117,12 +122,30 @@ async fn read_locator(path: &Path) -> Option<PathBuf> {
     }
 }
 
-async fn lock_locator(path: &Path) -> Result<FileLock, String> {
+async fn lock_locator(path: &Path) -> Result<FileLock, FsError> {
     let path = path.to_path_buf();
     tokio::task::spawn_blocking(move || FileLock::try_acquire(path))
         .await
-        .map_err(|error| format!("获取数据目录定位器锁失败: {error}"))?
-        .map_err(|error| error.to_string())
+        .map_err(|error| FsError::Task {
+            operation: "acquire data directory locator lock",
+            message: error.to_string(),
+        })?
+}
+
+async fn lock_locator_with_retry(path: &Path) -> Result<FileLock, FsError> {
+    let deadline = tokio::time::Instant::now() + LOCATOR_LOCK_WAIT_TIMEOUT;
+    loop {
+        match lock_locator(path).await {
+            Ok(lock) => return Ok(lock),
+            Err(error @ FsError::AlreadyLocked(_)) => {
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(error);
+                }
+                tokio::time::sleep(LOCATOR_LOCK_RETRY_DELAY).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 /// 搬迁数据目录内容（重命名源目录 + 复制 + 清理迁移源）。
@@ -320,7 +343,9 @@ mod tests {
         .await
         .expect("locator should be written");
 
-        run_startup_migration_at(&locator, &default_dir).await;
+        run_startup_migration_at(&locator, &default_dir)
+            .await
+            .expect("startup migration should acquire the locator lock");
 
         assert_eq!(
             tokio::fs::read_to_string(default_dir.join("settings.json"))
@@ -349,8 +374,56 @@ mod tests {
         .await
         .expect("locator should be written");
 
-        run_startup_migration_at(&locator, &default_dir).await;
+        run_startup_migration_at(&locator, &default_dir)
+            .await
+            .expect("startup migration should acquire the locator lock");
 
         assert!(locator.exists(), "missing source should not discard locator");
+    }
+
+    #[tokio::test]
+    async fn startup_migration_waits_for_another_host_to_release_locator_lock() {
+        let root = tempfile::tempdir().expect("temporary migration directory should be created");
+        let default_dir = root.path().join("default");
+        let old_dir = root.path().join("old");
+        let locator = default_dir.join(APP_DATA_LOCATOR_FILE);
+        tokio::fs::create_dir_all(&old_dir)
+            .await
+            .expect("old data directory should be created");
+        tokio::fs::write(old_dir.join("settings.json"), "{\"ok\":true}")
+            .await
+            .expect("old data should be written");
+        tokio::fs::create_dir_all(&default_dir)
+            .await
+            .expect("default data directory should be created");
+        tokio::fs::write(
+            &locator,
+            serde_json::to_vec(&serde_json::json!({ "data_dir": old_dir }))
+                .expect("locator should be encoded"),
+        )
+        .await
+        .expect("locator should be written");
+
+        let held_lock = FileLock::try_acquire(&locator).expect("test should hold locator lock");
+        let migration_locator = locator.clone();
+        let migration_default_dir = default_dir.clone();
+        let migration = tokio::spawn(async move {
+            run_startup_migration_at(&migration_locator, &migration_default_dir).await
+        });
+
+        tokio::time::sleep(LOCATOR_LOCK_RETRY_DELAY * 2).await;
+        drop(held_lock);
+
+        migration
+            .await
+            .expect("migration task should finish")
+            .expect("migration should succeed after the lock is released");
+        assert_eq!(
+            tokio::fs::read_to_string(default_dir.join("settings.json"))
+                .await
+                .expect("migrated data should be readable"),
+            "{\"ok\":true}"
+        );
+        assert!(!locator.exists(), "completed migration should remove locator");
     }
 }

--- a/crates/feature/src/config/sealantern/manager.rs
+++ b/crates/feature/src/config/sealantern/manager.rs
@@ -116,18 +116,58 @@ impl SettingsManager {
 
         // 版本迁移：分步升级，迁移前备份
         let version = mgr.inner.get().config_version;
+        if version > CURRENT_CONFIG_VERSION {
+            return Err(SettingsError::invalid_input(
+                "config_version",
+                format!(
+                    "unsupported future config version {version}; current version is {CURRENT_CONFIG_VERSION}"
+                ),
+            ));
+        }
         if version < CURRENT_CONFIG_VERSION {
-            let backup = backup_settings_file(&path).await?;
-            let mut settings = mgr.inner.get().clone();
-            upgrade_settings(&mut settings, version);
-            mgr.inner.set(settings);
-            mgr.inner.save(false).await?;
-            observability::config_settings_version_upgraded(
+            let mut upgraded_from = None;
+            let updated = ConfigFile::try_update_persisted_if_changed_with_backup(
                 &path,
-                version,
-                CURRENT_CONFIG_VERSION,
-                &backup,
-            );
+                AppSettings::default(),
+                true,
+                |settings| {
+                    let from_version = settings.config_version;
+                    if from_version > CURRENT_CONFIG_VERSION {
+                        return Err(SettingsError::invalid_input(
+                            "config_version",
+                            format!(
+                                "unsupported future config version {from_version}; current version is {CURRENT_CONFIG_VERSION}"
+                            ),
+                        ));
+                    }
+                    if from_version < CURRENT_CONFIG_VERSION {
+                        upgrade_settings(settings, from_version);
+                        settings.validate()?;
+                        upgraded_from = Some(from_version);
+                        Ok(true)
+                    } else {
+                        settings.validate()?;
+                        Ok(false)
+                    }
+                },
+            )
+            .await;
+            let (settings, backup) = match updated {
+                Ok(result) => result,
+                Err(UpdatePersistedError::Storage(error)) => return Err(error.into()),
+                Err(UpdatePersistedError::Update(error)) => return Err(error),
+            };
+            mgr.inner.set(settings);
+            if let (Some(from_version), Some(backup)) = (upgraded_from, backup) {
+                observability::config_settings_version_upgraded(
+                    &path,
+                    from_version,
+                    CURRENT_CONFIG_VERSION,
+                    &backup,
+                );
+            }
+        } else {
+            mgr.inner.get().validate()?;
         }
 
         observability::config_settings_loaded(&path, mgr.inner.get().config_version);
@@ -433,10 +473,18 @@ async fn migrate_legacy_format(path: &Path) -> Result<bool, FsError> {
     Ok(true)
 }
 
-/// 判断 JSON 内容是否为旧版嵌套格式（存在 `preferences` 对象）。
+/// 判断 JSON 内容是否为旧版嵌套格式。
+///
+/// 必须同时具备旧版的数字 `version` 和嵌套 `preferences`，且不能已经是
+/// 新版扁平配置；仅凭一个同名扩展字段不能触发破坏性迁移。
 fn is_legacy_format(content: &str) -> bool {
     serde_json::from_str::<serde_json::Value>(content)
-        .map(|v| v.get("preferences").is_some_and(|p| p.is_object()))
+        .map(|v| {
+            v.get("config_version").is_none()
+                && v.get("version").is_some_and(|version| version.is_number())
+                && v.get("preferences")
+                    .is_some_and(|preferences| preferences.is_object())
+        })
         .unwrap_or(false)
 }
 
@@ -444,22 +492,14 @@ fn is_legacy_format(content: &str) -> bool {
 ///
 /// 未来新增结构变更时，在循环内按版本号补充分支迁移，
 /// 版本号提升与字段迁移保持同步。
-fn upgrade_settings(settings: &mut AppSettings, from_version: u32) {
-    let mut version = from_version;
-    while version < CURRENT_CONFIG_VERSION {
-        // v0 → v1：扁平结构首次引入，此前旧版数据由 legacy 迁移处理。
-        // v1 → v2：Java 缓存新增置信度字段，缺失值由 serde 默认补齐。
-        // v2 → v3：新增全局代理设置，缺失值由 serde 默认补为 Adaptive。
-        // v3 → v4：服务器日志是否丢弃空行的配置。
-        // v4 → v5：新增自动进入轻量模式的延时配置，缺失值默认关闭。
-        version += 1;
-    }
+fn upgrade_settings(settings: &mut AppSettings, _from_version: u32) {
+    // 当前所有历史版本差异都由 serde 默认值覆盖，没有实际字段转换步骤。
     settings.config_version = CURRENT_CONFIG_VERSION;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SETTINGS_FILE_NAME, SettingsManager, default_settings_path};
+    use super::{SETTINGS_FILE_NAME, SettingsManager, default_settings_path, is_legacy_format};
     use crate::config::{AppSettings, JavaInfo, PartialAppSettings};
     use crate::models::CURRENT_CONFIG_VERSION;
     use sealantern_infra::fs::{FileLock, FsError};
@@ -748,5 +788,89 @@ mod tests {
         .expect("upgraded settings should decode");
         assert_eq!(persisted.config_version, CURRENT_CONFIG_VERSION);
         assert_eq!(persisted.proxy.mode, ProxyMode::Adaptive);
+    }
+
+    #[tokio::test]
+    async fn semantically_invalid_persisted_settings_are_rejected() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut invalid = serde_json::to_value(AppSettings::default())
+            .expect("settings fixture should serialize");
+        invalid["default_port"] = 0.into();
+        let original = serde_json::to_string_pretty(&invalid).expect("fixture should encode");
+        tokio::fs::write(&path, &original)
+            .await
+            .expect("invalid settings fixture should be written");
+
+        let result = SettingsManager::load(&path).await;
+
+        assert!(matches!(result, Err(SettingsError::InvalidInput { field: "default_port", .. })));
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("invalid settings should remain available for repair"),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn future_settings_version_is_rejected_without_rewriting_file() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        let mut future = serde_json::to_value(AppSettings::default())
+            .expect("settings fixture should serialize");
+        future["config_version"] = (CURRENT_CONFIG_VERSION + 1).into();
+        let original = serde_json::to_string_pretty(&future).expect("fixture should encode");
+        tokio::fs::write(&path, &original)
+            .await
+            .expect("future settings fixture should be written");
+
+        let result = SettingsManager::load(&path).await;
+
+        assert!(matches!(
+            result,
+            Err(SettingsError::InvalidInput { field: "config_version", .. })
+        ));
+        assert_eq!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .expect("future settings should remain available for a newer version"),
+            original
+        );
+    }
+
+    #[test]
+    fn legacy_detection_requires_the_legacy_version_marker() {
+        assert!(is_legacy_format(r#"{"version":1,"preferences":{}}"#));
+        assert!(!is_legacy_format(r#"{"preferences":{}}"#));
+        assert!(!is_legacy_format(r#"{"version":1,"config_version":5,"preferences":{}}"#));
+    }
+
+    #[tokio::test]
+    async fn legacy_nested_settings_are_migrated_without_losing_preferences() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("settings.json");
+        tokio::fs::write(
+            &path,
+            r#"{
+              "version": 1,
+              "preferences": {
+                "language": "zh-CN",
+                "theme": "dark",
+                "developer_mode": true
+              }
+            }"#,
+        )
+        .await
+        .expect("legacy settings fixture should be written");
+
+        let manager = SettingsManager::load(&path)
+            .await
+            .expect("legacy settings should migrate");
+
+        assert_eq!(manager.get().language, "zh-CN");
+        assert_eq!(manager.get().theme, "dark");
+        assert!(manager.get().developer_mode);
+        assert_eq!(manager.get().config_version, CURRENT_CONFIG_VERSION);
     }
 }

--- a/crates/feature/src/config/sealantern/registry.rs
+++ b/crates/feature/src/config/sealantern/registry.rs
@@ -48,6 +48,7 @@ impl InstanceRegistry {
     pub async fn save_instance(&mut self, instance: &Instance) -> Result<(), FsError> {
         let id = instance.id.clone();
         let name = instance.name.clone();
+        let mut inserted = false;
         let result = self
             .store
             .update(|list| {
@@ -55,12 +56,16 @@ impl InstanceRegistry {
                     *existing = instance.clone();
                 } else {
                     list.instances.push(instance.clone());
+                    inserted = true;
                 }
             })
             .await;
 
         match &result {
-            Ok(()) => observability::config_registry_server_added(&self.path, id.as_str(), &name),
+            Ok(()) if inserted => {
+                observability::config_registry_server_added(&self.path, id.as_str(), &name)
+            }
+            Ok(()) => observability::config_registry_server_updated(&self.path, id.as_str()),
             Err(e) => observability::config_registry_operation_failed(
                 &self.path,
                 "save",

--- a/crates/feature/src/config/sealantern/store.rs
+++ b/crates/feature/src/config/sealantern/store.rs
@@ -7,8 +7,9 @@
 //! "加载 → 修改 → 保存"，避免多个 `InstanceStore` 实例并发修改时
 //! 基于过期快照互相覆盖。
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use sealantern_infra::fs::{FileLock, FsError, write_atomic};
 use sealantern_infra::persistence::config::ConfigFile;
 
 use super::types::InstanceList;
@@ -24,9 +25,7 @@ impl InstanceStore {
     ///
     /// 若文件是 1.2.0 旧版裸数组格式，先迁移为新版 `InstanceList`
     /// 并写回磁盘，保证升级后首次启动即可正常解析。
-    pub async fn load(
-        path: impl Into<std::path::PathBuf>,
-    ) -> Result<Self, sealantern_infra::fs::FsError> {
+    pub async fn load(path: impl Into<std::path::PathBuf>) -> Result<Self, FsError> {
         let path = path.into();
         migrate_legacy_servers_file(&path).await?;
         let inner = ConfigFile::load_or_create(&path, InstanceList::default()).await?;
@@ -49,10 +48,7 @@ impl InstanceStore {
     /// 在单个文件锁内重新加载最新状态、应用修改并保存，
     /// 防止基于过期快照覆盖其它实例的修改。
     /// 更新完成后同步内存快照，保持与磁盘一致。
-    pub async fn update(
-        &mut self,
-        f: impl FnOnce(&mut InstanceList),
-    ) -> Result<(), sealantern_infra::fs::FsError> {
+    pub async fn update(&mut self, f: impl FnOnce(&mut InstanceList)) -> Result<(), FsError> {
         let updated =
             ConfigFile::update_persisted(&self.path, InstanceList::default(), false, f).await?;
         self.inner.set(updated);
@@ -69,14 +65,13 @@ impl InstanceStore {
 ///
 /// 旧版文件以 `[` 开头（数组）；新版以 `{` 开头（对象）。仅当文件存在且
 /// 以数组形式开头时才触发迁移，避免对空文件或已迁移文件做多余写入。
-async fn migrate_legacy_servers_file(
-    path: &std::path::Path,
-) -> Result<(), sealantern_infra::fs::FsError> {
+async fn migrate_legacy_servers_file(path: &Path) -> Result<(), FsError> {
+    let _lock = lock_legacy_file(path).await?;
     let raw = match tokio::fs::read(path).await {
         Ok(bytes) => bytes,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(e) => {
-            return Err(sealantern_infra::fs::FsError::Io {
+            return Err(FsError::Io {
                 operation: "read legacy servers",
                 path: path.to_path_buf(),
                 source: e,
@@ -86,7 +81,7 @@ async fn migrate_legacy_servers_file(
     let text = match String::from_utf8(raw) {
         Ok(text) => text,
         Err(e) => {
-            return Err(sealantern_infra::fs::FsError::Encoding {
+            return Err(FsError::Encoding {
                 path: path.to_path_buf(),
                 encoding: "UTF-8",
                 message: e.to_string(),
@@ -101,7 +96,7 @@ async fn migrate_legacy_servers_file(
     let records: Vec<crate::models::LegacyServerInstance> = match serde_json::from_str(&text) {
         Ok(records) => records,
         Err(e) => {
-            return Err(sealantern_infra::fs::FsError::Serialization {
+            return Err(FsError::Serialization {
                 format: "json",
                 operation: "decode legacy servers",
                 path: path.to_path_buf(),
@@ -113,7 +108,7 @@ async fn migrate_legacy_servers_file(
     let content = match serde_json::to_string_pretty(&list) {
         Ok(content) => content,
         Err(e) => {
-            return Err(sealantern_infra::fs::FsError::Serialization {
+            return Err(FsError::Serialization {
                 format: "json",
                 operation: "encode migrated servers",
                 path: path.to_path_buf(),
@@ -121,12 +116,64 @@ async fn migrate_legacy_servers_file(
             });
         }
     };
-    if let Err(e) = tokio::fs::write(path, content).await {
-        return Err(sealantern_infra::fs::FsError::Io {
-            operation: "write migrated servers",
-            path: path.to_path_buf(),
-            source: e,
-        });
-    }
+    write_atomic(path, content.as_bytes()).await?;
     Ok(())
+}
+
+async fn lock_legacy_file(path: &Path) -> Result<FileLock, FsError> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || FileLock::try_acquire(path))
+        .await
+        .map_err(|error| FsError::Task {
+            operation: "acquire legacy servers file lock",
+            message: error.to_string(),
+        })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InstanceStore;
+
+    #[tokio::test]
+    async fn legacy_server_array_is_migrated_to_an_object_atomically() {
+        let root = tempfile::tempdir().expect("temporary config directory should be created");
+        let path = root.path().join("servers.json");
+        let legacy = r#"[
+          {
+            "id": "srv-1",
+            "name": "My Server",
+            "core_type": "paper",
+            "core_version": "1.20.4",
+            "mc_version": "1.20.4",
+            "path": "D:\\MCServers\\A",
+            "jar_path": "D:\\MCServers\\A\\server.jar",
+            "startup_mode": "jar",
+            "custom_command": null,
+            "java_path": "D:\\Java\\jdk-21\\bin\\java.exe",
+            "max_memory": 2048,
+            "min_memory": 512,
+            "jvm_args": [],
+            "port": 25565,
+            "created_at": 1786865648,
+            "last_started_at": 1786865895
+          }
+        ]"#;
+        tokio::fs::write(&path, legacy)
+            .await
+            .expect("legacy fixture should be written");
+
+        let store = InstanceStore::load(&path)
+            .await
+            .expect("legacy server list should migrate");
+
+        assert_eq!(store.get().version, 1);
+        assert_eq!(store.get().instances.len(), 1);
+        let persisted: serde_json::Value = serde_json::from_slice(
+            &tokio::fs::read(&path)
+                .await
+                .expect("migrated server list should be readable"),
+        )
+        .expect("migrated server list should be valid JSON");
+        assert!(persisted.is_object());
+    }
 }

--- a/crates/infra/src/persistence/config.rs
+++ b/crates/infra/src/persistence/config.rs
@@ -295,14 +295,31 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
         auto_backup: bool,
         update: impl FnOnce(&mut T) -> Result<bool, E>,
     ) -> Result<T, UpdatePersistedError<E>> {
+        let (data, _) =
+            Self::try_update_persisted_if_changed_with_backup(path, default, auto_backup, update)
+                .await?;
+        Ok(data)
+    }
+
+    /// 在单个文件锁内加载、更新并持久化配置，同时返回本次生成的备份路径。
+    ///
+    /// 这是需要在成功事件中记录备份位置的迁移场景使用的扩展版本；不需要备份
+    /// 详情的调用方应继续使用 [`Self::try_update_persisted_if_changed`]。
+    pub async fn try_update_persisted_if_changed_with_backup<E>(
+        path: impl Into<PathBuf>,
+        default: T,
+        auto_backup: bool,
+        update: impl FnOnce(&mut T) -> Result<bool, E>,
+    ) -> Result<(T, Option<PathBuf>), UpdatePersistedError<E>> {
         let path = path.into();
         let format = ConfigFormat::from_extension(&path)?;
         let _guard = lock_config(&path).await?;
         let mut data = load_data_or_default(&path, format, default).await?;
+        let mut backup = None;
 
         if update(&mut data).map_err(UpdatePersistedError::Update)? {
             if auto_backup && path.exists() {
-                backup_path(&path).await?;
+                backup = Some(backup_path(&path).await?);
             }
             let content = format.serialize(&data).map_err(|error| {
                 UpdatePersistedError::Storage(FsError::serialization(
@@ -314,7 +331,7 @@ impl<T: Serialize + DeserializeOwned> ConfigFile<T> {
             })?;
             write_atomic(&path, content.as_bytes()).await?;
         }
-        Ok(data)
+        Ok((data, backup))
     }
 
     pub async fn backup(&self) -> Result<PathBuf, FsError> {


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [ ] 已阅读 `docs/rules/contributing.md`
- [ ] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Sourcery 总结

加强启动配置迁移和持久化机制，使并发访问、恢复、验证和旧版本升级更加安全。

错误修复：
- 当源目录缺失或无法继续迁移时，避免启动数据迁移丢弃定位器文件。
- 拒绝不受支持的未来配置版本和语义无效的持久化设置，且不重写原始文件。
- 避免将注册表更新错误地报告为新增服务器。
- 在迁移旧版嵌套设置之前，要求更强的标记。

增强功能：
- 通过文件锁定、有界定位器读取、原子写入，以及协调的加载-更新-保存操作，加强配置和服务器持久化。
- 在构造服务期间执行启动数据目录迁移，并改进迁移恢复和清理行为。
- 在版本升级期间保留并报告生成的配置备份。

测试：
- 增加对启动目录迁移、迁移源缺失、无效和未来设置版本、旧版格式检测、嵌套设置迁移以及旧版服务器列表迁移的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

加固启动迁移和配置持久化机制，使并发访问、恢复、验证和旧版本升级更加安全。

错误修复：
- 当源目录缺失或迁移无法完成时，防止启动数据迁移丢弃定位器文件。
- 拒绝不受支持的未来配置版本以及语义上无效的持久化设置，且不重写原始文件。
- 修正注册表可观测性，确保更新不会被报告为新添加的服务器。
- 在迁移旧版嵌套设置前，要求更严格的标记。

增强功能：
- 通过文件锁定、有界定位器读取、原子写入以及协调的加载-更新-保存操作，加固配置和服务器持久化。
- 在服务构造期间运行启动数据目录迁移，并改进恢复和清理行为。
- 在版本升级期间保留并报告生成的配置备份。

测试：
- 增加对启动目录迁移、迁移源缺失、无效和未来设置版本、旧版格式检测、嵌套设置迁移以及旧版服务器列表迁移的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden startup migration and configuration persistence to make concurrent access, recovery, validation, and legacy upgrades safer.

Bug Fixes:
- Prevent startup data migration from discarding locator files when the source directory is missing or migration cannot complete.
- Reject unsupported future configuration versions and semantically invalid persisted settings without rewriting the original files.
- Correct registry observability so updates are not reported as newly added servers.
- Require stronger markers before migrating legacy nested settings.

Enhancements:
- Harden configuration and server persistence with file locking, bounded locator reads, atomic writes, and coordinated load-update-save operations.
- Run startup data-directory migration during service construction with improved recovery and cleanup behavior.
- Preserve and report generated configuration backups during version upgrades.

Tests:
- Add coverage for startup directory migration, missing migration sources, invalid and future settings versions, legacy format detection, nested settings migration, and legacy server-list migration.

</details>

</details>