### PR TITLE
fix(system): 服务器页面磁盘占用改为实例目录统计

### DIFF
--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -14,12 +14,13 @@ use async_trait::async_trait;
 use sealantern_contract::SystemServiceError;
 use sealantern_contract::server::ServerState;
 use sealantern_contract::system::{
-    CpuInfo, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
+    CpuInfo, DirectoryUsage, DiskInfo, DiskSummary, MemoryInfo, NetworkInfo, ProcessResourceUsage,
     ServerResourceUsage, SystemSnapshot,
 };
 use sealantern_infra::platform::{
     collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
-    collect_system_info, cpu_brand_name, get_default_run_path, process_count,
+    collect_system_info, cpu_brand_name, directory_size, get_default_run_path, path_disk_capacity,
+    process_count,
 };
 
 use crate::error::SystemError;
@@ -233,6 +234,23 @@ impl SystemService for CoreSystemService {
         };
         let full = Self::snapshot_inner().await?;
 
+        // 磁盘占用按实例目录统计，而不是整机分区求和：服务器页面的磁盘指标
+        // 应反映该实例实际占用的空间与其所在挂载点容量。
+        let directory = instance.directory.clone();
+        let disk = tokio::task::spawn_blocking(move || {
+            let used = directory_size(&directory);
+            let (total, available) = path_disk_capacity(&directory);
+            DirectoryUsage {
+                path: directory,
+                used,
+                total,
+                available,
+                usage: percent(used, total),
+            }
+        })
+        .await
+        .map_err(SystemError::from)?;
+
         Ok(ServerResourceUsage {
             server_id: instance.id.as_str().to_string(),
             server_name: instance.name,
@@ -249,7 +267,7 @@ impl SystemService for CoreSystemService {
                 available: usage.memory_total.saturating_sub(usage.memory_used),
                 usage: usage.memory_usage.clamp(0.0, 100.0),
             },
-            disk: full.disk,
+            disk,
         })
     }
 }
@@ -318,5 +336,75 @@ mod tests {
             .expect("path should have a file name")
             .to_string_lossy();
         assert_eq!(name, "SeaLantern", "unexpected default run dir: {name}");
+    }
+
+    /// 服务器页面的磁盘指标应为实例目录占用，而非整机磁盘汇总。
+    #[tokio::test]
+    async fn server_resource_usage_reports_directory_disk_usage() {
+        use sealantern_core::instance::{InstanceId, LocalLaunch, StartupMode};
+
+        let dir = tempdir().expect("create temp dir");
+        let instance_dir = dir.path().join("server");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        // 写入已知大小的文件，验证磁盘占用按目录统计。
+        let payload = vec![0x5A; 4096];
+        std::fs::write(instance_dir.join("level.dat"), &payload).expect("write payload");
+
+        let instance_service = Arc::new(
+            CoreInstanceService::with_path(dir.path().join("instances.json"))
+                .await
+                .expect("create instance service"),
+        );
+        let spec = sealantern_core::instance::InstanceSpec {
+            id: InstanceId::new("disk-test").expect("valid id"),
+            name: "磁盘测试".into(),
+            aliases: Vec::new(),
+            core_type: "paper".into(),
+            core_version: "1.20.4".into(),
+            game_version: "1.20.4".into(),
+            directory: instance_dir.clone(),
+            port: 25565,
+            max_memory_mib: 2048,
+            min_memory_mib: 512,
+            created_at_unix_secs: 0,
+            last_started_at_unix_secs: None,
+            server_metadata: None,
+            launch: LocalLaunch {
+                startup_mode: StartupMode::Jar,
+                startup_target: Some(instance_dir.join("server.jar")),
+                custom_command: None,
+                custom_executable: None,
+                custom_arguments: Vec::new(),
+                java_executable: None,
+                jvm_arguments: Vec::new(),
+            },
+        };
+        let instance = instance_service
+            .create(spec)
+            .await
+            .expect("create instance");
+        let server = Arc::new(CoreServerService::new(
+            instance_service.clone(),
+            Arc::new(crate::service::CoreSettingsService::new()),
+        ));
+        let service = CoreSystemService::new(instance_service, server);
+
+        let usage = service
+            .server_resource_usage(instance.id.as_str())
+            .await
+            .expect("server resource usage");
+
+        // 目录占用应反映写入的文件（≈4096 字节），远小于整机磁盘量级。
+        assert!(
+            usage.disk.used >= payload.len() as u64,
+            "disk used too small: {}",
+            usage.disk.used
+        );
+        assert!(
+            usage.disk.used < 1024 * 1024,
+            "disk used looks like whole-machine usage: {}",
+            usage.disk.used
+        );
+        assert_eq!(usage.disk.path, instance.directory);
     }
 }

