### PR TITLE
fix(plugin): validate frontend trust source

### DIFF
--- a/src-tauri/src/adapter/tauri/commands/plugin.rs
+++ b/src-tauri/src/adapter/tauri/commands/plugin.rs
@@ -24,6 +24,18 @@ fn map_error(error: PluginServiceError) -> String {
     error.to_string()
 }
 
+fn validate_user_trust_source(trust_source: TrustSource) -> Result<(), String> {
+    match trust_source {
+        TrustSource::UntrustedLocal | TrustSource::LocallyTrusted => Ok(()),
+        TrustSource::StandardMarketplace
+        | TrustSource::VerifiedPublisher
+        | TrustSource::BuiltIn => {
+            Err("trust source must be established by the host, not supplied by the frontend"
+                .to_owned())
+        }
+    }
+}
+
 #[tauri::command(rename_all = "snake_case")]
 pub async fn plugin_v2_discover(services: State<'_, AppServices>) -> Result<Vec<PathBuf>, String> {
     plugin_service(&services)
@@ -128,12 +140,33 @@ pub async fn plugin_v2_set_trust(
     plugin_id: String,
     trust_source: TrustSource,
 ) -> Result<(), String> {
+    validate_user_trust_source(trust_source)?;
     plugin_service(&services)
         .await?
         .policy()
         .set_trust(&plugin_id, trust_source)
         .await
         .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_user_trust_source;
+    use sealantern_core::app_plugin::TrustSource;
+
+    #[test]
+    fn only_explicit_local_trust_decisions_are_accepted() {
+        assert!(validate_user_trust_source(TrustSource::UntrustedLocal).is_ok());
+        assert!(validate_user_trust_source(TrustSource::LocallyTrusted).is_ok());
+
+        for source in [
+            TrustSource::StandardMarketplace,
+            TrustSource::VerifiedPublisher,
+            TrustSource::BuiltIn,
+        ] {
+            assert!(validate_user_trust_source(source).is_err());
+        }
+    }
 }
 
 #[tauri::command(rename_all = "snake_case")]


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [ ] 已阅读 `docs/rules/contributing.md`
- [ ] 已执行与本次变更相关的测试或检查

## 影响范围

- [ ] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

<!-- 简单描述，尽量手写 -->

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Sourcery 摘要

验证前端提供的插件信任决策，确保无法伪造由主机建立的信任来源。

错误修复：
- 防止前端在更新插件信任时提供由主机建立的插件信任来源。

测试：
- 增加测试覆盖，确认前端仅接受明确的本地信任决策。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

验证前端插件信任决策，以防止伪造由主机建立的信任来源。

错误修复：
- 防止前端提供的插件信任更新声称拥有由主机建立的信任。

增强功能：
- 将前端插件信任决策限制为明确的本地信任状态。

测试：
- 添加测试覆盖，确认前端仅接受本地信任决策。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

验证前端提供的插件信任决策，确保无法伪造由主机建立的信任。

Bug 修复：
- 更新插件信任时，阻止前端请求提供由主机建立的插件信任来源。

增强功能：
- 将前端信任更新限制为明确的本地信任决策，同时继续由主机控制市场、发布者验证和内置的信任决策。

测试：
- 增加测试覆盖，确认前端仅可提交本地插件信任决策。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate frontend-supplied plugin trust decisions to ensure host-established trust cannot be forged.

Bug Fixes:
- Prevent frontend requests from supplying host-established plugin trust sources when updating plugin trust.

Enhancements:
- Restrict frontend trust updates to explicit local trust decisions while leaving marketplace, publisher-verified, and built-in trust decisions host-controlled.

Tests:
- Add coverage confirming that only local plugin trust decisions are accepted from the frontend.

</details>

</details>

</details>