### PR TITLE
perf(system): 服务器资源查询改用轻量 CPU 采集

### DIFF
--- a/application/src/service/system.rs
+++ b/application/src/service/system.rs
@@ -18,9 +18,9 @@ use sealantern_contract::system::{
     ServerResourceUsage, SystemSnapshot,
 };
 use sealantern_infra::platform::{
-    collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
-    collect_system_info, cpu_brand_name, directory_size, get_default_run_path, path_disk_capacity,
-    process_count,
+    collect_cpu_info, collect_disks, collect_networks, collect_process_usage,
+    collect_resource_snapshot, collect_system_info, cpu_brand_name, directory_size,
+    get_default_run_path, path_disk_capacity, process_count,
 };
 
 use crate::error::SystemError;
@@ -232,7 +232,11 @@ impl SystemService for CoreSystemService {
                 memory_usage: 0.0,
             },
         };
-        let full = Self::snapshot_inner().await?;
+        // CPU 品牌与核心数是静态信息，轻量采集即可；不再调用整机快照，避免
+        // 每次服务器资源查询都顺带扫一遍整机磁盘/网络/进程。
+        let (cpu_name, cpu_count) = tokio::task::spawn_blocking(collect_cpu_info)
+            .await
+            .map_err(SystemError::from)?;
 
         // 磁盘占用按实例目录统计，而不是整机分区求和：服务器页面的磁盘指标
         // 应反映该实例实际占用的空间与其所在挂载点容量。
@@ -257,8 +261,8 @@ impl SystemService for CoreSystemService {
             status,
             pid: snapshot.pid,
             cpu: CpuInfo {
-                name: full.cpu.name,
-                count: full.cpu.count,
+                name: cpu_name,
+                count: cpu_count,
                 usage: usage.cpu_usage.clamp(0.0, 100.0),
             },
             memory: MemoryInfo {

--- a/crates/infra/src/platform/mod.rs
+++ b/crates/infra/src/platform/mod.rs
@@ -20,7 +20,7 @@ pub use error::PlatformError;
 pub use locations::{get_app_data_dir, get_default_run_path, get_or_create_app_data_dir};
 pub use proxy::{PlatformSystemProxyProvider, SystemProxyReadError, current_system_proxy};
 pub use system::{
-    DiskUsage, NetworkUsage, ProcessUsage, ResourceSnapshot, SystemInfo, collect_disks,
-    collect_networks, collect_process_usage, collect_resource_snapshot, collect_system_info,
-    cpu_brand_name, directory_size, path_disk_capacity, process_count,
+    DiskUsage, NetworkUsage, ProcessUsage, ResourceSnapshot, SystemInfo, collect_cpu_info,
+    collect_disks, collect_networks, collect_process_usage, collect_resource_snapshot,
+    collect_system_info, cpu_brand_name, directory_size, path_disk_capacity, process_count,
 };

--- a/crates/infra/src/platform/system.rs
+++ b/crates/infra/src/platform/system.rs
@@ -278,17 +278,28 @@ fn normalize_for_mount_match(path: &Path) -> PathBuf {
     }
 }
 
+/// 采集 CPU 品牌与逻辑核心数。
+///
+/// 只刷新 CPU 信息（`refresh_cpu_all`），不枚举磁盘、网络或进程，适合需要
+/// 轻量获取 CPU 静态信息的场景（如服务器资源占用查询）。返回 `(品牌, 逻辑
+/// 核心数)`，品牌无法获取时为 `"Unknown"`。
+pub fn collect_cpu_info() -> (String, usize) {
+    let mut system = System::new();
+    system.refresh_cpu_all();
+    let brand = system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().to_string())
+        .unwrap_or_else(|| "Unknown".into());
+    let count = system.cpus().len();
+    (brand, count)
+}
+
 /// 获取 CPU 型号名称（如 `Intel(R) Core(TM) i7-9700K`）。
 ///
 /// 无法获取时返回 `"Unknown"`。
 pub fn cpu_brand_name() -> String {
-    let mut system = System::new();
-    system.refresh_cpu_all();
-    system
-        .cpus()
-        .first()
-        .map(|cpu| cpu.brand().to_string())
-        .unwrap_or_else(|| "Unknown".into())
+    collect_cpu_info().0
 }
 
 /// 获取当前运行的进程数。
@@ -309,6 +320,16 @@ mod tests {
         assert!(!info.family.is_empty());
         assert!(info.logical_cpu_count > 0);
         assert!(info.total_memory_bytes >= info.available_memory_bytes);
+    }
+
+    #[test]
+    fn cpu_info_reports_brand_and_logical_count() {
+        let (brand, count) = collect_cpu_info();
+
+        assert!(count > 0, "logical cpu count must be positive");
+        assert!(!brand.is_empty(), "cpu brand must not be empty");
+        // 与既有 cpu_brand_name 保持一致（内部应复用同一采集路径）。
+        assert_eq!(cpu_brand_name(), brand);
     }
 
     #[test]


### PR DESCRIPTION
<!-- 关联 Issue，如：Close #123、Fix #456 -->

## Checklist

- [x] 已阅读 `docs/rules/contributing.md`
- [x] 已执行与本次变更相关的测试或检查

## 影响范围

- [x] 前端 (UI/组件/路由/状态)
- [x] 后端 (API/逻辑/依赖)
- [ ] 基础设施 (CI/CD/部署)

## 变更摘要

上个 PR 把磁盘字段改为实例目录统计后，server_resource_usage 仍调用
snapshot_inner() 取 cpu.name/count——为两个静态字段付出整套整机快照的 代价：collect_disks 全分区扫描、collect_networks 全网卡采集、
process_count 全进程枚举都被执行后丢弃。服务器页面会轮询该接口，浪费
随轮询频率放大。

- infra 新增 collect_cpu_info()，返回 (品牌, 逻辑核心数)，只 refresh_cpu_all()，不枚举磁盘/网络/进程
- cpu_brand_name() 改为委托 collect_cpu_info().0，避免重复采集路径
- server_resource_usage 改用 spawn_blocking(collect_cpu_info)，删除对 snapshot_inner() 的调用；snapshot_inner 只保留给整机快照 system_snapshot 使用（其磁盘采集是正当用途）

新增单测：collect_cpu_info 返回正的核心数与非空品牌，且与 cpu_brand_name 一致。

<!-- 前端须知： -->
<!-- 涉及到 UI 变动，需要提供前后对比的截图/视频 -->

## Sourcery 摘要

通过仅收集响应所需的 CPU 信息，优化服务器资源轮询。

改进：
- 对服务器资源使用情况查询使用轻量级 CPU 信息收集，而不是完整的系统快照，从而避免在轮询期间进行不必要的磁盘、网络和进程信息收集。
- 复用统一的 CPU 信息收集路径来查询 CPU 品牌。

测试：
- 增加测试覆盖，验证 CPU 收集功能报告的逻辑核心数和品牌与现有 CPU 品牌 API 保持一致且有效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize server resource polling by collecting only the CPU information required for its response.

Enhancements:
- Use lightweight CPU information collection for server resource usage queries instead of full system snapshots, avoiding unnecessary disk, network, and process collection during polling.
- Reuse the unified CPU information collection path for CPU brand lookup.

Tests:
- Add coverage verifying that CPU collection reports a valid logical core count and brand consistently with the existing CPU brand API.

</details>