--- a/crates/contract/src/system/models.rs
+++ b/crates/contract/src/system/models.rs
@@ -153,6 +153,6 @@ pub struct ServerResourceUsage {
     pub cpu: CpuInfo,
     /// 内存资源。
     pub memory: MemoryInfo,
-    /// 磁盘汇总（总量/已用/可用为全部分区求和）。
-    pub disk: DiskSummary,
+    /// 实例目录磁盘占用（目录本身占用 + 所在挂载点容量）。
+    pub disk: DirectoryUsage,
 }

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -41,6 +41,15 @@ export interface DiskInfo {
   path?: string;
 }
 
+/** 目录磁盘占用：实例目录本身占用 + 所在挂载点容量（对齐后端 DirectoryUsage）。 */
+export interface DirectoryUsage {
+  path: string;
+  used: number;
+  total: number;
+  available: number;
+  usage: number;
+}
+
 export interface NetworkInterface {
   name: string;
   received: number;
@@ -76,7 +85,7 @@ export interface ServerResourceUsage {
   pid: number | null;
   cpu: CpuInfo;
   memory: MemoryInfo;
-  disk: DiskInfo;
+  disk: DirectoryUsage;
 }
 
 export interface IPv6TestTarget {


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/rules/contributing.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [ ] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

get_server_resource_usage 的 disk 字段原样复用了整机快照的 DiskSummary （全部分区已用求和），服务器页面因此显示整机磁盘占用（如 637.76 GB），
而非该实例实际占用的空间。

- ServerResourceUsage.disk 类型从 DiskSummary 改为 DirectoryUsage（契约里 早已定义但从未被使用）：目录本身占用 + 所在挂载点容量，语义与服务器页面 的「硬盘占用」一致
- server_resource_usage 用实例目录经 infra 的 directory_size（递归统计） 与 path_disk_capacity（挂载点容量）计算，放入 spawn_blocking 避免阻塞 异步运行时
- 前端 ServerResourceUsage.disk 类型同步为 DirectoryUsage（字段名 used 等 不变，ConsoleView 展示无需改动）

新增单测：实例目录写入 4096 字节文件后，server_resource_usage 返回的
disk.used 反映目录占用（介于文件大小与 1 MiB 之间），且 path 指向实例目录。

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Summary by Sourcery

将服务器磁盘资源统计改为反映实例目录的实际占用情况。

Bug Fixes:
- 修正服务器页面将整机磁盘汇总误显示为实例磁盘占用的问题。

Enhancements:
- 改用实例目录占用及其所在挂载点容量提供服务器磁盘资源数据，并同步前后端数据契约。

Tests:
- 新增实例目录磁盘占用统计的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将服务器磁盘资源统计改为反映实例目录的实际占用情况。

Bug Fixes:
- 修正服务器页面将整机磁盘汇总误显示为实例磁盘占用的问题。

Enhancements:
- 改用实例目录占用及其所在挂载点容量提供服务器磁盘资源数据，并同步前后端数据契约。

Tests:
- 新增实例目录磁盘占用统计的单元测试。

</details>